### PR TITLE
Add SassDoc syntax extension for Sass

### DIFF
--- a/index.html
+++ b/index.html
@@ -164,6 +164,14 @@
 	<p>It’s very easy to <a href="extending.html#writing-plugins">write your own Prism plugins</a>. Did you write a plugin for Prism that you want added to this list? <a href="https://github.com/LeaVerou/prism" target="_blank">Send a pull request</a>!</p>
 </section>
 
+<section id="languages">
+	<h1>Third-party language definitions</h1>
+
+	<ul>
+		<li><a href="https://github.com/SassDoc/prism-scss-sassdoc">SassDoc Sass/Scss comments</a></li>
+	</ul>
+</section>
+
 <section id="tutorials">
 	<h1>Third-party tutorials</h1>
 


### PR DESCRIPTION
This additional component highlights SassDoc comments in Sass/Scss code.

The code is from https://github.com/SassDoc/prism-scss-sassdoc.

Note: the `.min.js` file has bin generated with uglify-js 2.4.15, I don't know the tool and options you're usually using, and there's no makefile or something to generate the minified files.
