### PR TITLE
File highlight start/end line number option

### DIFF
--- a/plugins/file-highlight/index.html
+++ b/plugins/file-highlight/index.html
@@ -8,6 +8,7 @@
 <base href="../.." />
 <link rel="stylesheet" href="style.css" />
 <link rel="stylesheet" href="themes/prism.css" data-noprefix />
+<link rel="stylesheet" href="plugins/line-numbers/prism-line-numbers.css" data-noprefix />
 <script src="prefixfree.min.js"></script>
 
 <script>var _gaq = [['_setAccount', 'UA-33746269-1'], ['_trackPageview']];</script>
@@ -31,8 +32,11 @@
 	
 	<p>You don’t need to specify the language, it’s automatically determined by the file extension.
 	If, however, the language cannot be determined from the file extension or the file extension is incorrect, you may specify a language as well (with the usual class name way).</p>
+
+	<p>Optional: You can specify the <code>data-start</code> and/or <code>data-end</code> (Number) attributes on the <code>&lt;pre&gt;</code> element.  It will trim the file to the specified lines before highlighting.</p>
 	
 	<p>Please note that the files are fetched with XMLHttpRequest. This means that if the file is on a different origin, fetching it will fail, unless CORS is enabled on that website.</p>
+
 </section>
 
 <section>
@@ -41,18 +45,21 @@
 	<p>The plugin’s JS code:</p>
 	<pre data-src="plugins/file-highlight/prism-file-highlight.js"></pre>
 	
-	<p>This page:</p>
-	<pre data-src="plugins/file-highlight/index.html"></pre>
+	<p>This section of this page's HTML:</p>
+	<p>Please note the <code>data-start</code> and <code>data-end</code> attributes
+		(and use of the <a href="plugins/line-numbers">line numbers plugin</a>)</p>
+	<pre class="line-numbers" data-start="48" data-end="51" data-src="plugins/file-highlight/index.html"></pre>
 	
 	<p>File that doesn’t exist:</p>
 	<pre data-src="foobar.js"></pre>
-	
+
 	<p>For more examples, browse around the Prism website. Most large code samples are actually files fetched with this plugin.</p>
 </section>
 
 <footer data-src="templates/footer.html" data-type="text/html"></footer>
 
 <script src="prism.js"></script>
+<script src="plugins/line-numbers/prism-line-numbers.js"></script>
 <script src="plugins/file-highlight/prism-file-highlight.js"></script>
 <script src="utopia.js"></script>
 <script src="components.js"></script>

--- a/plugins/file-highlight/index.html
+++ b/plugins/file-highlight/index.html
@@ -47,7 +47,7 @@
 	
 	<p>This section of this page's HTML:</p>
 	<p>Please note the <code>data-start</code> and <code>data-end</code> attributes
-		(and use of the <a href="plugins/line-numbers">line numbers plugin</a>)</p>
+		(and use of the <a href="plugins/line-numbers">Line Numbers plugin</a>)</p>
 	<pre class="line-numbers" data-start="48" data-end="51" data-src="plugins/file-highlight/index.html"></pre>
 	
 	<p>File that doesn’t exist:</p>

--- a/plugins/file-highlight/prism-file-highlight.js
+++ b/plugins/file-highlight/prism-file-highlight.js
@@ -17,6 +17,15 @@ Array.prototype.slice.call(document.querySelectorAll('pre[data-src]')).forEach(f
 	var src = pre.getAttribute('data-src');
 	var extension = (src.match(/\.(\w+)$/) || [,''])[1];
 	var language = Extensions[extension] || extension;
+
+	var start = 0, end;
+	if (pre.hasAttribute('data-start')) {
+		start = (parseInt(pre.getAttribute('data-start'), 10) - 1);
+		start = Math.max(start, 0);
+	}
+	if (pre.hasAttribute('data-end')) {
+		end = parseInt(pre.getAttribute('data-end'), 10);
+	}
 	
 	var code = document.createElement('code');
 	code.className = 'language-' + language;
@@ -35,7 +44,11 @@ Array.prototype.slice.call(document.querySelectorAll('pre[data-src]')).forEach(f
 		if (xhr.readyState == 4) {
 			
 			if (xhr.status < 400 && xhr.responseText) {
-				code.textContent = xhr.responseText;
+				if (start || end) {
+					code.textContent = xhr.responseText.split('\n').slice(start, end).join('\n');
+				} else {
+					code.textContent = xhr.responseText;
+				}
 			
 				Prism.highlightElement(code);
 			}

--- a/plugins/line-numbers/prism-line-numbers.js
+++ b/plugins/line-numbers/prism-line-numbers.js
@@ -1,5 +1,5 @@
 Prism.hooks.add('after-highlight', function (env) {
-	// works only for <code> wrapped inside <pre data-line-numbers> (not inline)
+	// works only for <code> wrapped inside <pre class="line-numbers"> (not inline)
 	var pre = env.element.parentNode;
 	if (!pre || !/pre/i.test(pre.nodeName) || pre.className.indexOf('line-numbers') === -1) {
 		return;

--- a/prism.js
+++ b/prism.js
@@ -625,26 +625,39 @@ Array.prototype.slice.call(document.querySelectorAll('pre[data-src]')).forEach(f
 	var src = pre.getAttribute('data-src');
 	var extension = (src.match(/\.(\w+)$/) || [,''])[1];
 	var language = Extensions[extension] || extension;
-	
+
+	var start = 0, end;
+	if (pre.hasAttribute('data-start')) {
+		start = (parseInt(pre.getAttribute('data-start'), 10) - 1);
+		start = Math.max(start, 0);
+	}
+	if (pre.hasAttribute('data-end')) {
+		end = parseInt(pre.getAttribute('data-end'), 10);
+	}
+
 	var code = document.createElement('code');
 	code.className = 'language-' + language;
-	
+
 	pre.textContent = '';
-	
+
 	code.textContent = 'Loading…';
-	
+
 	pre.appendChild(code);
-	
+
 	var xhr = new XMLHttpRequest();
-	
+
 	xhr.open('GET', src, true);
 
 	xhr.onreadystatechange = function() {
 		if (xhr.readyState == 4) {
-			
+
 			if (xhr.status < 400 && xhr.responseText) {
-				code.textContent = xhr.responseText;
-			
+				if (start || end) {
+					code.textContent = xhr.responseText.split('\n').slice(start, end).join('\n');
+				} else {
+					code.textContent = xhr.responseText;
+				}
+
 				Prism.highlightElement(code);
 			}
 			else if (xhr.status >= 400) {
@@ -655,7 +668,7 @@ Array.prototype.slice.call(document.querySelectorAll('pre[data-src]')).forEach(f
 			}
 		}
 	};
-	
+
 	xhr.send(null);
 });
 


### PR DESCRIPTION
I incorporated the `data-start` attribute from the line-numbs plugin and added a corresponding `data-end` attribute. If either is present, the download file is split into lines and slice'd to the correct subset before highlighting.

Plays nice with line-numbers plugin, and treats negative `data-start`'s as `0`.

I included an example on the page.
