### PR TITLE
HTTPS links to twitter.com and w3.org + Google Analytics to HTTPS

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
 <script src="prefixfree.min.js"></script>
 
 <script>var _gaq = [['_setAccount', 'UA-33746269-1'], ['_trackPageview']];</script>
-<script src="http://www.google-analytics.com/ga.js" async></script>
+<script src="https://www.google-analytics.com/ga.js" async></script>
 </head>
 <body>
 
@@ -145,7 +145,7 @@
 
 	<p>If you want to opt-out of highlighting for a <code>&lt;code></code> element that is a descendant of an element with a declared code language, you can add the class <code>language-none</code> to it (or any non-existing language, really).</p>
 
-	<p>The <a href="http://www.w3.org/TR/html5/grouping-content.html#the-pre-element">recommended way to mark up a code block</a>
+	<p>The <a href="https://www.w3.org/TR/html5/grouping-content.html#the-pre-element">recommended way to mark up a code block</a>
 	(both for semantics and for Prism) is a <code>&lt;pre></code> element with a <code>&lt;code></code> element inside, like so:</p>
 	<pre><code>&lt;pre>&lt;code class="language-css">p { color: red }&lt;/code>&lt;/pre></code></pre>
 	<p>If you use that pattern, the <code>&lt;pre></code> will automatically get the <code>language-xxxx</code> class (if it doesn’t already have it) and will be styled as a code block.</p>
@@ -220,7 +220,7 @@ var html = Prism.highlight(code, Prism.languages.javascript);</code></pre>
 	<h1>Credits</h1>
 	<ul>
 		<li>Special thanks to <a href="https://github.com/Golmote">Golmote</a> and <a href="https://github.com/apfelbox">Jannik Zschiesche</a> for their contributions and for being <strong>amazing maintainers</strong>. Prism would not have been able to keep up without their help.</li>
-		<li>To <a href="http://twitter.com/kizmarh">Roman Komarov</a> for his contributions, feedback and testing.</li>
+		<li>To <a href="https://twitter.com/kizmarh">Roman Komarov</a> for his contributions, feedback and testing.</li>
 		<li>To <a href="https://twitter.com/zdfs">Zachary Forrest</a> for <a href="https://twitter.com/zdfs/statuses/217834980871639041">coming up with the name “Prism”</a></li>
 		<li>To <a href="http://stellarr.deviantart.com/">stellarr</a> for the <a href="http://stellarr.deviantart.com/art/Spectra-Wallpaper-Pack-97785901?q=gallery%3Astellarr%2F185512&qo=2">spectrum background</a> used on this page</li>
 		<li>To <a href="https://twitter.com/thecodezombie">Jason Hobbs</a> for <a href="https://twitter.com/thecodezombie/status/217663703825399809">encouraging me</a> to release this script as standalone</li>


### PR DESCRIPTION
HTTPS links to twitter.com and w3.org (they are HTTPS anyway so it saves redirect)
Updated Google Analytics URL to be HTTPS (recommended by Google)