### PR TITLE
Add version so bower will work

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,6 @@
 {
   "name": "prism",
+  "version": "0.0.0",
   "main": [
       "prism.js",
       "prism.css"


### PR DESCRIPTION
Currently bower install fails due to the lack of a version. This should fix that (maybe it is still needed to provide a git tag named `0.0.0` in the repo, this to be discovered).
Version set to 0.0.0 to make it clear it's a never-changing dummy version as Lea wished. :)
