### PR TITLE
Git component improvements

### DIFF
--- a/components/prism-git.js
+++ b/components/prism-git.js
@@ -51,8 +51,8 @@ Prism.languages.git = {
 	/*
 	 * Regexp to match the changed lines in a git diff output. Check the example above.
 	 */
-	'deleted': /^-(?!-).+$/m,
-	'inserted': /^\+(?!\+).+$/m,
+	'deleted': /^-.*$/m,
+	'inserted': /^\+.*$/m,
 
 	/*
 	 * Match a "commit [SHA1]" line in a git log output.

--- a/components/prism-git.min.js
+++ b/components/prism-git.min.js
@@ -1,1 +1,1 @@
-Prism.languages.git={comment:/^#.*$/m,string:/("|')(\\?.)*?\1/gm,command:{pattern:/^.*\$ git .*$/m,inside:{parameter:/\s(--|-)\w+/m}},coord:/^@@.*@@$/m,deleted:/^-(?!-).+$/m,inserted:/^\+(?!\+).+$/m,commit_sha1:/^commit \w{40}$/m}
+Prism.languages.git={comment:/^#.*$/m,string:/("|')(\\?.)*?\1/gm,command:{pattern:/^.*\$ git .*$/m,inside:{parameter:/\s(--|-)\w+/m}},coord:/^@@.*@@$/m,deleted:/^-.*$/m,inserted:/^\+.*$/m,commit_sha1:/^commit \w{40}$/m}

--- a/themes/prism-coy.css
+++ b/themes/prism-coy.css
@@ -151,7 +151,8 @@ pre[class*="language-"]:after {
 .token.atrule,
 .token.attr-value,
 .token.keyword,
-.token.class-name {
+.token.class-name,
+.token.coord {
 	color: #1990b8;
 }
 

--- a/themes/prism-dark.css
+++ b/themes/prism-dark.css
@@ -100,7 +100,8 @@ pre[class*="language-"] {
 
 .token.atrule,
 .token.attr-value,
-.token.keyword {
+.token.keyword,
+.token.coord {
 	color: hsl(350, 40%, 70%);
 }
 

--- a/themes/prism-funky.css
+++ b/themes/prism-funky.css
@@ -89,7 +89,8 @@ code[class*="language-"] {
 
 .token.atrule,
 .token.attr-value,
-.token.keyword {
+.token.keyword,
+.token.coord {
 	color: deeppink;
 }
 

--- a/themes/prism-okaidia.css
+++ b/themes/prism-okaidia.css
@@ -96,7 +96,8 @@ pre[class*="language-"] {
 	color: #e6db74;
 }
 
-.token.keyword {
+.token.keyword,
+.token.coord {
 	color: #66d9ef;
 }
 

--- a/themes/prism-tomorrow.css
+++ b/themes/prism-tomorrow.css
@@ -84,7 +84,8 @@ pre[class*="language-"] {
 .token.important,
 .token.atrule,
 .token.keyword,
-.token.builtin {
+.token.builtin,
+.token.coord {
 	color: #cc99cd;
 }
 

--- a/themes/prism-twilight.css
+++ b/themes/prism-twilight.css
@@ -98,7 +98,8 @@ code[class*="language-"]::selection, code[class*="language-"] ::selection {
 .token.selector,
 .token.constant,
 .token.symbol,
-.token.builtin {
+.token.builtin,
+.token.coord {
 	color: hsl(53, 89%, 79%); /* #F9EE98 */
 }
 

--- a/themes/prism.css
+++ b/themes/prism.css
@@ -108,7 +108,8 @@ pre[class*="language-"] {
 
 .token.atrule,
 .token.attr-value,
-.token.keyword {
+.token.keyword,
+.token.coord {
 	color: #07a;
 }
 
@@ -129,3 +130,4 @@ pre[class*="language-"] {
 .token.entity {
 	cursor: help;
 }
+


### PR DESCRIPTION
`---` and `+++` should be highlighted as well, as they really make the entire output look nicer and easier to see the green lines are in this file.

This is especially important when highlighting plain diff files that are not generated by Git, because in that case the original and new file names are different.

Ping @lgiraudel, maintainer of the Git component.