### PR TITLE
Add before-highlightall hook

### DIFF
--- a/components/prism-core.js
+++ b/components/prism-core.js
@@ -154,10 +154,17 @@ var _ = _self.Prism = {
 	plugins: {},
 	
 	highlightAll: function(async, callback) {
-		var elements = document.querySelectorAll('code[class*="language-"], [class*="language-"] code, code[class*="lang-"], [class*="lang-"] code');
+		var env = {
+			callback: callback,
+			selector: 'code[class*="language-"], [class*="language-"] code, code[class*="lang-"], [class*="lang-"] code'
+		};
+
+		_.hooks.run("before-highlightall", env);
+		
+		var elements = document.querySelectorAll(env.selector);
 
 		for (var i=0, element; element = elements[i++];) {
-			_.highlightElement(element, async === true, callback);
+			_.highlightElement(element, async === true, env.callback);
 		}
 	},
 


### PR DESCRIPTION
Needed for unescaped markup plugin, as discussed in #887.
Alternatively, we could reinstate @zeitgeist87’s PR about making the selector a config option.
Thoughts?