### PR TITLE
Autolinker IE8 Fix

### DIFF
--- a/components/prism-core.js
+++ b/components/prism-core.js
@@ -54,6 +54,15 @@ var _ = self.Prism = {
 			}
 
 			return o;
+		},
+
+		indexOf: function(a,o) {
+			if (a.indexOf) return a.indexOf(o);
+
+			for (var i = 0, j = this.length; i < j; i++) {
+					if (a[i] === o) { return i; }
+			}
+			return -1;
 		}
 	},
 

--- a/plugins/autolinker/prism-autolinker.js
+++ b/plugins/autolinker/prism-autolinker.js
@@ -15,7 +15,7 @@ for (var language in Prism.languages) {
 	var tokens = Prism.languages[language];
 	
 	Prism.languages.DFS(tokens, function (type, def) {
-		if (candidates.indexOf(type) > -1) {
+		if (Prism.util.indexOf(candidates,type) > -1) {
 			if (!def.pattern) {
 				def = this[type] = {
 					pattern: def


### PR DESCRIPTION
The Array.prototype.indexOf method does not exist in Internet Explorer 8. A workaround Util method fixes this by leveraging the native method if possible and if not, falls back to a for loop.
