### PR TITLE
Fixed 'self' variable in Safari (desktop & iOS)

### DIFF
--- a/components/prism-core.js
+++ b/components/prism-core.js
@@ -1,9 +1,9 @@
 self = (typeof window !== 'undefined')
 	? window   // if in browser
 	: (
-		(typeof WorkerGlobalScope !== 'undefined' && self instanceof WorkerGlobalScope)
-		? self // if in worker
-		: {}   // if in node js
+		(typeof global !== "undefined" && {}.toString.call(global) == '[object global]')
+		? {}   // if in node js
+        	: self // if in worker;
 	);
 
 /**


### PR DESCRIPTION
The old method to set 'self' variable worked incorrectly in Safari web browsers. So I propose the fix to make it work good on all browsers & nodejs as well.
