### PR TITLE
Add prefix for Firefox selection to Twilight theme

### DIFF
--- a/themes/prism-twilight.css
+++ b/themes/prism-twilight.css
@@ -42,13 +42,13 @@ pre[class*="language-"] {
 	padding: 1em;
 }
 
-pre[class*="language-"]::selection {
-	/* Safari */
+pre[class*="language-"]::-moz-selection {
+	/* Firefox */
 	background: hsl(200, 4%, 16%); /* #282A2B */
 }
 
 pre[class*="language-"]::selection {
-	/* Firefox */
+	/* Safari */
 	background: hsl(200, 4%, 16%); /* #282A2B */
 }
 


### PR DESCRIPTION
The two `pre[class*="language-"]::selection ` are basically the same rules
Firefox rule should have a prefix and be moved before the unprefixed rule