### PR TITLE
Remove `overflow: auto` from code element

### DIFF
--- a/plugins/show-language/prism-show-language.css
+++ b/plugins/show-language/prism-show-language.css
@@ -2,7 +2,6 @@ pre[class*='language-'] {
 	position: relative;
 }
 pre[class*='language-'] > code[data-language] {
-	overflow: scroll;
 	max-height: 28em;
 	display: block;
 }


### PR DESCRIPTION
Fixes #569. The pre element already has `overflow: auto` so the scrollbars will appear on it instead.