### PR TITLE
Fix parsing of CSS at-rules

### DIFF
--- a/components/prism-css.js
+++ b/components/prism-css.js
@@ -1,6 +1,6 @@
 Prism.languages.css = {
 	'comment': /\/\*[\w\W]*?\*\//g,
-	'atrule': /@[\w-]+?(\s+.+)?(?=\s*{|\s*;)/gi,
+	'atrule': /@[\w-]+?(\s+[^;{]+)?(?=\s*{|\s*;)/gi,
 	'url': /url\((["']?).*?\1\)/gi,
 	'selector': /[^\{\}\s][^\{\}]*(?=\s*\{)/g,
 	'property': /(\b|\B)[a-z-]+(?=\s*:)/ig,


### PR DESCRIPTION
Test case:

```
@page { size: A4 landscape; margin: 2cm }
```

The previous _atrule_ regexp matched until the `;` but it should stop at the first `{`.
