### PR TITLE
Fix Java examples which are not working

### DIFF
--- a/prism.js
+++ b/prism.js
@@ -479,3 +479,16 @@ if (Prism.languages.markup) {
 		}
 	});
 }
+
+/* **********************************************
+     Begin prism-java.js
+********************************************** */
+
+Prism.languages.java = Prism.languages.extend('clike', {
+	'keyword': /\b(abstract|continue|for|new|switch|assert|default|goto|package|synchronized|boolean|do|if|private|this|break|double|implements|protected|throw|byte|else|import|public|throws|case|enum|instanceof|return|transient|catch|extends|int|short|try|char|final|interface|static|void|class|finally|long|strictfp|volatile|const|float|native|super|while)\b/g,
+	'number': /\b0b[01]+\b|\b0x[\da-f]*\.?[\da-fp\-]+\b|\b\d*\.?\d+[e]?[\d]*[df]\b|\W\d*\.?\d+\b/gi,
+	'operator': {
+		pattern: /([^\.]|^)([-+]{1,2}|!|=?&lt;|=?&gt;|={1,2}|(&amp;){1,2}|\|?\||\?|\*|\/|%|\^|(&lt;){2}|($gt;){2,3}|:|~)/g,
+		lookbehind: true
+	}
+});


### PR DESCRIPTION
With the commit 5c7827d0e9afa9e836c57fb25fa8415fb7b8d299, you remove the prism-java component from the prism.js, so the Java examples here http://prismjs.com/examples.html are not working
