### PR TITLE
Use explicit language class if given.

### DIFF
--- a/plugins/file-highlight/prism-file-highlight.js
+++ b/plugins/file-highlight/prism-file-highlight.js
@@ -21,7 +21,7 @@ Array.prototype.slice.call(document.querySelectorAll('pre[data-src]')).forEach(f
 	var language = Extensions[extension] || extension;
 	
 	var code = document.createElement('code');
-	code.className = 'language-' + language;
+	code.className = pre.className || 'language-' + language;
 	
 	pre.textContent = '';
 	


### PR DESCRIPTION
Using the file highlight plugin with a custom file type didn't work for me, generating `code` with a class name of `language-<file extension>`, even with explicit language specification in the `pre`.  This did not highlight properly.  Copying the class from the `pre` to `code` fixed the problem.