### PR TITLE
highlightAll accepting an element to query

### DIFF
--- a/components/prism-core.js
+++ b/components/prism-core.js
@@ -140,8 +140,11 @@ var _ = self.Prism = {
 		}
 	},
 
-	highlightAll: function(async, callback) {
-		var elements = document.querySelectorAll('code[class*="language-"], [class*="language-"] code, code[class*="lang-"], [class*="lang-"] code');
+	highlightAll: function(element, async, callback) {
+		if (!element) {
+			element = document;
+		}
+		var elements = element.querySelectorAll('code[class*="language-"], [class*="language-"] code, code[class*="lang-"], [class*="lang-"] code');
 
 		for (var i=0, element; element = elements[i++];) {
 			_.highlightElement(element, async === true, callback);


### PR DESCRIPTION
Currently, the `highlightAll` function queries `document` for all highlightable elements, then calls `highlightElement` on all of them. Sometimes we may wish to do so for a specific element deeper down the DOM tree.
There is already a `highlightElement` function, but it exits for elements that are not immediately highlightable. The `highlightAll` function seems to be a good candidate for a simple generalisation.
If no element is passed, the function can default to querying `document`, hopefully requiring minimal changes to existing code.
