### PR TITLE
Reorder languages in components.js (Fix #441)

### DIFF
--- a/components.js
+++ b/components.js
@@ -41,57 +41,43 @@ var components = {
 			"title": "Markup",
 			"option": "default"
 		},
-		"twig": {
-			"title": "Twig",
-			"require": "markup",
-			"owner": "brandonkelly"
-		},
 		"css": {
 			"title": "CSS",
 			"option": "default"
 		},
-		"css-extras": {
-			"title": "CSS Extras",
-			"require": "css",
-			"owner": "milesj"
-		},
 		"clike": {
 			"title": "C-like",
 			"option": "default"
-		},
-		"eiffel": {
-			"title": "Eiffel",
-			"owner": "Conaclos"
 		},
 		"javascript": {
 			"title": "JavaScript",
 			"option": "default",
 			"require": "clike"
 		},
-		"java": {
-			"title": "Java",
-			"require": "clike",
-			"owner": "sherblot"
-		},
-		"php": {
-			"title": "PHP",
-			"require": "clike",
-			"owner": "milesj"
-		},
-		"php-extras": {
-			"title": "PHP Extras",
-			"require": "php",
-			"owner": "milesj"
-		},
-		"coffeescript": {
-			"title": "CoffeeScript",
+
+		// ---
+
+		"actionscript": {
+			"title": "ActionScript",
 			"require": "javascript",
-			"owner": "R-osey"
+			"owner": "Golmote"
 		},
-		"scss": {
-			"title": "Sass (Scss)",
-			"require": "css",
-			"owner": "MoOx"
+		"apacheconf": {
+			"title": "Apache Configuration",
+			"owner": "GuiTeK"
+		},
+		"applescript": {
+			"title": "AppleScript",
+			"owner": "Golmote"
+		},
+		"aspnet": {
+			"title": "ASP.NET (C#)",
+			"require": "markup",
+			"owner": "nauzilus"
+		},
+		"autohotkey": {
+			"title": "AutoHotkey",
+			"owner": "aviaryan"
 		},
 		"bash": {
 			"title": "Bash",
@@ -103,113 +89,69 @@ var components = {
 			"require": "clike",
 			"owner": "zeitgeist87"
 		},
+		"csharp": {
+			"title": "C#",
+			"require": "clike",
+			"owner": "mvalipour"
+		},
 		"cpp": {
 			"title": "C++",
 			"require": "c",
 			"owner": "zeitgeist87"
 		},
-		"python": {
-			"title": "Python",
-			"owner": "multipetros"
+		"coffeescript": {
+			"title": "CoffeeScript",
+			"require": "javascript",
+			"owner": "R-osey"
 		},
-		"julia": {
-			"title": "julia",
-			"owner": "cdagnino"
+		"css-extras": {
+			"title": "CSS Extras",
+			"require": "css",
+			"owner": "milesj"
 		},
-		"sql": {
-			"title": "SQL",
-			"owner": "multipetros"
-		},
-		"groovy": {
-			"title": "Groovy",
+		"dart": {
+			"title": "Dart",
 			"require": "clike",
-			"owner": "robfletcher"
+			"owner": "Golmote"
 		},
-		"http": {
-			"title": "HTTP",
-			"owner": "danielgtaylor"
+		"eiffel": {
+			"title": "Eiffel",
+			"owner": "Conaclos"
 		},
-		"ruby": {
-			"title": "Ruby",
+		"erlang": {
+			"title": "Erlang",
+			"owner": "Golmote"
+		},
+		"fsharp": {
+			"title": "F#",
 			"require": "clike",
-			"owner": "samflores"
+			"owner": "simonreynolds7"
 		},
-		"rip": {
-			"title": "Rip",
-			"owner": "ravinggenius"
+		"fortran": {
+			"title": "Fortran",
+			"owner": "Golmote"
 		},
 		"gherkin": {
 			"title": "Gherkin",
 			"owner": "hason"
 		},
-		"csharp": {
-			"title": "C#",
-			"require": "clike",
-			"owner": "mvalipour"
+		"git": {
+			"title": "Git",
+			"owner": "lgiraudel"
 		},
 		"go": {
 			"title": "Go",
 			"require": "clike",
 			"owner": "arnehormann"
 		},
-		"nsis": {
-			"title": "NSIS",
-			"owner": "idleberg"
-		},
-		"aspnet": {
-			"title": "ASP.NET (C#)",
-			"require": "markup",
-			"owner": "nauzilus"
-		},
-		"scala": {
-			"title": "Scala",
-			"require": "java",
-			"owner": "jozic"
-		},
-		"haskell": {
-			"title": "Haskell",
-			"owner": "bholst"
-		},
-		"swift": {
-			"title": "Swift",
+		"groovy": {
+			"title": "Groovy",
 			"require": "clike",
-			"owner": "chrischares"
+			"owner": "robfletcher"
 		},
-		"objectivec": {
-			"title": "Objective-C",
-			"require": "c",
-			"owner": "uranusjr"
-		},
-		"autohotkey": {
-			"title": "AutoHotkey",
-			"owner": "aviaryan"
-		},
-		"ini": {
-			"title": "Ini",
-			"owner": "aviaryan"
-		},
-		"latex": {
-			"title": "LaTeX",
-			"owner": "japborst"
-		},
-		"apacheconf": {
-			"title": "Apache Configuration",
-			"owner": "GuiTeK"
-		},
-		"git": {
-			"title": "Git",
-			"owner": "lgiraudel"
-		},
-		"scheme" : {
-			"title": "Scheme",
-			"owner" : "bacchus123"
-		},
-		"nasm": {
-			"title": "NASM",
-			"owner": "rbmj"
-		},
-		"perl": {
-			"title": "Perl",
+		"haml": {
+			"title": "Haml",
+			"require": "ruby",
 			"owner": "Golmote"
 		},
 		"handlebars": {
@@ -217,70 +159,43 @@ var components = {
 			"require": "markup",
 			"owner": "Golmote"
 		},
-		"matlab": {
-			"title": "MATLAB",
-			"owner": "Golmote"
+		"haskell": {
+			"title": "Haskell",
+			"owner": "bholst"
 		},
-		"less": {
-			"title": "Less",
-			"require": "css",
-			"owner": "Golmote"
+		"http": {
+			"title": "HTTP",
+			"owner": "danielgtaylor"
 		},
-		"r": {
-			"title": "R",
-			"owner": "Golmote"
-		},
-		"lolcode": {
-			"title": "LOLCODE",
-			"owner": "Golmote"
-		},
-		"fortran": {
-			"title": "Fortran",
-			"owner": "Golmote"
-		},
-		"erlang": {
-			"title": "Erlang",
-			"owner": "Golmote"
-		},
-		"haml": {
-			"title": "Haml",
-			"require": "ruby",
-			"owner": "Golmote"
+		"ini": {
+			"title": "Ini",
+			"owner": "aviaryan"
 		},
 		"jade": {
 			"title": "Jade",
 			"require": "javascript",
 			"owner": "Golmote"
 		},
-		"pascal": {
-			"title": "Pascal",
-			"owner": "Golmote"
-		},
-		"applescript": {
-			"title": "AppleScript",
-			"owner": "Golmote"
-		},
-		"rust": {
-			"title": "Rust",
-			"owner": "Golmote"
-		},
-		"dart": {
-			"title": "Dart",
+		"java": {
+			"title": "Java",
 			"require": "clike",
+			"owner": "sherblot"
+		},
+		"julia": {
+			"title": "Julia",
+			"owner": "cdagnino"
+		},
+		"latex": {
+			"title": "LaTeX",
+			"owner": "japborst"
+		},
+		"less": {
+			"title": "Less",
+			"require": "css",
 			"owner": "Golmote"
 		},
-		"powershell": {
-			"title": "PowerShell",
-			"owner": "nauzilus"
-		},
-		"smarty": {
-			"title": "Smarty",
-			"require": "markup",
-			"owner": "Golmote"
-		},
-		"actionscript": {
-			"title": "ActionScript",
-			"require": "javascript",
+		"lolcode": {
+			"title": "LOLCODE",
 			"owner": "Golmote"
 		},
 		"markdown": {
@@ -288,40 +203,128 @@ var components = {
 			"require": "markup",
 			"owner": "Golmote"
 		},
+		"matlab": {
+			"title": "MATLAB",
+			"owner": "Golmote"
+		},
+		"nasm": {
+			"title": "NASM",
+			"owner": "rbmj"
+		},
+		"nsis": {
+			"title": "NSIS",
+			"owner": "idleberg"
+		},
+		"objectivec": {
+			"title": "Objective-C",
+			"require": "c",
+			"owner": "uranusjr"
+		},
+		"pascal": {
+			"title": "Pascal",
+			"owner": "Golmote"
+		},
+		"php": {
+			"title": "PHP",
+			"require": "clike",
+			"owner": "milesj"
+		},
+		"php-extras": {
+			"title": "PHP Extras",
+			"require": "php",
+			"owner": "milesj"
+		},
+		"perl": {
+			"title": "Perl",
+			"owner": "Golmote"
+		},
+		"powershell": {
+			"title": "PowerShell",
+			"owner": "nauzilus"
+		},
+		"python": {
+			"title": "Python",
+			"owner": "multipetros"
+		},
+		"r": {
+			"title": "R",
+			"owner": "Golmote"
+		},
 		"jsx":{
 			"title": "React JSX",
 			"require": ["markup", "javascript"],
 			"owner": "vkbansal"
+		},
+		"rest": {
+			"title": "reST (reStructuredText)",
+			"owner": "Golmote"
+		},
+		"rip": {
+			"title": "Rip",
+			"owner": "ravinggenius"
+		},
+		"ruby": {
+			"title": "Ruby",
+			"require": "clike",
+			"owner": "samflores"
+		},
+		"rust": {
+			"title": "Rust",
+			"owner": "Golmote"
+		},
+		"sas": {
+			"title": "SAS",
+			"owner": "Golmote"
+		},
+		"scss": {
+			"title": "Sass (Scss)",
+			"require": "css",
+			"owner": "MoOx"
+		},
+		"scala": {
+			"title": "Scala",
+			"require": "java",
+			"owner": "jozic"
+		},
+		"scheme" : {
+			"title": "Scheme",
+			"owner" : "bacchus123"
+		},
+		"smalltalk": {
+			"title": "Smalltalk",
+			"owner": "Golmote"
+		},
+		"smarty": {
+			"title": "Smarty",
+			"require": "markup",
+			"owner": "Golmote"
+		},
+		"sql": {
+			"title": "SQL",
+			"owner": "multipetros"
+		},
+		"stylus" : {
+			"title": "Stylus",
+			"owner": "vkbansal"
+		},
+		"swift": {
+			"title": "Swift",
+			"require": "clike",
+			"owner": "chrischares"
+		},
+		"twig": {
+			"title": "Twig",
+			"require": "markup",
+			"owner": "brandonkelly"
 		},
 		"typescript":{
 			"title": "TypeScript",
 			"require": "javascript",
 			"owner": "vkbansal"
 		},
-		"fsharp": {
-			"title": "F#",
-			"require": "clike",
-			"owner": "simonreynolds7"
-		},
-		"sas": {
-			"title": "SAS",
-			"owner": "Golmote"
-		},
-		"rest": {
-			"title": "reST (reStructuredText)",
-			"owner": "Golmote"
-		},
-		"stylus" : {
-			"title": "Stylus",
-			"owner": "vkbansal"
-		},
 		"wiki": {
 			"title": "Wiki markup",
 			"require": "markup",
-			"owner": "Golmote"
-		},
-		"smalltalk": {
-			"title": "Smalltalk",
 			"owner": "Golmote"
 		}
 	},

--- a/components.js
+++ b/components.js
@@ -224,6 +224,10 @@ var components = {
 			"title": "Pascal",
 			"owner": "Golmote"
 		},
+		"perl": {
+			"title": "Perl",
+			"owner": "Golmote"
+		},
 		"php": {
 			"title": "PHP",
 			"require": "clike",
@@ -233,10 +237,6 @@ var components = {
 			"title": "PHP Extras",
 			"require": "php",
 			"owner": "milesj"
-		},
-		"perl": {
-			"title": "Perl",
-			"owner": "Golmote"
 		},
 		"powershell": {
 			"title": "PowerShell",

--- a/download.html
+++ b/download.html
@@ -65,6 +65,12 @@ section.options#category-languages {
 		column-span: all;
 	}
 
+	section.options#category-languages label[data-id="javascript"] {
+		border-bottom: 1px solid #aaa;
+		padding-bottom: 1em;
+		margin-bottom: 1em;
+	}
+
 section.options#category-themes {
 	width: 66.6%;
 	width: calc(100% * 2/3);

--- a/examples.html
+++ b/examples.html
@@ -19,6 +19,11 @@
 		display: block;
 		padding: .2em;
 	}
+	#languages label[data-id="javascript"] {
+		border-bottom: 1px solid #aaa;
+		padding-bottom: 1em;
+		margin-bottom: 1em;
+	}
 	#languages .unavailable {
 		color: #aaa;
 	}


### PR DESCRIPTION
(GitHub makes it look like a lot of change, but this is really just a reorder ^^)

Visually, I simply added a border to separate the "popular" languages from the others:

![http://puu.sh/gIQAp/3e8557a33e.png](http://puu.sh/gIQAp/3e8557a33e.png)

![http://puu.sh/gIQCl/60373ef32d.png](http://puu.sh/gIQCl/60373ef32d.png)

EDIT: Second commit fixes the ordering of Perl and PHP... ><