### PR TITLE
Fix coy theme shadows

### DIFF
--- a/themes/prism-coy.css
+++ b/themes/prism-coy.css
@@ -47,12 +47,6 @@ pre[class*="language-"] {
 	padding: 0;
 }
 
-@media screen {
-	pre[class*="language-"] {
-		max-height: 30em;
-	}
-}
-
 code[class*="language"] {
 	max-height: inherit;
 	height: 100%;
@@ -96,6 +90,7 @@ pre[class*="language-"]:after {
 	left: 0.18em;
 	width: 40%;
 	height: 20%;
+	max-height: 13em;
 	-webkit-box-shadow: 0px 13px 8px #979797;
 	-moz-box-shadow: 0px 13px 8px #979797;
 	box-shadow: 0px 13px 8px #979797;


### PR DESCRIPTION
This patch removes max-height from the pre tag in the coy theme,
because this height limitation is inconsistent with the other
themes.

The above change causes a bug in the shadows of the coy theme.
Adding max-height: 13em to the ::before and ::after selector fixes
the shadow bug.