### PR TITLE
prevent urls from being interpreted as comments

### DIFF
--- a/components/prism-clike.js
+++ b/components/prism-clike.js
@@ -1,6 +1,6 @@
 Prism.languages.clike = {
 	'comment': {
-		pattern: /(^|[^\\])(\/\*[\w\W]*?\*\/|[^:]?\/\/.*?(\r?\n|$))/g,
+		pattern: /(^|[^\\])(\/\*[\w\W]*?\*\/|(^|[^:])\/\/.*?(\r?\n|$))/g,
 		lookbehind: true
 	},
 	'string': /("|')(\\?.)*?\1/g,


### PR DESCRIPTION
Fix to allow clike languages like JavaScript to start with `//` comments, but still ignoring URLs like http://example.com
