### PR TITLE
Fix Keep Markup plugin incorrect highlighting

### DIFF
--- a/plugins/keep-markup/prism-keep-markup.js
+++ b/plugins/keep-markup/prism-keep-markup.js
@@ -23,7 +23,7 @@
 				} else if(child.nodeType === 3) { // text
 					if(!firstWhiteSpaces) {
 						// We need to ignore the first white spaces in the code block
-						child.data = child.data.replace(/^(?:\r?\n|\r)/, '');
+						child.data = child.data.replace(/^(?:\r\n|\r)/, '');
 						firstWhiteSpaces = true;
 					}
 					pos += child.data.length;

--- a/plugins/keep-markup/prism-keep-markup.js
+++ b/plugins/keep-markup/prism-keep-markup.js
@@ -5,7 +5,6 @@
 	}
 
 	Prism.hooks.add('before-highlight', function (env) {
-		var firstWhiteSpaces = false;
 		var pos = 0;
 		var data = [];
 		var f = function (elt, baseNode) {
@@ -21,11 +20,6 @@
 				if (child.nodeType === 1) { // element
 					f(child);
 				} else if(child.nodeType === 3) { // text
-					if(!firstWhiteSpaces) {
-						// We need to ignore the first white spaces in the code block
-						child.data = child.data.replace(/^(?:\r\n|\r)/, '');
-						firstWhiteSpaces = true;
-					}
 					pos += child.data.length;
 				}
 			}


### PR DESCRIPTION
Hi!

This change fixes #879, it looks like that the Regex replace is messing the correct positions of the markers in the markup, that's why it looked _moved_ one position:
![screen shot 2016-02-05 at 22 29 42](https://cloud.githubusercontent.com/assets/1002461/12864780/7ad2c25e-cc65-11e5-8f7f-291469854b00.png)

After this fix it looks like this:
![screen shot 2016-02-06 at 00 05 33](https://cloud.githubusercontent.com/assets/1002461/12864783/8c8cd49e-cc65-11e5-985b-a18128cfdb9a.png)

I am not completely sure about this fix because I do not have experience with Prism, probably @Golmote or @LeaVerou can find the real issue.

Thanks!

