### PR TITLE
Add HTTP, Coffeescript and Java to gulpfile

### DIFF
--- a/examples.html
+++ b/examples.html
@@ -440,6 +440,9 @@ X-Response-Time: 10ms
 <footer data-src="templates/footer.html" data-type="text/html"></footer>
 
 <script src="prism.js"></script>
+<script src="components/prism-java.js"></script>
+<script src="components/prism-http.js"></script>
+<script src="components/prism-coffeescript.js"></script>
 <script src="utopia.js"></script>
 <script src="components.js"></script>
 <script src="code.js"></script>


### PR DESCRIPTION
This is necessary, because the `examples.html` needs them. If those
languages are not included the `examples.html` has a lot of code, that
is not highlighted at all.
