### PR TITLE
Solarized Light Theme for PrismJS

### DIFF
--- a/themes/prism-solarizedlight
+++ b/themes/prism-solarizedlight
@@ -1,0 +1,128 @@
+/*
+ Solarized Color Schemes originally by Ethan Schoonover
+ http://ethanschoonover.com/solarized
+
+ Ported for PrismJS by Hector Matos
+ Website: https://krakendev.io
+ Twitter Handle: https://twitter.com/allonsykraken)
+*/
+
+code[class*="language-"],
+pre[class*="language-"] {
+	color: #2176c7;
+	font-family: Consolas, Monaco, 'Andale Mono', monospace;
+	direction: ltr;
+	text-align: left;
+	white-space: pre;
+	word-spacing: normal;
+	word-break: normal;
+	word-wrap: normal;
+	
+	line-height: 1.5;
+	
+	-moz-tab-size: 4;
+	-o-tab-size: 4;
+	tab-size: 4;
+	
+	-webkit-hyphens: none;
+	-moz-hyphens: none;
+	-ms-hyphens: none;
+	hyphens: none;
+}
+
+/* Code blocks */
+pre[class*="language-"] {
+	padding: 1em;
+	margin: .5em 0;
+	overflow: auto;
+	border-radius: 0.3em;
+}
+
+:not(pre) > code[class*="language-"],
+pre[class*="language-"] {
+	background: #eee8d5;
+}
+
+/* Inline code */
+:not(pre) > code[class*="language-"] {
+	padding: .1em;
+	border-radius: .3em;
+}
+
+.token.comment,
+.token.prolog,
+.token.doctype,
+.token.cdata {
+	color: #475b62;
+}
+
+.token.punctuation {
+	color: #586e75;
+}
+
+.namespace {
+	opacity: .7;
+}
+
+.token.property,
+.token.tag,
+.token.constant,
+.token.symbol,
+.token.deleted {
+	color: #2176c7;
+}
+
+.token.boolean {
+	color: #2176c7;
+}
+
+.token.number,
+.token.selector,
+.token.attr-name,
+.token.string,
+.token.char,
+.token.builtin,
+.token.inserted {
+	color: #259286;
+}
+
+.token.operator,
+.token.entity,
+.token.url,
+.language-css .token.string,
+.style .token.string,
+.token.variable {
+	color: #5662b5;
+}
+
+.token.keyword,
+.token.atrule,
+.token.attr-value {
+	color: #738a05;
+}
+
+.token.function,
+.token.regex,
+.token.important {
+	color: #708284;
+}
+
+.token.important,
+.token.bold {
+	font-weight: bold;
+}
+.token.italic {
+	font-style: italic;
+}
+
+.token.entity {
+	cursor: help;
+}
+
+::selection {
+	background: #CAD6D9;
+}
+::-moz-selection {
+	background: #CAD6D9;
+}
+


### PR DESCRIPTION
I quite like the solarized themes - they are pretty accessible and a lot of work was done on created something that is easy on the eyes. I ported Solarized Light for PrismJS. It would be pretty cool if the solarized themes were included with PrismJS! However, after some research, I couldn't quite see any attribution rules so I provided a link to the original creator of the solarized formats in a comment at the top of the css file.