### PR TITLE
No background for <code> in <pre>

### DIFF
--- a/themes/prism-coy.css
+++ b/themes/prism-coy.css
@@ -7,6 +7,7 @@
 code[class*="language-"],
 pre[class*="language-"] {
 	color: black;
+	background: none;
 	font-family: Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
 	direction: ltr;
 	text-align: left;
@@ -50,10 +51,6 @@ pre[class*="language-"] {
 	pre[class*="language-"] {
 		max-height: 30em;
 	}
-}
-
-pre[class*="language-"] > code {
-	background: none;
 }
 
 code[class*="language"] {

--- a/themes/prism-coy.css
+++ b/themes/prism-coy.css
@@ -52,6 +52,10 @@ pre[class*="language-"] {
 	}
 }
 
+pre[class*="language-"] > code {
+	background: none;
+}
+
 code[class*="language"] {
 	max-height: inherit;
 	height: 100%;

--- a/themes/prism-dark.css
+++ b/themes/prism-dark.css
@@ -49,6 +49,10 @@ pre[class*="language-"] {
 	box-shadow: 1px 1px .5em black inset;
 }
 
+pre[class*="language-"] > code {
+	background: none;
+}
+
 /* Inline code */
 :not(pre) > code[class*="language-"] {
 	padding: .15em .2em .05em;

--- a/themes/prism-dark.css
+++ b/themes/prism-dark.css
@@ -7,6 +7,7 @@
 code[class*="language-"],
 pre[class*="language-"] {
 	color: white;
+	background: none;
 	text-shadow: 0 -.1em .2em black;
 	font-family: Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
 	direction: ltr;
@@ -47,10 +48,6 @@ pre[class*="language-"] {
 	border: .3em solid hsl(30, 20%, 40%);
 	border-radius: .5em;
 	box-shadow: 1px 1px .5em black inset;
-}
-
-pre[class*="language-"] > code {
-	background: none;
 }
 
 /* Inline code */

--- a/themes/prism-okaidia.css
+++ b/themes/prism-okaidia.css
@@ -7,6 +7,7 @@
 code[class*="language-"],
 pre[class*="language-"] {
 	color: #f8f8f2;
+	background: none;
 	text-shadow: 0 1px rgba(0, 0, 0, 0.3);
 	font-family: Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
 	direction: ltr;
@@ -33,10 +34,6 @@ pre[class*="language-"] {
 	margin: .5em 0;
 	overflow: auto;
 	border-radius: 0.3em;
-}
-
-pre[class*="language-"] > code {
-	background: none;
 }
 
 :not(pre) > code[class*="language-"],

--- a/themes/prism-okaidia.css
+++ b/themes/prism-okaidia.css
@@ -35,6 +35,10 @@ pre[class*="language-"] {
 	border-radius: 0.3em;
 }
 
+pre[class*="language-"] > code {
+	background: none;
+}
+
 :not(pre) > code[class*="language-"],
 pre[class*="language-"] {
 	background: #272822;

--- a/themes/prism-tomorrow.css
+++ b/themes/prism-tomorrow.css
@@ -34,6 +34,10 @@ pre[class*="language-"] {
 	overflow: auto;
 }
 
+pre[class*="language-"] > code {
+	background: none;
+}
+
 :not(pre) > code[class*="language-"],
 pre[class*="language-"] {
 	background: #2d2d2d;

--- a/themes/prism-tomorrow.css
+++ b/themes/prism-tomorrow.css
@@ -7,6 +7,7 @@
 code[class*="language-"],
 pre[class*="language-"] {
 	color: #ccc;
+	background: none;
 	font-family: Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
 	direction: ltr;
 	text-align: left;
@@ -32,10 +33,6 @@ pre[class*="language-"] {
 	padding: 1em;
 	margin: .5em 0;
 	overflow: auto;
-}
-
-pre[class*="language-"] > code {
-	background: none;
 }
 
 :not(pre) > code[class*="language-"],

--- a/themes/prism-twilight.css
+++ b/themes/prism-twilight.css
@@ -6,6 +6,7 @@
 code[class*="language-"],
 pre[class*="language-"] {
 	color: white;
+	background: none;
 	direction: ltr;
 	font-family: Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
 	text-align: left;
@@ -49,10 +50,6 @@ pre[class*="language-"]::selection {
 pre[class*="language-"]::selection {
 	/* Firefox */
 	background: hsl(200, 4%, 16%); /* #282A2B */
-}
-
-pre[class*="language-"] > code {
-	background: none;
 }
 
 /* Text Selection colour */

--- a/themes/prism-twilight.css
+++ b/themes/prism-twilight.css
@@ -51,6 +51,10 @@ pre[class*="language-"]::selection {
 	background: hsl(200, 4%, 16%); /* #282A2B */
 }
 
+pre[class*="language-"] > code {
+	background: none;
+}
+
 /* Text Selection colour */
 pre[class*="language-"]::-moz-selection, pre[class*="language-"] ::-moz-selection,
 code[class*="language-"]::-moz-selection, code[class*="language-"] ::-moz-selection {

--- a/themes/prism.css
+++ b/themes/prism.css
@@ -53,6 +53,10 @@ pre[class*="language-"] {
 	overflow: auto;
 }
 
+pre[class*="language-"] > code {
+	background: none;
+}
+
 :not(pre) > code[class*="language-"],
 pre[class*="language-"] {
 	background: #f5f2f0;

--- a/themes/prism.css
+++ b/themes/prism.css
@@ -7,6 +7,7 @@
 code[class*="language-"],
 pre[class*="language-"] {
 	color: black;
+	background: none;
 	text-shadow: 0 1px white;
 	font-family: Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
 	direction: ltr;
@@ -51,10 +52,6 @@ pre[class*="language-"] {
 	padding: 1em;
 	margin: .5em 0;
 	overflow: auto;
-}
-
-pre[class*="language-"] > code {
-	background: none;
 }
 
 :not(pre) > code[class*="language-"],


### PR DESCRIPTION
Avoid things like:

![screen shot 2016-01-22 at 14 34 39](https://cloud.githubusercontent.com/assets/8536330/12512163/e38b3646-c116-11e5-82fa-ac5b96d3550c.png)

![screen shot 2016-01-22 at 14 40 32](https://cloud.githubusercontent.com/assets/8536330/12512167/e8f58cf8-c116-11e5-9c40-f76699377f37.png)

![screen shot 2016-01-22 at 14 43 20](https://cloud.githubusercontent.com/assets/8536330/12512175/effc569e-c116-11e5-99ea-1ef438bec423.png)

![screen shot 2016-01-22 at 14 44 06](https://cloud.githubusercontent.com/assets/8536330/12512176/f47255c0-c116-11e5-8092-8f0967559e3a.png)

when we have something like

```css
pre, code {
  background-color: #F7FAFB;
}
```

in our CSS before prism

Not needed in funky theme