### PR TITLE
correct calculation for number of lines

### DIFF
--- a/plugins/line-numbers/prism-line-numbers.js
+++ b/plugins/line-numbers/prism-line-numbers.js
@@ -5,10 +5,10 @@ Prism.hooks.add('after-highlight', function (env) {
 		return;
 	}
 
-	var linesNum = (1 + env.code.split('\n').length);
+	var linesNum = env.code.match(/\n(?!$)/g).length + 1
 	var lineNumbersWrapper;
 
-	lines = new Array(linesNum);
+	lines = new Array(linesNum + 1);
 	lines = lines.join('<span></span>');
 
 	lineNumbersWrapper = document.createElement('span');


### PR DESCRIPTION
A final \n in a `<pre>` is not rendered by browsers, so we shouldn't
include it in the calculation for the number of lines.

Fixes #382.