### PR TITLE
Fixing coy theme + line numbers plugin overflowing on long blocks of text

### DIFF
--- a/themes/prism-coy.css
+++ b/themes/prism-coy.css
@@ -44,10 +44,11 @@ pre[class*="language-"] {
 	background-origin: content-box;
 	overflow: visible;
 	max-height: 30em;
+	padding: 0;
 }
 
 code[class*="language"] {
-	max-height: 28.5em;
+	max-height: inherit;
 	height: 100%;
 	padding: 0 1em;
 	display: block;

--- a/themes/prism-coy.css
+++ b/themes/prism-coy.css
@@ -47,7 +47,7 @@ pre[class*="language-"] {
 }
 
 code[class*="language"] {
-	max-height: inherit;
+	max-height: 28.5em;
 	height: 100%;
 	padding: 0 1em;
 	display: block;


### PR DESCRIPTION
Currently, with the coy theme and line numbers plugin, due to the before and after pseudo elements, long blocks of text overflow outside of the code blocks like so:

<img width="278" alt="screen shot 2015-09-08 at 10 42 48 pm" src="https://cloud.githubusercontent.com/assets/1011628/9754149/0418b0a2-567b-11e5-8579-60bf64838f3f.png">

This commit fixes this, making the code element's max height slightly smaller than the pre element's max height. All code is shown properly, and code no longer overflows outside of the pre element.

Seen on Mac, Chrome Version 45.0.2454.85 (64-bit)