### PR TITLE
Npm modules

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -71,7 +71,7 @@ function readme(themeName) {
 
 function packagejson(themeName) {
 	return JSON.stringify({
-		name: 'prism-' + themeName + '-theme',
+		name: 'prismjs-' + themeName + '-theme',
 		version: version,
 	  description: 'A CSS theme for PrismJS',
 		repository: {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -9,6 +9,7 @@ var gulp   = require('gulp'),
 	File = require('vinyl'),
 	del = require('del'),
 	yargs = require('yargs'),
+	npm = require('npm'),
 
   runningPackagingTask = yargs.argv._.indexOf('createPackages') > -1,
   version = yargs.argv.version,
@@ -145,4 +146,23 @@ if (runningPackagingTask && !version) {
 }
 
 gulp.task('createPackages', ['copy-css', 'copy-files', 'update-version']);
+
+gulp.task('publishPackages', function(done) {
+	var packages = fs.readdirSync('dist')
+		.map(function(packageName) {
+			return path.join('dist', packageName);
+		})
+		.concat('.');
+
+	npm.load({}, function() {
+		function next() {
+			if (packages.length > 0) {
+				npm.commands.publish([packages.pop()], next);
+			} else {
+				done();
+			}
+		}
+		next();
+	});
+});
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -73,7 +73,7 @@ function packagejson(themeName) {
 	return JSON.stringify({
 		name: 'prismjs-' + themeName + '-theme',
 		version: version,
-	  description: 'A CSS theme for PrismJS',
+		description: 'A CSS theme for PrismJS',
 		repository: {
 			type: 'git',
 			url: 'https://github.com/PrismJS/prism.git'

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "gulp-rename": "^1.2.0",
     "gulp-uglify": "^0.3.1",
     "highland": "^2.5.0",
+    "npm": "^2.9.1",
     "vinyl": "^0.4.6",
     "yargs": "^3.9.0"
   }

--- a/package.json
+++ b/package.json
@@ -18,10 +18,14 @@
   "license": "MIT",
   "readmeFilename": "README.md",
   "devDependencies": {
+    "del": "^1.1.1",
     "gulp": "^3.8.6",
     "gulp-concat": "^2.3.4",
     "gulp-header": "^1.0.5",
     "gulp-rename": "^1.2.0",
-    "gulp-uglify": "^0.3.1"
+    "gulp-uglify": "^0.3.1",
+    "highland": "^2.5.0",
+    "vinyl": "^0.4.6",
+    "yargs": "^3.9.0"
   }
 }


### PR DESCRIPTION
cc/ @stubbornella @vinsonchuong

This PR makes publishing NPM modules programmatic. It publishes the following packages to NPM
- `prismjs` containing all of the JavaScript
- `prismjs-THEMENAME-theme` one package per theme:
  - `prismjs-coy-theme`
  - `prismjs-dark-theme`
  - `prismjs-default-theme`
  - `prismjs-funky-theme`
  - `prismjs-okaidia-theme`
  - `prismjs-tomorrow-theme`
  - `prismjs-twilight-theme`

Run `gulp createPackages --version X.X.X` to create the packages. The theme packages are added to the `dist/` folder. The version number in the main `package.json` is updated as well.

If all looks good, run `gulp publishPackages` to publish to npm.

We published v0.0.1 of all the packages to NPM and added you as an owner
