### PR TITLE
Corrected instructions in command-line plugin

### DIFF
--- a/plugins/command-line/index.html
+++ b/plugins/command-line/index.html
@@ -28,7 +28,7 @@
 
 	<p>This is intended for code blocks (<code class="language-markup">&lt;pre>&lt;code></code>) and not for inline code.</p>
 
-	<p>Add class <strong>command-line</strong> to your <code class="language-markup">&lt;pre></code>. For a server command line, specify the user and host names using the <code class="language-markup">data-user</code> and <code class="language-markup">data-host</code> attributes. The resulting prompt displays a <strong>#</strong> for the root user and <strong>$</strong> for all other users. For any other command line, such as a Windows prompt, you may specify the entire prompt using the <code class="language-markup">data-prompt</code> attribute.</p>
+	<p>Add class <strong>command-line</strong> to your <code class="language-markup">&lt;code></code> tag. For a server command line, specify the user and host names using the <code class="language-markup">data-user</code> and <code class="language-markup">data-host</code> attributes. The resulting prompt displays a <strong>#</strong> for the root user and <strong>$</strong> for all other users. For any other command line, such as a Windows prompt, you may specify the entire prompt using the <code class="language-markup">data-prompt</code> attribute.</p>
 
 	<p>Optional: You may specify the lines to be presented as output (no prompt) through the <code class="language-markup">data-output</code> attribute on the <code class="language-markup">&lt;pre></code> element in the following simple format:</p>
 	<ul>


### PR DESCRIPTION
It instructes the user to add the `command-line` class to the `<pre>` tag, but it actually needs adding to the `<code>` tag in order to get it to work.

The other tags are fine on the `<pre>` tag.