### PR TITLE
Fix twilight text selection

### DIFF
--- a/themes/prism-twilight.css
+++ b/themes/prism-twilight.css
@@ -37,6 +37,12 @@ pre[class*="language-"] {
 	overflow: auto;
 	padding: 1em;
 }
+pre[class*="language-"]::selection { /* Safari */
+	background:hsl(200, 4%, 16%); /* #282A2B */
+}
+pre[class*="language-"]::selection { /* Firefox */
+	background:hsl(200, 4%, 16%); /* #282A2B */
+}
 
 /* Text Selection colour */
 pre[class*="language-"]::-moz-selection, pre[class*="language-"] ::-moz-selection,


### PR DESCRIPTION
I'm not 100% on the color so please glance over this real quick.
The original twilight had both:

``` css
pre[class*="language-"]::selection { /* Safari */
    background:hsl(200, 4%, 16%); /* #282A2B */
}
pre[class*="language-"]::selection { /* Firefox */
    background:hsl(200, 4%, 16%); /* #282A2B */
}
```

And:

``` css
/* Text Selection colour */
::selection {
    background: hsla(0,0%,93%,0.15); /* #EDEDED */
}
::-moz-selection {
    background: hsla(0,0%,93%,0.15); /* #EDEDED */
}
```

I'm not sure which highlight was intended really. I went with the lighter:

``` css
/* Text Selection colour */
pre[class*="language-"]::-moz-selection, pre[class*="language-"] ::-moz-selection,
code[class*="language-"]::-moz-selection, code[class*="language-"] ::-moz-selection {
    text-shadow: none;
    background: hsla(0,0%,93%,0.15); /* #EDEDED */
}

pre[class*="language-"]::selection, pre[class*="language-"] ::selection,
code[class*="language-"]::selection, code[class*="language-"] ::selection {
    text-shadow: none;
    background: hsla(0,0%,93%,0.15); /* #EDEDED */
}
```
