### PR TITLE
Add Ubuntu Mono font to font stack

### DIFF
--- a/themes/prism-coy.css
+++ b/themes/prism-coy.css
@@ -7,7 +7,7 @@
 code[class*="language-"],
 pre[class*="language-"] {
 	color: black;
-	font-family: Consolas, Monaco, 'Andale Mono', monospace;
+	font-family: Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
 	direction: ltr;
 	text-align: left;
 	white-space: pre;

--- a/themes/prism-dark.css
+++ b/themes/prism-dark.css
@@ -8,7 +8,7 @@ code[class*="language-"],
 pre[class*="language-"] {
 	color: white;
 	text-shadow: 0 -.1em .2em black;
-	font-family: Consolas, Monaco, 'Andale Mono', monospace;
+	font-family: Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
 	direction: ltr;
 	text-align: left;
 	white-space: pre;

--- a/themes/prism-funky.css
+++ b/themes/prism-funky.css
@@ -6,7 +6,7 @@
 
 code[class*="language-"],
 pre[class*="language-"] {
-	font-family: Consolas, Monaco, 'Andale Mono', monospace;
+	font-family: Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
 	direction: ltr;
 	text-align: left;
 	white-space: pre;

--- a/themes/prism-okaidia.css
+++ b/themes/prism-okaidia.css
@@ -8,7 +8,7 @@ code[class*="language-"],
 pre[class*="language-"] {
 	color: #f8f8f2;
 	text-shadow: 0 1px rgba(0, 0, 0, 0.3);
-	font-family: Consolas, Monaco, 'Andale Mono', monospace;
+	font-family: Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
 	direction: ltr;
 	text-align: left;
 	white-space: pre;

--- a/themes/prism-tomorrow.css
+++ b/themes/prism-tomorrow.css
@@ -7,7 +7,7 @@
 code[class*="language-"],
 pre[class*="language-"] {
 	color: #ccc;
-	font-family: Consolas, Monaco, 'Andale Mono', monospace;
+	font-family: Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
 	direction: ltr;
 	text-align: left;
 	white-space: pre;

--- a/themes/prism-twilight.css
+++ b/themes/prism-twilight.css
@@ -7,7 +7,7 @@ code[class*="language-"],
 pre[class*="language-"] {
 	color: white;
 	direction: ltr;
-	font-family: Consolas, Monaco, 'Andale Mono', monospace;
+	font-family: Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
 	text-align: left;
 	text-shadow: 0 -.1em .2em black;
 	white-space: pre;

--- a/themes/prism.css
+++ b/themes/prism.css
@@ -8,7 +8,7 @@ code[class*="language-"],
 pre[class*="language-"] {
 	color: black;
 	text-shadow: 0 1px white;
-	font-family: Consolas, Monaco, 'Andale Mono', monospace;
+	font-family: Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
 	direction: ltr;
 	text-align: left;
 	white-space: pre;


### PR DESCRIPTION
None of the other fonts are currently available on Ubuntu and the
addition of Ubuntu Mono to the font stack makes the code look much nicer
on Ubuntu systems.

Also added a missing newline to the end of prism-coy.css