### PR TITLE
Add class-name highlighting for Eiffel

### DIFF
--- a/components/prism-eiffel.js
+++ b/components/prism-eiffel.js
@@ -13,6 +13,8 @@ Prism.languages.eiffel = {
 	'char': /'(?:%'|.)+?'/,
 	'keyword': /\b(?:across|agent|alias|all|and|attached|as|assign|attribute|check|class|convert|create|Current|debug|deferred|detachable|do|else|elseif|end|ensure|expanded|export|external|feature|from|frozen|if|implies|inherit|inspect|invariant|like|local|loop|not|note|obsolete|old|once|or|Precursor|redefine|rename|require|rescue|Result|retry|select|separate|some|then|undefine|until|variant|Void|when|xor)\b/i,
 	'boolean': /\b(?:True|False)\b/i,
+	// Convention: class-names are always all upper-case characters
+	'class-name': /\b[A-Z][\dA-Z_]*\b/g,
 	'number': [
 		// hexa | octal | bin
 		/\b0[xcb][\da-f](?:_*[\da-f])*\b/i,

--- a/components/prism-eiffel.js
+++ b/components/prism-eiffel.js
@@ -14,7 +14,10 @@ Prism.languages.eiffel = {
 	'keyword': /\b(?:across|agent|alias|all|and|attached|as|assign|attribute|check|class|convert|create|Current|debug|deferred|detachable|do|else|elseif|end|ensure|expanded|export|external|feature|from|frozen|if|implies|inherit|inspect|invariant|like|local|loop|not|note|obsolete|old|once|or|Precursor|redefine|rename|require|rescue|Result|retry|select|separate|some|then|undefine|until|variant|Void|when|xor)\b/i,
 	'boolean': /\b(?:True|False)\b/i,
 	// Convention: class-names are always all upper-case characters
-	'class-name': /\b[A-Z][\dA-Z_]*\b/g,
+	'class-name': {
+		'pattern': /\b[A-Z][\dA-Z_]*\b/g,
+		'alias': 'builtin'
+	},
 	'number': [
 		// hexa | octal | bin
 		/\b0[xcb][\da-f](?:_*[\da-f])*\b/i,


### PR DESCRIPTION
Hi!

The creation of external theme, in particular a themes, in particular the [EiffelStudio IDE](https://www.eiffel.com/) theme, the Eiffel language definition must enable highlighting of the class-names.

I based the regex on the unanimously used Eiffel convention for class naming (i.e. class-names are always all upper-case characters).
The only known issue is that the formal generics are considered as class names...

Thanks.
