### PR TITLE
Show Language: fix the problem of language label scrolling out of view with code.

### DIFF
--- a/plugins/show-language/prism-show-language.css
+++ b/plugins/show-language/prism-show-language.css
@@ -1,8 +1,8 @@
-pre[class*='language-'] {
+div.prism-show-language {
 	position: relative;
 }
-pre[class*='language-'][data-language]::before {
-	content: attr(data-language);
+
+div.prism-show-language > div.prism-show-language-label[data-language] {
 	color: black;
 	background-color: #CFCFCF;
 	display: inline-block;

--- a/plugins/show-language/prism-show-language.js
+++ b/plugins/show-language/prism-show-language.js
@@ -14,17 +14,30 @@ Prism.hooks.add('before-highlight', function(env) {
 	var language = Languages[env.language] || (env.language.substring(0, 1).toUpperCase() + env.language.substring(1));
 	pre.setAttribute('data-language', language);
 
-	var div = document.createElement('div');
-	var div2 = document.createElement('div');
+	/* check if the divs already exist */
+	var sib = pre.previousSibling;
+	var div, div2;
+	if (sib && /\s*\bprism-show-language\b\s*/.test(sib.className) &&
+		sib.firstChild &&
+		/\s*\bprism-show-language-label\b\s*/.test(sib.firstChild.className)) {
+		div2 = sib.firstChild;
+		if (div2.getAttribute('data-language') !== language) {
+			div2.setAttribute('data-language', language);
+			div2.innerHTML = language;
+		}
+	} else {
+		div = document.createElement('div');
+		div2 = document.createElement('div');
 
-	div2.className = 'prism-show-language-label';
-	div2.setAttribute('data-language', language);
-	div2.innerHTML = language;
+		div2.className = 'prism-show-language-label';
+		div2.setAttribute('data-language', language);
+		div2.innerHTML = language;
 
-	div.className = 'prism-show-language';
-	div.appendChild(div2);
+		div.className = 'prism-show-language';
+		div.appendChild(div2);
 
-	pre.parentNode.insertBefore(div, pre);
+		pre.parentNode.insertBefore(div, pre);
+	}
 });
 
 })();

--- a/plugins/show-language/prism-show-language.js
+++ b/plugins/show-language/prism-show-language.js
@@ -13,6 +13,18 @@ Prism.hooks.add('before-highlight', function(env) {
 	}
 	var language = Languages[env.language] || (env.language.substring(0, 1).toUpperCase() + env.language.substring(1));
 	pre.setAttribute('data-language', language);
+
+	var div = document.createElement('div');
+	var div2 = document.createElement('div');
+
+	div2.className = 'prism-show-language-label';
+	div2.setAttribute('data-language', language);
+	div2.innerHTML = language;
+
+	div.className = 'prism-show-language';
+	div.appendChild(div2);
+
+	pre.parentNode.insertBefore(div, pre);
 });
 
 })();


### PR DESCRIPTION
Fix this problem by moving the label to a previous sibling of 'pre'.

I've made tests with Line Number plugin and it works fine.
