### PR TITLE
Prevent infinite recursion in DFS

### DIFF
--- a/components/prism-core.js
+++ b/components/prism-core.js
@@ -125,16 +125,19 @@ var _ = _self.Prism = {
 		},
 
 		// Traverse a language definition with Depth First Search
-		DFS: function(o, callback, type) {
+		DFS: function(o, callback, type, visited) {
+			visited = visited || {};
 			for (var i in o) {
 				if (o.hasOwnProperty(i)) {
 					callback.call(o, i, o[i], type || i);
 
-					if (_.util.type(o[i]) === 'Object') {
-						_.languages.DFS(o[i], callback);
+					if (_.util.type(o[i]) === 'Object' && !visited[o[i]]) {
+						visited[o[i]] = true;
+						_.languages.DFS(o[i], callback, null, visited);
 					}
-					else if (_.util.type(o[i]) === 'Array') {
-						_.languages.DFS(o[i], callback, i);
+					else if (_.util.type(o[i]) === 'Array' && !visited[o[i]]) {
+						visited[o[i]] = true;
+						_.languages.DFS(o[i], callback, i, visited);
 					}
 				}
 			}


### PR DESCRIPTION
This PR should fix issue #818 but it should also increase the performance of DFS in general. A lot of languages have direct references to each other and DFS is called for all languages every time insertBefore() is called. So it makes sense to skip objects that have been traversed already.

The only problem is, that I don't know if this modification breaks any of the plugins or languages.