### PR TITLE
Adding default colors for `.token.deleted` and `.token.inserted`

### DIFF
--- a/themes/prism-coy.css
+++ b/themes/prism-coy.css
@@ -206,3 +206,10 @@ pre[class*="language-"].line-numbers code {
 pre[class*="language-"].line-numbers .line-numbers-rows {
 	left: 0;
 }
+
+.token.deleted {
+	color: red;
+}
+.token.inserted {
+	color: green;
+}

--- a/themes/prism-dark.css
+++ b/themes/prism-dark.css
@@ -115,3 +115,10 @@ pre[class*="language-"] {
 .token.entity {
 	cursor: help;
 }
+
+.token.deleted {
+	color: red;
+}
+.token.inserted {
+	color: lime;
+}

--- a/themes/prism-funky.css
+++ b/themes/prism-funky.css
@@ -104,3 +104,10 @@ code[class*="language-"] {
 .token.entity {
 	cursor: help;
 }
+
+.token.deleted {
+	color: red;
+}
+.token.inserted {
+	color: green;
+}

--- a/themes/prism-okaidia.css
+++ b/themes/prism-okaidia.css
@@ -110,3 +110,10 @@ pre[class*="language-"] {
 .token.entity {
 	cursor: help;
 }
+
+.token.deleted {
+	color: red;
+}
+.token.inserted {
+	color: green;
+}

--- a/themes/prism-tomorrow.css
+++ b/themes/prism-tomorrow.css
@@ -108,3 +108,10 @@ pre[class*="language-"] {
 .token.entity {
 	cursor: help;
 }
+
+.token.deleted {
+	color: red;
+}
+.token.inserted {
+	color: green;
+}

--- a/themes/prism-twilight.css
+++ b/themes/prism-twilight.css
@@ -143,6 +143,13 @@ pre[data-line] {
 	color: hsl(33, 33%, 52%); /* #AC885B */
 }
 
+.token.deleted {
+	color: red;
+}
+.token.inserted {
+	color: green;
+}
+
 /* Make the tokens sit above the line highlight so the colours don't look faded. */
 .token {
 	position: relative;

--- a/themes/prism.css
+++ b/themes/prism.css
@@ -127,3 +127,10 @@ pre[class*="language-"] {
 .token.entity {
 	cursor: help;
 }
+
+.token.deleted {
+	color: red;
+}
+.token.inserted {
+	color: green;
+}


### PR DESCRIPTION
Adding default colors in all themes for `.token.deleted` and `.token.inserted` related to Git language support (cf #227).
