### PR TITLE
Allow more characters in attribute values

### DIFF
--- a/components/prism-markup.js
+++ b/components/prism-markup.js
@@ -4,7 +4,7 @@ Prism.languages.markup = {
 	'doctype': /&lt;!DOCTYPE.+?>/,
 	'cdata': /&lt;!\[CDATA\[[\w\W]*?]]>/i,
 	'tag': {
-		pattern: /&lt;\/?[\w:-]+\s*(?:\s+[\w:-]+(?:=(?:("|')(\\?[\w\W])*?\1|\w+))?\s*)*\/?>/gi,
+		pattern: /&lt;\/?[\w:-]+\s*(?:\s+[\w:-]+(?:=(?:("|')(\\?[\w\W])*?\1|[^\s'">=]+))?\s*)*\/?>/gi,
 		inside: {
 			'tag': {
 				pattern: /^&lt;\/?[\w:-]+/i,


### PR DESCRIPTION
The current pattern uses `\w+` but the [html5 grammar](http://www.w3.org/html/wg/drafts/html/master/syntax.html#attribute-value-(unquoted%29-state) allows just about any character, `[^\s'">=]+`
