### PR TITLE
Change references to non-existent grammar in API docs

### DIFF
--- a/extending.html
+++ b/extending.html
@@ -151,7 +151,7 @@
 			<dt>text</dt>
 			<dd>A string with the code to be highlighted.</dd>
 			<dt>grammar</dt>
-			<dd>An object containing the tokens to use. Usually a language definition like <code>Prism.languages.html</code></dd>
+			<dd>An object containing the tokens to use. Usually a language definition like <code>Prism.languages.markup</code></dd>
 		</dl>
 		
 		<h2>Returns</h2>
@@ -168,7 +168,7 @@
 			<dt>text</dt>
 			<dd>A string with the code to be highlighted.</dd>
 			<dt>grammar</dt>
-			<dd>An object containing the tokens to use. Usually a language definition like <code>Prism.languages.html</code></dd>
+			<dd>An object containing the tokens to use. Usually a language definition like <code>Prism.languages.markup</code></dd>
 		</dl>
 		
 		<h2>Returns</h2>


### PR DESCRIPTION
In case anyone else gets a brainfart and gets tripped up by this like I did. :smiley:
