### PR TITLE
Trim plugin

### DIFF
--- a/components.js
+++ b/components.js
@@ -594,6 +594,11 @@ var components = {
 			"owner": "Golmote",
 			"noCSS": true
 		},
+		"trim": {
+			"title": "Whitespace trimmer",
+			"owner": "telic",
+			"noCSS": true
+		},
 		"keep-markup": {
 			"title": "Keep Markup",
 			"owner": "Golmote",

--- a/components/prism-core.js
+++ b/components/prism-core.js
@@ -183,6 +183,7 @@ var _ = _self.Prism = {
 		};
 
 		if (!code || !grammar) {
+			_.hooks.run('wont-highlight', env);
 			_.hooks.run('complete', env);
 			return;
 		}

--- a/plugins/trim/index.html
+++ b/plugins/trim/index.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+
+	<meta charset="utf-8" />
+	<link rel="shortcut icon" href="favicon.png" />
+	<title>Whitespace trimmer ▲ Prism plugins</title>
+	<base href="../.." />
+	<link rel="stylesheet" href="style.css" />
+	<link rel="stylesheet" href="themes/prism.css" data-noprefix />
+	<link rel="stylesheet" href="plugins/show-invisibles/prism-show-invisibles.css" data-noprefix />
+	<script src="prefixfree.min.js"></script>
+
+	<script>var _gaq = [['_setAccount', 'UA-33746269-1'], ['_trackPageview']];</script>
+	<script src="http://www.google-analytics.com/ga.js" async></script>
+</head>
+<body>
+
+<header>
+	<div class="intro" data-src="templates/header-plugins.html" data-type="text/html"></div>
+
+	<h2>Whitespace trimmer</h2>
+	<p>Removes initial and tailing blank lines, end-of-line whitespace, and consistent indents.</p>
+</header>
+
+<section class="language-markup">
+	<h1>How to use</h1>
+
+	<p>Obviously, this is supposed to work only for code blocks (<code>&lt;pre>&lt;code></code>) and not for inline code.</p>
+	<p>With this plugin included, all periphery whitespace will be removed by default.</p>
+	<p>To bypass this behaviour for a particular <code>&lt;code></code> block, you may add one or more of the following classes to it or any ancestor:</p>
+	<dl>
+		<dt>dont-trim</dt>
+		<dd>Disables whitespace trimming entirely.</dd>
+		<dt>dont-trim-start</dt>
+		<dd>Preserve initial blank lines.</dd>
+		<dt>dont-trim-end</dt>
+		<dd>Preserve trailing blank lines.</dd>
+		<dt>dont-trim-trailing</dt>
+		<dd>Preserve whitespace at the end of each line.</dd>
+		<dt>dont-trim-indent</dt>
+		<dd>Preserve overall indentation.</dd>
+	</dl>
+	<p>Alternately, you can set global preferences in code by modifying <code class="language-javascript">Prism.plugins.trim</code>.</p>
+</section>
+
+<section class="language-markup">
+	<h1>Examples</h1>
+	<p>Without this plugin, your code blocks might end up looking like this</p>
+	<pre class="dont-trim _trim-example"><code>   
+
+		&lt;p>Hello, world!&lt;/p>  
+		&lt;ol> 	 
+		    &lt;li>one&lt;/li>
+			&lt;li>two&lt;/li>
+		&lt;/ol>	
+
+	</code></pre>
+	<p>With this plugin enabled, here's what you'll get instead!</p>
+	<p class="_trim-placeholder">
+		You'd see an example here if you
+		had Javascript turned on…
+	</p>
+</section>
+
+<footer data-src="templates/footer.html" data-type="text/html"></footer>
+
+<script src="utopia.js"></script>
+<script>
+(function() {
+	// clone the example so we don't need to keep the two
+	// code blocks in sync by hand
+	var example = $("._trim-example");
+	var placeholder = $("._trim-placeholder");
+	var trimmed = example.cloneNode(true);
+	trimmed.removeAttribute("class");
+	placeholder.parentNode.replaceChild(trimmed, placeholder);
+})();
+</script>
+<script src="prism.js"></script>
+<script src="plugins/show-invisibles/prism-show-invisibles.js"></script>
+<script src="plugins/trim/prism-trim.js"></script>
+<script src="components.js"></script>
+<script src="code.js"></script>
+
+
+</body>
+</html>

--- a/plugins/trim/prism-trim.js
+++ b/plugins/trim/prism-trim.js
@@ -1,0 +1,68 @@
+(function() {
+	"use strict";
+	if ( !self.Prism || ![].filter) return;
+
+	// classes for disabling trimming
+	var dont = /\bdont-trim(?:-(indent|start|end|trailing))?\b/g;
+	// the horrible character classes below are just \s without \r and \n
+	var eolSpace = /[ \f\t\v​\u00a0\u1680​\u180e\u2000-\u200a\u2028\u2029\u202f\u205f​\u3000\ufeff]+$/gm;
+	var solSpace = /^[ \f\t\v​\u00a0\u1680​\u180e\u2000-\u200a\u2028\u2029\u202f\u205f​\u3000\ufeff]+(?=\S)/m;
+
+	// determines what to trim (can be affected by any ancestor)
+	function get_conf(el) {
+		if (!/pre/i.test(el.parentNode.nodeName)) return false; // only trim blocks
+		var conf = {
+			'indent': true,
+			'start': true,
+			'end': true,
+			'trailing': true
+		};
+		function updateConf(m, t) {
+			if (t === undefined) conf = false;
+			else conf[t] = false;
+		}
+		while (el && conf) {
+			// note: abusing .replace to iterate over matches
+			(""+el.className).replace(dont, updateConf);
+			el = el.parentNode;
+		}
+		return conf;
+	}
+	
+	function trim(env) {
+		var conf = get_conf(env.element);
+		if (conf) {
+			if (conf.start) env.code = env.code.replace(/^\s*\n/g, '');
+			if (conf.end) env.code = env.code.replace(/\r?\n\s+$/g, '');
+			if (conf.trailing) env.code = env.code.replace(eolSpace, '');
+			if (conf.indent) {
+				var first_indent = env.code.match(solSpace);
+				if (first_indent) {
+					env.code = env.code.replace(
+						(new RegExp("^"+first_indent[0], "gm")),
+						''
+					);
+				}
+			}
+		}
+	}
+
+	Prism.hooks.add('before-highlight', trim);
+	Prism.hooks.add('wont-highlight', function (env) {
+		if (env.code && env.language === "none") {
+			// find just the child that is the code,
+			// in case other plugins have added extra already
+			var codeChild = [].filter.call(
+				env.element.childNodes,
+				function (el) {
+					if (el.textContent === env.code) return true;
+					else return false;
+				}
+			)[0];
+			if (codeChild) {
+				trim(env);
+				codeChild.textContent = env.code;
+			}
+		}
+	});
+})();


### PR DESCRIPTION
Trims blank lines from the beginning and end of code blocks, as well as removing indents and end-of-line whitespace.

This makes the "remove-initial-line-feed" plugin redundant.

This plugin needs to run before those that attach to the "complete" hook (e.g. line-numbers), or strange things may happen. There didn't appear to be any way to ensure this when running on "language-none" blocks, so I added a new "wont-highlight" hook for this use.