### PR TITLE
Change 'cdata' regex to capture empty instances (+ to *)

### DIFF
--- a/components/prism-markup.js
+++ b/components/prism-markup.js
@@ -2,7 +2,7 @@ Prism.languages.markup = {
 	'comment': /&lt;!--[\w\W]*?--(&gt;|&gt;)/g,
 	'prolog': /&lt;\?.+?\?&gt;/,
 	'doctype': /&lt;!DOCTYPE.+?&gt;/,
-	'cdata': /&lt;!\[CDATA\[[\w\W]+?]]&gt;/i,
+	'cdata': /&lt;!\[CDATA\[[\w\W]*?]]&gt;/i,
 	'tag': {
 		pattern: /&lt;\/?[\w:-]+\s*(?:\s+[\w:-]+(?:=(?:("|')(\\?[\w\W])*?\1|\w+))?\s*)*\/?&gt;/gi,
 		inside: {


### PR DESCRIPTION
Changing "`+`" to "`*`" enables the regex to match zero or more occurrences of the preceding range instead of one or more occurrences. In cases where there are multiple `CDATA` sections, the opening tag ("`<![CDATA[`") of the first section and the closing tag ("`]]>`") of the next section are captured as a single instance.

Demo: http://dabblet.com/gist/4176483 (the HTML+Result panel shows the same issue I see with "language-markup")
