### PR TITLE
Fix prism.js for Objective-C

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -11,6 +11,7 @@ var gulp   = require('gulp'),
 			'components/prism-markup.js',
 			'components/prism-css.js',
 			'components/prism-clike.js',
+			'components/prism-c.js',
 			'components/prism-javascript.js',
 			'plugins/file-highlight/prism-file-highlight.js'
 		],

--- a/prism.js
+++ b/prism.js
@@ -498,37 +498,6 @@ Prism.languages.clike = {
 	'punctuation': /[{}[\];(),.:]/g
 };
 
-/* **********************************************
-		 Begin prism-c.js
-********************************************** */
-
-Prism.languages.c = Prism.languages.extend('clike', {
-	// allow for c multiline strings
-	'string': /("|')([^\n\\\1]|\\.|\\\r*\n)*?\1/g,
-	'keyword': /\b(asm|typeof|inline|auto|break|case|char|const|continue|default|do|double|else|enum|extern|float|for|goto|if|int|long|register|return|short|signed|sizeof|static|struct|switch|typedef|union|unsigned|void|volatile|while)\b/g,
-	'operator': /[-+]{1,2}|!=?|<{1,2}=?|>{1,2}=?|\->|={1,2}|\^|~|%|&{1,2}|\|?\||\?|\*|\//g
-});
-
-Prism.languages.insertBefore('c', 'string', {
-	// property class reused for macro statements
-	'property': {
-		// allow for multiline macro definitions
-		// spaces after the # character compile fine with gcc
-		pattern: /((^|\n)\s*)#\s*[a-z]+([^\n\\]|\\.|\\\r*\n)*/gi,
-		lookbehind: true,
-		inside: {
-			// highlight the path of the include statement as a string
-			'string': {
-				pattern: /(#\s*include\s*)(<.+?>|("|')(\\?.)+?\3)/g,
-				lookbehind: true,
-			}
-		}
-	}
-});
-
-delete Prism.languages.c['class-name'];
-delete Prism.languages.c['boolean'];
-
 
 /* **********************************************
      Begin prism-javascript.js


### PR DESCRIPTION
Objective-C depends on C, which prism.js did not contain. Included now.
