### PR TITLE
Fixing to initial copyright year

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT LICENSE
 
-Copyright (c) 2012-2013 Lea Verou
+Copyright (c) 2012 Lea Verou
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
According to http://www.copyright.gov/circs/circ01.pdf , listing the first year of publication in the copyright is enough