### PR TITLE
Number recognition improved and documented regex

### DIFF
--- a/components/prism-java.js
+++ b/components/prism-java.js
@@ -5,7 +5,7 @@ Prism.languages.java = Prism.languages.extend('clike', {
 	// a word consisting of 0x an optional letter from a to f or digit perhaps one dot at least one letter from a to f or digit or
 	// a word consisting of an optional digit perhaps one dot at least one digit perhaps the letter e a + or - symbol, optional digits and perhaps one of the letters d f l or
 	// a word consisting of an optional digit perhaps one dot at least one digit
-	'number': /\b0b[01]+\b|\b0x[\da-f]*\.?[\da-fp\-]+\b|\b\d+\.?\d*(e|E)?([\+]|[\-])?[\d]*[dfl]*\b|\b\d*\.?\d+\b/i,
+	'number': /\b0b[01]+\b|\b0x[\da-f]*\.?[\da-fp\-]+\b|\b\d+\.?\d*e?[+-]?[\d]*[dfl]*\b|\b\d*\.?\d+\b/i,
 	'operator': {
 		pattern: /(^|[^\.])(?:\+=|\+\+?|-=|--?|!=?|<{1,2}=?|>{1,3}=?|==?|&=|&&?|\|=|\|\|?|\?|\*=?|\/=?|%=?|\^=?|:|~)/m,
 		lookbehind: true

--- a/components/prism-java.js
+++ b/components/prism-java.js
@@ -1,6 +1,11 @@
 Prism.languages.java = Prism.languages.extend('clike', {
 	'keyword': /\b(abstract|continue|for|new|switch|assert|default|goto|package|synchronized|boolean|do|if|private|this|break|double|implements|protected|throw|byte|else|import|public|throws|case|enum|instanceof|return|transient|catch|extends|int|short|try|char|final|interface|static|void|class|finally|long|strictfp|volatile|const|float|native|super|while)\b/,
-	'number': /\b0b[01]+\b|\b0x[\da-f]*\.?[\da-fp\-]+\b|\b\d*\.?\d+[e]?[\d]*[df]\b|\b\d*\.?\d+\b/i,
+	// number is either
+	// a word consisting of 0b the 0 or 1 number one or more times or
+	// a word consisting of 0x an optional letter from a to f or digit perhaps one dot at least one letter from a to f or digit or
+	// a word consisting of an optional digit perhaps one dot at least one digit perhaps the letter e a + or - symbol, optional digits and perhaps one of the letters d f l or
+	// a word consisting of an optional digit perhaps one dot at least one digit
+	'number': /\b0b[01]+\b|\b0x[\da-f]*\.?[\da-fp\-]+\b|\b\d+\.?\d*(e|E)?([\+]|[\-])?[\d]*[dfl]*\b|\b\d*\.?\d+\b/i,
 	'operator': {
 		pattern: /(^|[^\.])(?:\+=|\+\+?|-=|--?|!=?|<{1,2}=?|>{1,3}=?|==?|&=|&&?|\|=|\|\|?|\?|\*=?|\/=?|%=?|\^=?|:|~)/m,
 		lookbehind: true


### PR DESCRIPTION
Explained the regex with natural language so people unfamiliar with it can understand it and easily improve the regex expressions


Tested with:

    0b001
    0x56ab16ec675.7648p34
    public static final double MAX_VALUE = 0x1.fffffffFfffffP+1023;
    public static final double MIN_NORMAL = 0x1.0p-1022;
    public static final double MIN_VALUE = 0x0.0000000000001P-1022; // 4.9e-324
    4.9e-324
    3.30e23
    3.30e+23
    3.30e+23f
    3.30e+23l
    6.67e−11
    9.870699812169277
    NumberFormat formatter = new DecimalFormat("0.00000000000");
    String string = formatter.format(9.870699812169277E-4);
    System.out.println(string);