### PR TITLE
Add link to API at end of "Basic usage" section

### DIFF
--- a/index.html
+++ b/index.html
@@ -131,7 +131,7 @@
 	<pre><code>&lt;pre>&lt;code class="language-css">p { color: red }&lt;/code>&lt;/pre></code></pre>
 	<p>If you use that pattern, the <code>&lt;pre></code> will automatically get the <code>language-xxxx</code> class (if it doesn’t already have it) and will be styled as a code block.</p>
 	
-	<p>If you want to prevent any elements from being automatically highlighted, you can use the attribute <code>data-manual</code> on the <code>&lt;script></code> element you used for prism.
+	<p>If you want to prevent any elements from being automatically highlighted, you can use the attribute <code>data-manual</code> on the <code>&lt;script></code> element you used for prism and use the <a href="extending.html#api">API</a>.
 	Example:</p>
 	<pre><code>&lt;script src="prism.js" data-manual>&lt;/script></code></pre>
 </p>


### PR DESCRIPTION
A link to the API section is helpful for those who need to use the "data-manual" or other features that are not included in "Basic usage" since the API section is located on the "Extending Prism" page.
