### PR TITLE
On download page was code going over de download button

### DIFF
--- a/download.html
+++ b/download.html
@@ -88,19 +88,21 @@ section.download {
 }
 
 	#download pre {
-		height: 20em;
+		height: 30em;
 		word-wrap: break-word;
 	}
 
 	#download-js .download-button {
 		border-top-right-radius: 0;
 		border-bottom-right-radius: 0;
+		position: relative;
 	}
 	
 	#download-css .download-button {
 		background-color: #dc9e23;
 		border-top-left-radius: 0;
 		border-bottom-left-radius: 0;
+		position: relative;
 	}
 </style>
 <script src="prefixfree.min.js"></script>


### PR DESCRIPTION
On the download page the code that was rendered was running over the download buttons in FireFox on the website. So I changed #download pre { height: 20em; word-wrap: break-word; } into #download pre { height: 30em; word-wrap: break-word; }

Now it looks that it's working fine again.

Signed-off-by: Kaj Rietberg kaj@kajrietberg.nl
