### PR TITLE
Colorful Solarized Light theme

### DIFF
--- a/components.js
+++ b/components.js
@@ -32,7 +32,7 @@ var components = {
 		},
 		"prism-solarizedlight": {
 			"title": "Solarized Light",
-			"owner": "hectormatos2011 "
+			"owner": "hectormatos2011"
 		}
 	},
 	"languages": {

--- a/themes/prism-solarizedlight.css
+++ b/themes/prism-solarizedlight.css
@@ -88,7 +88,7 @@ pre[class*="language-"] {
 }
 
 .token.punctuation {
-	color: #586e75; /* base01 */
+	color: #dc322f; /* red */
 }
 
 .namespace {
@@ -101,7 +101,8 @@ pre[class*="language-"] {
 .token.number,
 .token.constant,
 .token.symbol,
-.token.deleted {
+.token.deleted,
+.token.variable {
 	color: #268bd2; /* blue */
 }
 
@@ -122,7 +123,8 @@ pre[class*="language-"] {
 
 .token.atrule,
 .token.attr-value,
-.token.keyword {
+.token.keyword,
+.token.operator {
 	color: #859900; /* green */
 }
 
@@ -130,10 +132,12 @@ pre[class*="language-"] {
 	color: #b58900; /* yellow */
 }
 
-.token.regex,
-.token.important,
-.token.variable {
+.token.regex {
 	color: #cb4b16; /* orange */
+}
+
+.token.important {
+	color: #dc322f; /* red */
 }
 
 .token.important,


### PR DESCRIPTION
This patch uses more colors for the Solarized Light theme. All
punctuation is red, operators are green and variables are blue.

The result looks like this:

![solarized-js](https://cloud.githubusercontent.com/assets/1210795/12717128/01cc3c5a-c8e6-11e5-995a-6183b1812a2a.png)
![solarized-html](https://cloud.githubusercontent.com/assets/1210795/12717130/07097ffc-c8e6-11e5-9ed8-c5b41d388dba.png)

