### PR TITLE
Debounce multiple rapid generateCode calls.

### DIFF
--- a/download.js
+++ b/download.js
@@ -241,9 +241,17 @@ function update(updatedCategory, updatedId){
 		title: prettySize(total.css)
 	});
 	
-	generateCode();
+	delayedGenerateCode();
 }
 
+var timerId = 0;
+// "debounce" multiple rapid requests to generate and highlight code
+function delayedGenerateCode(){
+	if ( timerId !== 0 ) {
+		clearTimeout(timerId);
+	}
+	timerId = setTimeout(generateCode, 500);
+}
 function generateCode(){
 	var code = {js: '', css: ''};
 	


### PR DESCRIPTION
Fix for issue #218.
Changing compression level or on page load causes a large amount of generate code requests as each source file is loaded. Because there's no guarantee the order that these requests will start-and more importantly, end-the generated code can contain undefined code snippets.

"Debounce" multiple `generateCode` calls by delaying the call, and extending this out as each rapid request comes in.
