### PR TITLE
Redownload URL

### DIFF
--- a/download.js
+++ b/download.js
@@ -10,12 +10,12 @@ var minified = true;
 
 var dependencies = {};
 
-var qstr = window.location.search.match(/(?:languages|plugins)=[-|\w]+|themes=[-\w]+/g);
+var qstr = window.location.search.match(/(?:languages|plugins)=[-+\w]+|themes=[-\w]+/g);
 if (qstr) {
 	qstr.forEach(function(str) {
 		var kv = str.split('=', 2),
 			category = kv[0],
-			ids = kv[1].split('|');
+			ids = kv[1].split('+');
 		if (category !== 'meta' && category !== 'core' && components[category]) {
 			for (var id in components[category]) {
 				if (components[category][id].option) {
@@ -305,7 +305,7 @@ function generateCode(){
 	
 	var redownloadUrl = window.location.href.split("?")[0] + "?";
 	for (var category in redownload) {
-		redownloadUrl += category + "=" + redownload[category].join('|') + "&";
+		redownloadUrl += category + "=" + redownload[category].join('+') + "&";
 	}
 	redownloadUrl = "/* " + redownloadUrl.replace(/&$/,"") + " */";
 


### PR DESCRIPTION
Generate a URL which can be used change the default selected plugins/themes/languages, so the same package can be redownloaded with any updates available, for example:
http://prismjs.com/download.html?themes=prism-coy&languages=clike|javascript|coffeescript&plugins=autolinker|file-highlight

If you have a custom build of Prism in your environment, and you want to rebuild it to get any bug fixes for instance, or add a new language on top of your current build, you'd need to either remember what you included in the package, or look through the (probably) minified source. This way your source contains a URL to get your specific build back, with the latest code.
