### PR TITLE
Highlight after language downloaded

### DIFF
--- a/test.html
+++ b/test.html
@@ -85,7 +85,7 @@ textarea {
 (function() {
 var form = $('form'), code = $('code', form),
     languages = components.languages,
-	highlightCode = function() { Prism.highlightElement(code); };
+    highlightCode = function() { Prism.highlightElement(code); };
 
 for (var id in languages) {
 	if (id == 'meta') {


### PR DESCRIPTION
If loading a new language, don't attempt highlight until the language has downloaded.
Otherwise it will remain unhighlighted, and look like Prism is not actually working.

This is a bit of an edge case. To test: load the page, without changing the language options, type some C# code for example, _then_ change the language to C#.
