### PR TITLE
Issue 324 - Fixing word wrap on long code lines, which is breaking the line-numbers plugin

### DIFF
--- a/themes/prism-coy.css
+++ b/themes/prism-coy.css
@@ -13,6 +13,7 @@ pre[class*="language-"] {
 	white-space: pre;
 	word-spacing: normal;
 	word-break: normal;
+	word-wrap: normal;
 	line-height: 1.5;
 
 	-moz-tab-size: 4;

--- a/themes/prism-dark.css
+++ b/themes/prism-dark.css
@@ -14,6 +14,7 @@ pre[class*="language-"] {
 	white-space: pre;
 	word-spacing: normal;
 	word-break: normal;
+	word-wrap: normal;
 	line-height: 1.5;
 
 	-moz-tab-size: 4;

--- a/themes/prism-funky.css
+++ b/themes/prism-funky.css
@@ -12,6 +12,7 @@ pre[class*="language-"] {
 	white-space: pre;
 	word-spacing: normal;
 	word-break: normal;
+	word-wrap: normal;
 	line-height: 1.5;
 
 	-moz-tab-size: 4;

--- a/themes/prism-okaidia.css
+++ b/themes/prism-okaidia.css
@@ -14,6 +14,7 @@ pre[class*="language-"] {
 	white-space: pre;
 	word-spacing: normal;
 	word-break: normal;
+	word-wrap: normal;
 	line-height: 1.5;
 
 	-moz-tab-size: 4;

--- a/themes/prism-tomorrow.css
+++ b/themes/prism-tomorrow.css
@@ -13,6 +13,7 @@ pre[class*="language-"] {
 	white-space: pre;
 	word-spacing: normal;
 	word-break: normal;
+	word-wrap: normal;
 	line-height: 1.5;
 
 	-moz-tab-size: 4;

--- a/themes/prism-twilight.css
+++ b/themes/prism-twilight.css
@@ -13,6 +13,7 @@ pre[class*="language-"] {
 	white-space: pre;
 	word-spacing: normal;
 	word-break: normal;
+	word-wrap: normal;
 	line-height: 1.5;
 
 	-moz-tab-size: 4;

--- a/themes/prism.css
+++ b/themes/prism.css
@@ -14,6 +14,7 @@ pre[class*="language-"] {
 	white-space: pre;
 	word-spacing: normal;
 	word-break: normal;
+	word-wrap: normal;
 	line-height: 1.5;
 
 	-moz-tab-size: 4;


### PR DESCRIPTION
This commit fixes **part** of Issue https://github.com/PrismJS/prism/issues/324, which is breaking the line-numbers plugin when working with bootstrap.

Currently, if a line overflows onto the next line, the line numbers will not space out accordingly to compensate for this overflow.

This change rectifies this by not breaking long lines onto multiple lines
(It will be up to the developer to break their code onto multiple lines if they do not want the overflow)