### PR TITLE
+ Build and Publish

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 hide-*.js
 node_modules
 .idea/
+lib/

--- a/bower.json
+++ b/bower.json
@@ -4,6 +4,8 @@
   "main": [
       "prism.js",
       "themes/prism.css"
+      "lib/prism.js",
+      "themes/prism.css"
   ],
   "homepage": "http://prismjs.com",
   "authors": "Lea Verou",

--- a/package.json
+++ b/package.json
@@ -2,9 +2,12 @@
   "name": "prismjs",
   "version": "0.0.1",
   "description": "Lightweight, robust, elegant syntax highlighting. A spin-off project from Dabblet.",
-  "main": "prism.js",
+  "main": "lib/prism.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "build": "atma tools/atma-config.js run build",
+    "release": "atma tools/atma-config.js run release",
+    "watch": "atma tools/atma-config.js run watch"
   },
   "repository": {
     "type": "git",
@@ -22,6 +25,8 @@
     "gulp-concat": "^2.3.4",
     "gulp-header": "^1.0.5",
     "gulp-rename": "^1.2.0",
-    "gulp-uglify": "^0.3.1"
+    "gulp-uglify": "^0.3.1",
+    "uglify-js": "^2.4.15",
+    "atma": "^0.10.26"
   }
 }

--- a/tools/atma-config.js
+++ b/tools/atma-config.js
@@ -1,0 +1,15 @@
+module.exports = {
+	'build': {
+		action: 'custom',
+		script: '/tools/build/builder.js'
+	},
+	'release': {
+		action: 'custom',
+		script: '/tools/release/process.js'
+	},
+	'watch': {
+		files: 'components/**',
+		config: '#[build]'
+	},
+	'default': [ 'build' ]
+};

--- a/tools/build/builder.js
+++ b/tools/build/builder.js
@@ -1,0 +1,87 @@
+module.exports = {
+	process: function(config, done){
+
+		build_Prism();
+		build_Components();
+		build_Plugins();
+
+		done();
+	}
+};
+
+
+var OUTPUT = '/lib/',
+	DIR = __dirname + '/';
+
+function build_Prism () {
+	io.settings({
+		extensions: {
+			js: [ 'importer:read' ]
+		}
+	});
+
+	saveJavascript(
+		io.File.read(DIR + 'prism-lib.js'), '', 'prism.js'
+	);
+}
+function build_Components () {
+	var umd = io.File.read(DIR + 'extension-umd.js'),
+		SKIP = [
+			'.min.',
+			'-core.',
+			'-markup.',
+			'-css.',
+			'-clike.',
+			'-javascript.'
+		];
+
+	io.glob.readFiles('components/*.js').forEach(function(file){
+		if (!shouldSkip(file, SKIP)) 
+			wrapJavascript(file, umd, 'components/');
+	});
+}
+function build_Plugins () {
+	var umd = io.File.read(DIR + 'extension-umd.js'),
+		SKIP = [
+			'.min.',
+			'index.html'
+		];
+	io.glob.read('plugins/*').forEach(function(dir){
+		if (dir instanceof io.Directory === false) return;
+
+		var pluginName = dir.getName();
+
+		dir.readFiles('*').files.forEach(function(file) {
+			if (shouldSkip(file, SKIP)) return;
+			if (file.uri.getName() !== 'prism-' + pluginName + '.js') {
+				file.copyTo(OUTPUT + 'plugins/' + pluginName + '/');
+				return;
+			}
+
+			wrapJavascript(file, umd, 'plugins/' + pluginName + '/');
+		});
+	})
+}
+
+
+function minify (source) {
+	return require('uglify-js').minify(source, {fromString: true}).code;
+}
+function shouldSkip (file, patterns) {
+	return patterns.some(function(pattern){
+		return file.uri.file.indexOf(pattern) !== -1;
+	});
+}
+function wrapJavascript(file, umdSource, outputDir) {
+	logger.log('wrap', file.uri.file.bold);
+
+	var source = umdSource.replace('//%SOURCE%', function() { 
+		return file.read() 
+	});
+
+	saveJavascript(source, outputDir, file.uri.file);
+}
+function saveJavascript(source, outputDir, filename) {
+	io.File.write(OUTPUT + outputDir + filename, source);
+	io.File.write(OUTPUT + outputDir + filename.replace('.js', '.min.js'), minify(source), { skipHooks: true });
+}

--- a/tools/build/extension-umd.js
+++ b/tools/build/extension-umd.js
@@ -1,0 +1,30 @@
+(function(factory){
+
+	var prism_  = (typeof Prism  !== 'undefined' && Prism ) || null,
+		global_ = (typeof global !== 'undefined' && global) 
+		|| (typeof window !== 'undefined' && window)
+		|| (typeof WorkerGlobalScope !== 'undefined' && self instanceof WorkerGlobalScope && self)
+		|| null;
+	
+	if (prism_ == null && typeof require === 'function') {
+		prism_ = require('prismjs');
+	}
+	if (prism_ == null && typeof define === 'function' && define.amd) {
+		define(['prismjs'], function (Prism) {
+			return factory(Prism, global_, { Prism: Prism });
+		});
+		return;
+	}
+
+	if (prism_ == null) {
+		throw Error('Prism is not loaded');
+	}
+
+	// some plugins depend on `self`
+	factory(prism_, global_, { Prism: Prism });
+
+}(function(Prism, window, self) {
+
+	//%SOURCE%
+
+}));

--- a/tools/build/prism-lib.js
+++ b/tools/build/prism-lib.js
@@ -1,0 +1,15 @@
+(function(root, factory){
+
+	factory(root);
+
+}(this, function(self) {
+
+	// import /components/prism-core.js
+
+	// import /components/prism-markup.js
+	// import /components/prism-css.js
+	// import /components/prism-clike.js
+	// import /components/prism-javascript.js
+	// import /plugins/file-highlight/prism-file-highlight.js
+
+}));

--- a/tools/release/process.js
+++ b/tools/release/process.js
@@ -1,0 +1,48 @@
+var Builder 	= require('../build/builder');
+var BRANCH 		= 'builder';
+
+module.exports = {
+	process: function(config, done){
+		
+		app
+			.findAction('release')
+			.done(function(Release){
+				
+				// bump package.json and bower.json versions
+				Release.bump(function(err, version){
+							
+					Release.runCommands([
+						'git add -A',
+						'git commit -a -m "v' + version + '"',
+						'git push origin ' + BRANCH,
+						'git checkout -B release',
+						function (done) {
+							Builder.process({}, done);
+						},
+						function () {
+							Release.includeFiles.create([
+								'lib/**',
+								'themes/**',
+								'README.md',
+								'LICENSE',
+								'package.json',
+								'bower.json'
+							]);
+						},
+						'git rm -r --cached .',
+						'git add -A',
+						'git commit -a -m "v' + version + '"',
+						'git push origin release -ff',
+						'git tag v' + version,
+						'git push --tags',
+						//'npm publish',
+						function () {
+						 	Release.includeFiles.reset();
+						},
+						'git checkout ' + BRANCH + ' -ff'
+					], done);
+				});
+			
+			});
+	}
+};


### PR DESCRIPTION
Hello Team,

there is still no npm package, components and plugins are not ready to use in node env., and the bower package is from the 3rd part source. 
I'm proposing here automatically build and release the prism. 

**Build**: For the `node` environment, factory wrapper is used for each component and plugin, so it is then possible to `require` it.
**Release**: Just run `npm run release` from the cli and the script bumps both `bower/npm` versions, check-outs new `release` branch, builds the library, creates proper `.gitignore`,  publishes the new release branch and also the new git tag. If the maintainer uncomments `npm publish` [line](https://github.com/tenbits/prism/blob/builder/tools/release/process.js#L37) this will also publish the package. Bower's package updates after the new tag is created (_but we should ask the current bower maintainer to update the repo url_).

There is how release branch looks then: [prism/release](https://github.com/tenbits/prism/tree/release) 

Should you have any questions please give me a note, Alex.