### PR TITLE
Add support for the space character for the show-invisibles plugin

### DIFF
--- a/plugins/show-invisibles/prism-show-invisibles.css
+++ b/plugins/show-invisibles/prism-show-invisibles.css
@@ -1,7 +1,16 @@
+.token.tab:not(:empty),
+.token.cr,
+.token.lf,
+.token.space {
+	position: relative;
+}
+
 .token.tab:not(:empty):before,
 .token.cr:before,
-.token.lf:before {
+.token.lf:before,
+.token.space:before {
 	color: hsl(24, 20%, 85%);
+	position: absolute;
 }
 
 .token.tab:not(:empty):before {
@@ -17,4 +26,8 @@
 }
 .token.lf:before {
     content: '\240A';
+}
+
+.token.space:before {
+	content: '\00B7';
 }

--- a/plugins/show-invisibles/prism-show-invisibles.js
+++ b/plugins/show-invisibles/prism-show-invisibles.js
@@ -14,5 +14,6 @@ Prism.hooks.add('before-highlight', function(env) {
 	tokens.crlf = /\r\n/g;
 	tokens.lf = /\n/g;
 	tokens.cr = /\r/g;
+	tokens.space = / /g;
 });
 })();

--- a/plugins/show-invisibles/prism-show-invisibles.min.js
+++ b/plugins/show-invisibles/prism-show-invisibles.min.js
@@ -1,1 +1,1 @@
-!function(){if(("undefined"==typeof self||self.Prism)&&("undefined"==typeof global||global.Prism))for(var f in Prism.languages){var n=Prism.languages[f];n.tab=/\t/g,n.crlf=/\r\n/g,n.lf=/\n/g,n.cr=/\r/g}}();
+!function(){"undefined"!=typeof self&&!self.Prism||"undefined"!=typeof global&&!global.Prism||Prism.hooks.add("before-highlight",function(e){var f=e.grammar;f.tab=/\t/g,f.crlf=/\r\n/g,f.lf=/\n/g,f.cr=/\r/g,f.space=/ /g})}();


### PR DESCRIPTION
This patch adds a bit of position magic, so that the invisibles
are displayed on top of the original character. This allows for
the inclusion of the space character.

The result looks like this:

![invisibles](https://cloud.githubusercontent.com/assets/1210795/12718490/2fc46cb4-c8ef-11e5-8d87-e7e03fbfe45e.png)
