### PR TITLE
Revert white-space to normal when code is inline instead of in a pre

### DIFF
--- a/themes/prism-coy.css
+++ b/themes/prism-coy.css
@@ -77,6 +77,7 @@ pre[class*="language-"] {
 	color: #c92c2c;
 	border: 1px solid rgba(0, 0, 0, 0.1);
 	display: inline;
+	white-space: normal;
 }
 
 pre[class*="language-"]:before,

--- a/themes/prism-dark.css
+++ b/themes/prism-dark.css
@@ -55,6 +55,7 @@ pre[class*="language-"] {
 	border-radius: .3em;
 	border: .13em solid hsl(30, 20%, 40%);
 	box-shadow: 1px 1px .3em -.1em black inset;
+	white-space: normal;
 }
 
 .token.comment,

--- a/themes/prism-funky.css
+++ b/themes/prism-funky.css
@@ -45,6 +45,7 @@ code[class*="language-"] {
 	padding: .2em;
 	border-radius: .3em;
 	box-shadow: none;
+	white-space: normal;
 }
 
 .token.comment,

--- a/themes/prism-okaidia.css
+++ b/themes/prism-okaidia.css
@@ -44,6 +44,7 @@ pre[class*="language-"] {
 :not(pre) > code[class*="language-"] {
 	padding: .1em;
 	border-radius: .3em;
+	white-space: normal;
 }
 
 .token.comment,

--- a/themes/prism-tomorrow.css
+++ b/themes/prism-tomorrow.css
@@ -43,6 +43,7 @@ pre[class*="language-"] {
 :not(pre) > code[class*="language-"] {
 	padding: .1em;
 	border-radius: .3em;
+	white-space: normal;
 }
 
 .token.comment,

--- a/themes/prism-twilight.css
+++ b/themes/prism-twilight.css
@@ -70,6 +70,7 @@ code[class*="language-"]::selection, code[class*="language-"] ::selection {
 	border: .13em solid hsl(0, 0%, 33%); /* #545454 */
 	box-shadow: 1px 1px .3em -.1em black inset;
 	padding: .15em .2em .05em;
+	white-space: normal;
 }
 
 .token.comment,

--- a/themes/prism.css
+++ b/themes/prism.css
@@ -62,6 +62,7 @@ pre[class*="language-"] {
 :not(pre) > code[class*="language-"] {
 	padding: .1em;
 	border-radius: .3em;
+	white-space: normal;
 }
 
 .token.comment,


### PR DESCRIPTION
All of the themes have in common that they set `white-space: pre` on `code`, even if `code` is not inside a `pre`. That is problematic for two reasons:

1. `code` normally does not work that way, so you can normally safely go to the next line inside of an inline `code`; with `pre` that white space becomes visible. When we turned Prism on for our site (which has a lot of inline `code`) it immediately turned into a train wreck.
2. The lack of wrapping means that it easily overflows on small screens. For `pre` we are protected by wrappers that scroll the overflow, but you don't expect that from inline elements.

This PR simply returns inline `code` to its expected `normal` value.