### PR TITLE
Simplify the “lang” regex

### DIFF
--- a/components/prism-core.js
+++ b/components/prism-core.js
@@ -15,7 +15,7 @@ var _self = (typeof window !== 'undefined')
 var Prism = (function(){
 
 // Private helper vars
-var lang = /\blang(?:uage)?-(?!\*)(\w+)\b/i;
+var lang = /\blang(?:uage)?-(\w+)\b/i;
 
 var _ = _self.Prism = {
 	util: {


### PR DESCRIPTION
Remove an useless `(?!\*)` part from the `lang` regex.