### PR TITLE
::selection is in effect only on elements interesting to prism.js

### DIFF
--- a/prism.css
+++ b/prism.css
@@ -24,12 +24,14 @@ pre[class*="language-"] {
 	hyphens: none;
 }
 
-::-moz-selection {
+pre[class*="language-"]::-moz-selection, pre[class*="language-"] ::-moz-selection,
+code[class*="language-"]::-moz-selection, code[class*="language-"] ::-moz-selection {
 	text-shadow: none;
 	background: #b3d4fc;
 }
 
-::selection {
+pre[class*="language-"]::selection, pre[class*="language-"] ::selection,
+code[class*="language-"]::selection, code[class*="language-"] ::selection {
 	text-shadow: none;
 	background: #b3d4fc;
 }


### PR DESCRIPTION
Present prism.css replaces any `::selection` made by site style. This commit fixes that so that the `::selection` is in effect only on `pre` and `code` elements with `language-*` classes.
