### PR TITLE
add protobuf support

### DIFF
--- a/components/prism-proto.js
+++ b/components/prism-proto.js
@@ -1,0 +1,8 @@
+Prism.languages.proto = Prism.languages.extend('clike', {
+    keyword: /\b(package|import|message|enum)\b/,
+    builtin: /\b(required|repeated|optional|reserved)\b/,
+    primitive: {
+        pattern: /\b(double|float|int32|int64|uint32|uint64|sint32|sint64|fixed32|fixed64|sfixed32|sfixed64|bool|string|bytes)\b/,
+        alias: 'symbol'
+    }
+});


### PR DESCRIPTION
[Protobuf](https://developers.google.com/protocol-buffers/docs/proto) is a binary format for data transfer.

This is an example how [test file](https://github.com/google/protobuf/blob/master/examples/addressbook.proto) will look:
![image](https://cloud.githubusercontent.com/assets/812240/14788289/ec258214-0b0f-11e6-9bbf-9d4c967bca01.png)