### PR TITLE
fixed highlighting inside string interpolations

### DIFF
--- a/components/prism-swift.js
+++ b/components/prism-swift.js
@@ -1,5 +1,6 @@
-// issues: nested multiline comments, highlighting inside string interpolations
+// issues: nested multiline comments
 Prism.languages.swift = Prism.languages.extend('clike', {
+	'string': /("|'|\)).*?("|'|\\\()/g, // highlighting inside string interpolations
 	'keyword': /\b(as|associativity|break|case|class|continue|convenience|default|deinit|didSet|do|dynamicType|else|enum|extension|fallthrough|final|for|func|get|if|import|in|infix|init|inout|internal|is|lazy|left|let|mutating|new|none|nonmutating|operator|optional|override|postfix|precedence|prefix|private|protocol|public|required|return|right|safe|self|Self|set|static|struct|subscript|super|switch|Type|typealias|unowned|unowned|unsafe|var|weak|where|while|willSet|__COLUMN__|__FILE__|__FUNCTION__|__LINE__)\b/g,
 	'number': /\b([\d_]+(\.[\de_]+)?|0x[a-f0-9_]+(\.[a-f0-9p_]+)?|0b[01_]+|0o[0-7_]+)\b/gi,
 	'constant': /\b(nil|[A-Z_]{2,}|k[A-Z][A-Za-z_]+)\b/g,


### PR DESCRIPTION
This line fixes the “highlighting inside string interpolations”-issues. The following code will be highlighted correctly using prism.

```swift
let age = 42
let str = "\(age) years old"
```