### PR TITLE
Add missing keywords for SAS.

### DIFF
--- a/components/prism-sas.js
+++ b/components/prism-sas.js
@@ -23,7 +23,7 @@ Prism.languages.sas = {
 		alias: 'number'
 	},
 	'string': /(["'])(?:\1\1|(?!\1)[\s\S])*\1/,
-	'keyword': /\b(?:data|else|format|if|input|proc|run|then)\b/i,
+	'keyword': /\b(?:data|else|format|if|input|proc\s\S+|quit|run|then)\b/i,
 	// Decimal (1.2e23), hexadecimal (0c1x)
 	'number': /(?:\B-|\b)(?:[\da-f]+x|\d+(?:\.\d+)?(?:e[+-]?\d+)?)/i,
 	'operator': /\*\*?|\|\|?|!!?|¦¦?|<[>=]?|>[<=]?|[-+\/=&]|[~¬^]=?|\b(?:eq|ne|gt|lt|ge|le|in|not)\b/i,

--- a/components/prism-sas.js
+++ b/components/prism-sas.js
@@ -23,7 +23,7 @@ Prism.languages.sas = {
 		alias: 'number'
 	},
 	'string': /(["'])(?:\1\1|(?!\1)[\s\S])*\1/,
-	'keyword': /\b(?:data|else|format|if|input|proc\s\S+|quit|run|then)\b/i,
+	'keyword': /\b(?:data|else|format|if|input|proc\s\w+|quit|run|then)\b/i,
 	// Decimal (1.2e23), hexadecimal (0c1x)
 	'number': /(?:\B-|\b)(?:[\da-f]+x|\d+(?:\.\d+)?(?:e[+-]?\d+)?)/i,
 	'operator': /\*\*?|\|\|?|!!?|¦¦?|<[>=]?|>[<=]?|[-+\/=&]|[~¬^]=?|\b(?:eq|ne|gt|lt|ge|le|in|not)\b/i,


### PR DESCRIPTION
Two changes:
(1) PROC keyword now also includes its associated name (e.g., PROC TABULATE, PROC SQL).
(2) QUIT now included, as it is used to close/complete various procedures.