### PR TITLE
Add Node.js support

### DIFF
--- a/components/prism-core.js
+++ b/components/prism-core.js
@@ -1,10 +1,12 @@
+var self = (typeof window !== 'undefined') ? window : {};
+
 /**
  * Prism: Lightweight, robust, elegant syntax highlighting
  * MIT license http://www.opensource.org/licenses/mit-license.php/
  * @author Lea Verou http://lea.verou.me
  */
 
-(function(){
+var Prism = (function(){
 
 // Private helper vars
 var lang = /\blang(?:uage)?-(?!\*)(\w+)\b/i;
@@ -323,7 +325,11 @@ Token.stringify = function(o, language, parent) {
 };
 
 if (!self.document) {
-	// In worker
+	if (!self.addEventListener) {
+		// in Node.js
+		return self.Prism;
+	}
+ 	// In worker
 	self.addEventListener('message', function(evt) {
 		var message = JSON.parse(evt.data),
 		    lang = message.language,
@@ -333,7 +339,7 @@ if (!self.document) {
 		self.close();
 	}, false);
 	
-	return;
+	return self.Prism;
 }
 
 // Get current script and highlight
@@ -349,4 +355,10 @@ if (script) {
 	}
 }
 
+return self.Prism;
+
 })();
+
+if (typeof module !== 'undefined' && module.exports) {
+	module.exports = Prism;
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "prism",
+  "version": "0.0.0",
+  "description": "Lightweight, robust, elegant syntax highlighting. A spin-off project from Dabblet.",
+  "main": "prism.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/LeaVerou/prism.git"
+  },
+  "keywords": [
+    "prism",
+    "highlight"
+  ],
+  "author": "Lea Verou",
+  "license": "MIT",
+  "readmeFilename": "README.md"
+}

--- a/prism.js
+++ b/prism.js
@@ -4,13 +4,15 @@
      Begin prism-core.js
 ********************************************** */
 
+var self = (typeof window !== 'undefined') ? window : {};
+
 /**
  * Prism: Lightweight, robust, elegant syntax highlighting
  * MIT license http://www.opensource.org/licenses/mit-license.php/
  * @author Lea Verou http://lea.verou.me
  */
 
-(function(){
+var Prism = (function(){
 
 // Private helper vars
 var lang = /\blang(?:uage)?-(?!\*)(\w+)\b/i;
@@ -329,7 +331,11 @@ Token.stringify = function(o, language, parent) {
 };
 
 if (!self.document) {
-	// In worker
+	if (!self.addEventListener) {
+		// in Node.js
+		return self.Prism;
+	}
+ 	// In worker
 	self.addEventListener('message', function(evt) {
 		var message = JSON.parse(evt.data),
 		    lang = message.language,
@@ -339,7 +345,7 @@ if (!self.document) {
 		self.close();
 	}, false);
 	
-	return;
+	return self.Prism;
 }
 
 // Get current script and highlight
@@ -355,7 +361,13 @@ if (script) {
 	}
 }
 
+return self.Prism;
+
 })();
+
+if (typeof module !== 'undefined' && module.exports) {
+	module.exports = Prism;
+}
 
 /* **********************************************
      Begin prism-markup.js


### PR DESCRIPTION
I was hoping to use Prism on Node.js - this PR adds Node support, without changing browser behaviour.  I've tried to keep the changes as small as possible:
- `self` is declared as a variable (equal to `window` in the browser, or `{}` in Node).
- `Prism` is declared as a variable in `prism-core.js` so that other files (like language definitions) can use it
- If `module.exports` is defined, then it is assigned to `Prism`.
- An extra check for `self.addEventListener`

I believe these should have no effect on a browser environment, and `test.html` still works for me, at least.

Obviously, most of the methods don't work in Node, but I don't see a great benefit in removing them.  Node usage:

``` javascript
var Prism = require('prism');

var jsCode = 'var a = 1';
var html = Prism.highlight(jsCode, Prism.languages.javascript);
```

If you feel like it, it should be ready to just `npm publish`.
