### PR TITLE
Updated prism-c.js for enhanced C macro support

### DIFF
--- a/components/prism-c.js
+++ b/components/prism-c.js
@@ -4,6 +4,11 @@ Prism.languages.c = Prism.languages.extend('clike', {
 });
 
 Prism.languages.insertBefore('c', 'keyword', {
-	//property class reused for macro statements
-	'property': /#\s*[a-zA-Z]+/g
+    //property class reused for macro statements
+    'property': {
+        pattern:/#[a-zA-Z]+\ .*/g,
+        inside: {
+            property: /&lt;[a-zA-Z.]+>/g
+        }   
+    }   
 });


### PR DESCRIPTION
Previously, #include <stdio.h> resulted in the < and > being tagged as operators, which is confusing. Also, preprocessor directives are not allowed to have spaces after the # and before the directive (#include, #define, #if, etc.), so I updated the regex to ignore improperly formatted macros. Currently, macro arguments will be highlighted as properties, but you can line 11 to whatever flagging is desired (keyword, for instance) to visually distinguish between the macro and its arguments.
