### PR TITLE
Ensure show-invisibles compat with autoloader

### DIFF
--- a/plugins/show-invisibles/prism-show-invisibles.js
+++ b/plugins/show-invisibles/prism-show-invisibles.js
@@ -7,13 +7,12 @@ if (
 	return;
 }
 
-for (var language in Prism.languages) {
-	var tokens = Prism.languages[language];
-	
-    tokens.tab = /\t/g;
-    tokens.crlf = /\r\n/g;
-    tokens.lf = /\n/g;
-	tokens.cr = /\r/g;
-}
+Prism.hooks.add('before-highlight', function(env) {
+	var tokens = env.grammar;
 
+	tokens.tab = /\t/g;
+	tokens.crlf = /\r\n/g;
+	tokens.lf = /\n/g;
+	tokens.cr = /\r/g;
+});
 })();


### PR DESCRIPTION
When using the autoloader, the language isn't loaded
at the time the show-invisibles plugin attaches its
extra tokens. This defers attaching the extra tokens
to just before highlighting, so we ensure we're able
to attach to the language grammar.