### PR TITLE
Added support for installing the npm package with JSPM

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,5 +27,17 @@
     "gulp-replace": "^0.5.4",
     "mocha": "^2.2.5",
     "yargs": "^3.26.0"
+  },
+  "jspm": {
+    "main": "prism",
+    "registry": "jspm",
+    "jspmPackage": true,
+    "format": "global",
+    "files": [
+      "components/**/*.min.js",
+      "plugins/**/*",
+      "themes/*.css",
+      "prism.js"
+    ]
   }
 }


### PR DESCRIPTION
Small addition to package.json to allow users of JSPM installing the prismjs npm package to experience a smooth install experience.

JSPM installation Instructions:

Installing the prismjs with jspm
```
jspm i npm:prismjs
```
loading prism with systemjs/ jspm:
```
import "prismjs";
```
All required files will be installed, but the theme and/or plugins will not be loaded by default.

To load a theme (requires systemjs plugin-css ```jspm i css```):
```
import "prismjs/themes/prism.css!"
```
or 
```
import "prismjs/themes/prism-dark.css!"
```
Plugins are not loaded by default, but can be loaded by performing:
```
import "prismjs/plugins/show-language/prism-show-language";
import "prismjs/plugins/show-language/prism-show-language.css!";
```
Would love to see the main npm package support JSPM.
Saves me time to keep a scoped npm package up-to-date :-).

Thanks,

Erik

