### PR TITLE
Fix bug related to line-highlighting plugin with Coy theme

### DIFF
--- a/themes/prism-coy.css
+++ b/themes/prism-coy.css
@@ -215,3 +215,17 @@ pre[class*="language-"].line-numbers code {
 pre[class*="language-"].line-numbers .line-numbers-rows {
 	left: 0;
 }
+
+/* Plugin styles: Line Highlight */
+pre[class*="language-"][data-line] {
+	padding-top: 0;
+	padding-bottom: 0;
+	padding-left: 0;
+}
+pre[data-line] code {
+	position: relative;
+	padding-left: 4em;
+}
+pre .line-highlight {
+	margin-top: 0;
+}


### PR DESCRIPTION
This is an attempt to fix #318.
This only solves the problem with the Line-highlight plugin used with Coy theme.
This does not solve the problem that occurs currently when using both the Light-highlight plugin and the Line-numbers plugin.

(The drop-shadow on the Coy theme, which implies the `<code>` is scrollable instead of the `<pre>` is a real pain in the neck.)