### PR TITLE
Adding font-size:100% to autolinker plugin css

### DIFF
--- a/plugins/autolinker/prism-autolinker.css
+++ b/plugins/autolinker/prism-autolinker.css
@@ -1,3 +1,4 @@
 .token a {
 	color: inherit;
+  font-size: 100%;
 }


### PR DESCRIPTION
When anchor is added to code via autolinker plugin, it can cause font size to change, (if font size is already declared on a/pre/code tags in ems) - this makes sure the anchor font size is the same as the rest of the pre/code.
