### PR TITLE
Fix ToC generator to work with base

### DIFF
--- a/code.js
+++ b/code.js
@@ -71,7 +71,7 @@ $$('body > section > h1').forEach(function(h1) {
 		contents: {
 			tag: 'a',
 			properties: {
-				href: '#' + (h1.id || section.id)
+				href: window.location.pathname + '#' + (h1.id || section.id)
 			},
 			contents: text
 		},


### PR DESCRIPTION
Subpages use the `base` tag, the ToC generator doesn't take this in to account and generates document fragment links based on the homepage, essentially rendering the ToC useless on any page not in prism root.
