### PR TITLE
Add Third Party Jekyll tutorial

### DIFF
--- a/index.html
+++ b/index.html
@@ -173,6 +173,7 @@
 		<li><a href="http://davidpeach.co.uk/2013/02/prism-js-code-highlighter/">Prism JS Code Highlighter</a></li>
 		<li><a href="http://schier.co/post/how-to-re-run-prismjs-on-ajax-content">How To Re-Run Prism.js On AJAX Content</a></li>
 		<li><a href="http://www.semisedlak.com/article/highlight-your-code-syntax-with-prismjs/">Highlight your code syntax with Prism.js</a></li>
+		<li><a href="http://gmurphey.com/2012/08/09/jekyll-plugin-syntax-highlighting-with-prism.html">Jekyll Plugin: Syntax Highlighting With Prism</a></li>
 	</ul>
 	
 	<p>Please note that the tutorials listed here are not verified to contain correct information. Read at your risk and always check the official documentation here if something doesn’t work :)</p>


### PR DESCRIPTION
I wrote a tutorial on replacing Pygments.rb with Prism.js on Jekyll and Octopress sites. Added it to the Third-Party Tutorial section. Thanks for this wonderful tool!
