### PR TITLE
Fix hidden line numbers in coy theme

### DIFF
--- a/themes/prism-coy.css
+++ b/themes/prism-coy.css
@@ -27,7 +27,7 @@ pre[class*="language-"] {
 /* Code blocks */
 pre[class*="language-"] {
   position:relative;
-  padding: 1em;
+  padding-left: 1em;
   margin: .5em 0;
   -webkit-box-shadow: -1px 0px 0px 0px #358ccb, 0px 0px 0px 1px #dfdfdf;
   -moz-box-shadow: -1px 0px 0px 0px #358ccb, 0px 0px 0px 1px #dfdfdf;
@@ -41,13 +41,14 @@ pre[class*="language-"] {
   background-image: linear-gradient(transparent 50%, rgba(69, 142, 209, 0.04) 50%);
   background-size: 3em 3em;
   background-origin:content-box;
-  overflow: scroll;
-  max-height:30em;
+  overflow: visible;
 }
 
 code[class*="language"] {
-  max-height:29em;
+  max-height: 30em;
+  padding-right: 1em;
   display:block;
+  overflow: auto;
 }
 
 /* Margin bottom to accomodate shadow */


### PR DESCRIPTION
The issue is that the `<code>` element needs the `overflow: scroll` (since the code block has a `max-height`). So the line numbers container, which is positioned absolutely using a negative left position is hidden.

This is fixed by changing the way the `<code>` element is positioned: not with a margin and a small size, but with the padding & and using the complete size of the `<pre>` tag. This way the line numbers container is in the visible area of the `<code>`-element.

Fixes #188
Note: this also slightly changes the way the theme looks (see the linked issue for screenshots).
