### PR TITLE
support for PHP's #-style comments

### DIFF
--- a/components/prism-php.js
+++ b/components/prism-php.js
@@ -13,7 +13,11 @@
 
 Prism.languages.php = Prism.languages.extend('clike', {
 	'keyword': /\b(and|or|xor|array|as|break|case|cfunction|class|const|continue|declare|default|die|do|else|elseif|enddeclare|endfor|endforeach|endif|endswitch|endwhile|extends|for|foreach|function|include|include_once|global|if|new|return|static|switch|use|require|require_once|var|while|abstract|interface|public|implements|private|protected|parent|throw|null|echo|print|trait|namespace|final|yield|goto|instanceof|finally|try|catch)\b/ig,
-	'constant': /\b[A-Z0-9_]{2,}\b/g
+	'constant': /\b[A-Z0-9_]{2,}\b/g,
+	'comment': {
+		pattern: /(^|[^\\])(\/\*[\w\W]*?\*\/|(^|[^:])(\/\/|#).*?(\r?\n|$))/g,
+		lookbehind: true
+	},
 });
 
 Prism.languages.insertBefore('php', 'keyword', {


### PR DESCRIPTION
although it fails to detect when a # is within a string, just like it does for // though when // isn't preceded by a :

but such are the limits of parsing code with regexp :(
