### PR TITLE
Improve highlight.

### DIFF
--- a/components/prism-c.js
+++ b/components/prism-c.js
@@ -16,9 +16,17 @@ Prism.languages.insertBefore('c', 'string', {
 			'string': {
 				pattern: /(#\s*include\s*)(<.+?>|("|')(\\?.)+?\3)/,
 				lookbehind: true
+			},
+			// highlight macro directives as keywords
+			'directive': {
+				pattern: /(#\s*)\b(define|elif|else|endif|error|ifdef|ifndef|if|import|include|line|pragma|undef|using)\b/,
+				lookbehind: true,
+				alias: 'keyword'
 			}
 		}
-	}
+	},
+	// highlight predefined macros as constants
+	'constant': /\b(__FILE__|__LINE__|__DATE__|__TIME__|__TIMESTAMP__|__func__|EOF|NULL|stdin|stdout|stderr)\b/
 });
 
 delete Prism.languages.c['class-name'];

--- a/components/prism-csharp.js
+++ b/components/prism-csharp.js
@@ -10,6 +10,15 @@ Prism.languages.csharp = Prism.languages.extend('clike', {
 Prism.languages.insertBefore('csharp', 'keyword', {
 	'preprocessor': {
 		pattern: /(^\s*)#.*/m,
-		lookbehind: true
+		lookbehind: true,
+		alias: 'property',
+		inside: {
+			// highlight preprocessor directives as keywords
+			'directive': {
+				pattern: /(\s*#)\b(define|elif|else|endif|endregion|error|if|line|pragma|region|undef|warning)\b/,
+				lookbehind: true,
+				alias: 'keyword'
+			}
+		}
 	}
 });

--- a/components/prism-fsharp.js
+++ b/components/prism-fsharp.js
@@ -19,5 +19,15 @@ Prism.languages.fsharp = Prism.languages.extend('clike', {
 	]
 });
 Prism.languages.insertBefore('fsharp', 'keyword', {
-	'preprocessor': /^[^\r\n\S]*#.*/m
+	'preprocessor': {
+		pattern: /^[^\r\n\S]*#.*/m,
+		alias: 'property',
+		inside: {
+			'directive': {
+				pattern: /(\s*#)\b(else|endif|if|light|line|nowarn)\b/,
+				lookbehind: true,
+				alias: 'keyword'
+			}
+		}
+	}
 });

--- a/components/prism-javascript.js
+++ b/components/prism-javascript.js
@@ -1,5 +1,5 @@
 Prism.languages.javascript = Prism.languages.extend('clike', {
-	'keyword': /\b(as|async|await|break|case|catch|class|const|continue|debugger|default|delete|do|else|enum|export|extends|false|finally|for|from|function|get|if|implements|import|in|instanceof|interface|let|new|null|of|package|private|protected|public|return|set|static|super|switch|this|throw|true|try|typeof|var|void|while|with|yield)\b/,
+	'keyword': /\b(as|async|await|break|case|catch|class|const|continue|debugger|default|delete|do|else|enum|export|extends|finally|for|from|function|get|if|implements|import|in|instanceof|interface|let|new|null|of|package|private|protected|public|return|set|static|super|switch|this|throw|try|typeof|var|void|while|with|yield)\b/,
 	'number': /\b-?(0x[\dA-Fa-f]+|0b[01]+|0o[0-7]+|\d*\.?\d+([Ee][+-]?\d+)?|NaN|Infinity)\b/,
 	// Allow for all non-ASCII characters (See http://stackoverflow.com/a/2008444)
 	'function': /[_$a-zA-Z\xA0-\uFFFF][_$a-zA-Z0-9\xA0-\uFFFF]*(?=\()/i


### PR DESCRIPTION
Add highlight for directives in C/C++ macros and C#/F# preprocessor lines;
Add some predefined constants in C;
Remove `true` and `false` from keyword list in JavaScript, they should be considered as boolean constant.