### PR TITLE
Twilight: Use hsla where alpha argument is passed

### DIFF
--- a/prism-twilight.css
+++ b/prism-twilight.css
@@ -131,11 +131,11 @@ pre[data-line] {
 	z-index:1;
 }
 .line-highlight {
-	background: -moz-linear-gradient(left, hsl(0, 0%, 33%,.1) 70%, hsl(0, 0%, 33%,0)); /* #545454 */
-	background: -o-linear-gradient(left, hsl(0, 0%, 33%,.1) 70%, hsl(0, 0%, 33%,0)); /* #545454 */
-	background: -webkit-linear-gradient(left, hsl(0, 0%, 33%,.1) 70%, hsl(0, 0%, 33%,0)); /* #545454 */
+	background: -moz-linear-gradient(left, hsla(0, 0%, 33%,.1) 70%, hsla(0, 0%, 33%,0)); /* #545454 */
+	background: -o-linear-gradient(left, hsla(0, 0%, 33%,.1) 70%, hsla(0, 0%, 33%,0)); /* #545454 */
+	background: -webkit-linear-gradient(left, hsla(0, 0%, 33%,.1) 70%, hsla(0, 0%, 33%,0)); /* #545454 */
 	background: hsla(0, 0%, 33%, 0.25); /* #545454 */
-	background: linear-gradient(left, hsl(0, 0%, 33%,.1) 70%, hsl(0, 0%, 33%,0)); /* #545454 */
+	background: linear-gradient(left, hsla(0, 0%, 33%,.1) 70%, hsla(0, 0%, 33%,0)); /* #545454 */
 	border-bottom:1px dashed hsl(0, 0%, 33%); /* #545454 */
 	border-top:1px dashed hsl(0, 0%, 33%); /* #545454 */
 	left: 0;


### PR DESCRIPTION
Small correction to the Twilight theme: in the `.line-highlight` gradient declarations `hsl` should be `hsla`, since there is a 4th argument being passed in for alpha. Credit goes to CodeKit/Sass/Compass for catching that :)

Signed-off-by: Gabriel Luethje gabriel@thefstopdesign.com
