### PR TITLE
Ignore tests directory in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -16,6 +16,7 @@
     "**/.*",
     "img",
     "templates",
+    "tests",
     "CNAME",
     "*.html",
     "style.css",


### PR DESCRIPTION
Hi!

Your  `tests/` is quite large, and contains rather strange files (having [`!` in the name](https://github.com/PrismJS/prism/tree/gh-pages/tests/languages/css!%2Bcss-extras), for example). When consuming this package (`bower install`and off you go) the tests and associated files are not needed, thus they can be ignored in `bower.json`.

This would save a little bandwidth and also prevent issues with the file names.