### PR TITLE
Disable for elements within [contenteditable=true]

### DIFF
--- a/prism.js
+++ b/prism.js
@@ -149,6 +149,9 @@ var _ = self.Prism = {
 		var elements = document.querySelectorAll('code[class*="language-"], [class*="language-"] code, code[class*="lang-"], [class*="lang-"] code');
 
 		for (var i=0, element; element = elements[i++];) {
+			if(element.matches('[contenteditable=true] *')) {
+				continue;
+			}
 			_.highlightElement(element, async === true, callback);
 		}
 	},


### PR DESCRIPTION
Inline editors use `[contenteditable=true]` for container and it is not desired that Prism modifies markup inside since it stands to be standards-aware and it should be possible to remove it at any time without any problems (without this, however, source code is modified).