### PR TITLE
Line Numbers plugin

### DIFF
--- a/components.js
+++ b/components.js
@@ -27,6 +27,7 @@ var components = {
 			hasCSS: true
 		},
 		'line-highlight': 'Line Highlight',
+		'line-numbers': 'Line Numbers',
 		'show-invisibles': 'Show Invisibles',
 		'autolinker': 'Autolinker',
 		'wpd': 'WebPlatform Docs',

--- a/plugins/line-numbers/index.html
+++ b/plugins/line-numbers/index.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+
+<meta charset="utf-8" />
+<link rel="shortcut icon" href="favicon.png" />
+<title>Line Numbers ▲ Prism plugins</title>
+<base href="../.." />
+<link rel="stylesheet" href="style.css" />
+<link rel="stylesheet" href="prism.css" data-noprefix />
+<link rel="stylesheet" href="plugins/line-numbers/prism-line-numbers.css" data-noprefix />
+<script src="prefixfree.min.js"></script>
+
+<script>var _gaq = [['_setAccount', 'UA-33746269-1'], ['_trackPageview']];</script>
+<script src="http://www.google-analytics.com/ga.js" async></script>
+</head>
+<body>
+
+<header>
+  <div class="intro" data-src="templates/header-plugins.html" data-type="text/html"></div>
+
+  <h2>Line Numbers</h2>
+  <p>Line number at the beginning of code lines.</p>
+</header>
+
+<section class="language-markup">
+  <h1>How to use</h1>
+
+  <p>Obviously, this is supposed to work only for code blocks (<code>&lt;pre>&lt;code></code>) and not for inline code.</p>
+  <p>Add class <strong>line-numbers</strong> to your desired <code>&lt;pre></code> and line-numbers plugin will take care.</p>
+  <p>Optional: You can specify the <code>data-start</code> (Number) attribute on the <code>&lt;pre></code> element. It will shift the line counter.</p>
+</section>
+
+<section>
+  <h1>Examples</h1>
+
+  <h2>JavaScript</h2>
+  <pre class="line-numbers" data-src="plugins/line-numbers/prism-line-numbers.js"></pre>
+
+  <h2>CSS</h2>
+  <pre class="line-numbers" data-src="plugins/line-numbers/prism-line-numbers.css"></pre>
+
+  <h2>HTML</h2>
+  <p>Please note the <code>data-start="-5"</code> in the code below.</p>
+  <pre class="line-numbers" data-src="plugins/line-numbers/index.html" data-start="-5"></pre>
+</section>
+
+<footer data-src="templates/footer.html" data-type="text/html"></footer>
+
+<script src="prism.js"></script>
+<script src="plugins/line-numbers/prism-line-numbers.js"></script>
+<script src="utopia.js"></script>
+<script src="code.js"></script>
+
+
+</body>
+</html>

--- a/plugins/line-numbers/prism-line-numbers.css
+++ b/plugins/line-numbers/prism-line-numbers.css
@@ -1,0 +1,40 @@
+pre.line-numbers {
+	position: relative;
+	padding-left: 3.8em;
+	counter-reset: linenumber;
+}
+
+pre.line-numbers > code {
+	position: relative;
+}
+
+.line-numbers .line-numbers-rows {
+	position: absolute;
+	pointer-events: none;
+	top: 0;
+	font-size: 100%;
+	left: -3.8em;
+	width: 3em; /* works for line-numbers below 1000 lines */
+	letter-spacing: -1px;
+	border-right: 1px solid #999;
+
+	-webkit-user-select: none;
+	-moz-user-select: none;
+	-ms-user-select: none;
+	user-select: none;
+
+}
+
+	.line-numbers-rows > span {
+		pointer-events: none;
+		display: block;
+		counter-increment: linenumber;
+	}
+
+		.line-numbers-rows > span:before {
+			content: counter(linenumber);
+			color: #999;
+			display: block;
+			padding-right: 0.8em;
+			text-align: right;
+		}

--- a/plugins/line-numbers/prism-line-numbers.js
+++ b/plugins/line-numbers/prism-line-numbers.js
@@ -1,0 +1,24 @@
+Prism.hooks.add('after-highlight', function (env) {
+	// works only for <code> wrapped inside <pre data-line-numbers> (not inline)
+	var pre = env.element.parentNode;
+	if (!pre || !/pre/i.test(pre.nodeName) || pre.className.indexOf('line-numbers') === -1) {
+		return;
+	}
+
+	var linesNum = (1 + env.code.split('\n').length);
+	var lineNumbersWrapper;
+
+	lines = new Array(linesNum);
+	lines = lines.join('<span></span>');
+
+	lineNumbersWrapper = document.createElement('span');
+	lineNumbersWrapper.className = 'line-numbers-rows';
+	lineNumbersWrapper.innerHTML = lines;
+
+	if (pre.hasAttribute('data-start')) {
+		pre.style.counterReset = 'linenumber ' + (parseInt(pre.getAttribute('data-start'), 10) - 1);
+	}
+
+	env.element.appendChild(lineNumbersWrapper);
+
+});


### PR DESCRIPTION
Hi there,
- [x] Add Line Numbers plugin to components
- [x] Line numbers are un-selectable
- [x] Plugin page with info How To Use
- [x] Works only for `line-numbers` class on `<pre>` element
- [x] Can be shifted (down and up) with `data-start` attribute

Is it ok?
