### PR TITLE
Add bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,26 @@
+{
+  "name": "prism",
+  "main": [
+      "prism.js",
+      "prism.css"
+  ],
+  "homepage": "http://prismjs.com",
+  "authors": "Lea Verou",
+  "description": "Lightweight, robust, elegant syntax highlighting. A spin-off project from Dabblet.",
+  "license": "MIT",
+  "ignore": [
+    "**/.*",
+    "img",
+    "templates",
+    "CNAME",
+    "*.html",
+    "style.css",
+    "favicon.png",
+    "logo.svg",
+    "download.js",
+    "prefixfree.min.js",
+    "utopia.js",
+    "code.js",
+    "components.js"
+  ]
+}


### PR DESCRIPTION
Prism is already registered with bower. This bower.json file just ignores the website-bits of the repo.

Running `bower install prism#gh-pages` will install these files:

``` shell
.
├── components/
├── plugins/
├── bower.json
├── LICENSE
├── prism-coy.css
├── prism.css
├── prism-dark.css
├── prism-funky.css
├── prism.js
├── prism-okaidia.css
├── prism-tomorrow.css
├── prism-twilight.css
└── README.md
```

Related issue: #52
