### PR TITLE
prism.css: Remove `-webkit-tab-size`

### DIFF
--- a/prism.css
+++ b/prism.css
@@ -14,7 +14,6 @@ pre[class*="language-"] {
 	white-space: pre;
 	word-spacing: normal;
 	
-	-webkit-tab-size: 4;
 	-moz-tab-size: 4;
 	-o-tab-size: 4;
 	tab-size: 4;


### PR DESCRIPTION
WebKit implemented the unprefixed `tab-size` right away; `-webkit-tab-size` has never been implemented.
