### PR TITLE
Removed extra character in variable regexp

### DIFF
--- a/components/prism-ruby.js
+++ b/components/prism-ruby.js
@@ -16,6 +16,6 @@ Prism.languages.insertBefore('ruby', 'keyword', {
 		pattern: /(^|[^/])\/(?!\/)(\[.+?]|\\.|[^/\r\n])+\/[gim]{0,3}(?=\s*($|[\r\n,.;})]))/g,
 		lookbehind: true
 	},
-	'variable': /[@$&]+\b[a-zA-Z_][a-zA-Z_0-9]*[?!]?\b/g,
+	'variable': /[@$]+\b[a-zA-Z_][a-zA-Z_0-9]*[?!]?\b/g,
 	'symbol': /:\b[a-zA-Z_][a-zA-Z_0-9]*[?!]?\b/g
 });


### PR DESCRIPTION
Fix #175 by removing '&' as a variable prefix. For some reason, this
change also fixes the '<' character being appended with a ;
character.
