### PR TITLE
Defer File Highlight until the full DOM has loaded.

### DIFF
--- a/plugins/file-highlight/prism-file-highlight.js
+++ b/plugins/file-highlight/prism-file-highlight.js
@@ -71,6 +71,10 @@
 
 	};
 
-	self.Prism.fileHighlight();
+	if (document.addEventListener) {
+		document.addEventListener('DOMContentLoaded', self.Prism.fileHighlight);
+	} else {
+		self.Prism.fileHighlight();
+	}
 
 })();


### PR DESCRIPTION
This allows the File Highlight plugin to work properly even when the script is loaded before the elements that should have a file loaded into them.