### PR TITLE
Fixed 'before-insert' hook

### DIFF
--- a/components/prism-php.js
+++ b/components/prism-php.js
@@ -62,8 +62,10 @@ if (Prism.languages.markup) {
 
 	// Restore env.code for other plugins (e.g. line-numbers)
 	Prism.hooks.add('before-insert', function(env) {
-		env.code = env.backupCode;
-		delete env.backupCode;
+		if (env.language === 'php') {
+			env.code = env.backupCode;
+			delete env.backupCode;
+		}
 	});
 
 	// Re-insert the tokens after highlighting


### PR DESCRIPTION
Fixed **'before-insert'** hook: now checks if language is PHP before assigning `env.code` to `env.backupCode`.

Only "language-php" defines `env.backupCode`: without this condition, `env.Code` would be undefined for any other language than PHP after this hook is called. It would then lead to wrong behaviours (eg. _Line Numbers_ plugin would not show lines).
