### PR TITLE
Probem with JS code that starts with `// comment`

### DIFF
--- a/components/prism-clike.js
+++ b/components/prism-clike.js
@@ -1,6 +1,6 @@
 Prism.languages.clike = {
 	'comment': {
-		pattern: /(^|[^\\])(\/\*[\w\W]*?\*\/|[^:]\/\/.*?(\r?\n|$))/g,
+		pattern: /(^|[^\\])(\/\*[\w\W]*?\*\/|[^:]?\/\/.*?(\r?\n|$))/g,
 		lookbehind: true
 	},
 	'string': /("|')(\\?.)*?\1/g,


### PR DESCRIPTION
I had a problem with syntax highlighting of JavaScript when it starts with a `// comment`.

The problem of the comment pattern was

```
/(^|[^\\])(\/\*[\w\W]*?\*\/|[^:]\/\/.*?(\r?\n|$))/g
                            ^^^^
```

And I'm not sure what it is for, exactly? Adding a `?` to it fixes the problem for me, but I hope that it doesn't cause problems with other use case. Could you look into it? Is there any test suite for the existing code?
