### PR TITLE
fix hilighting of YAML keys on first line of code block

### DIFF
--- a/components/prism-yaml.js
+++ b/components/prism-yaml.js
@@ -6,7 +6,7 @@ Prism.languages.yaml = {
 	},
 	'comment': /#.*/,
 	'key': {
-		pattern: /(\s*[:\-,[{\r\n?][ \t]*(![^\s]+)?[ \t]*)[^\r\n{[\]},#]+?(?=\s*:\s)/,
+		pattern: /(\s*(?:^|[:\-,[{\r\n?])[ \t]*(![^\s]+)?[ \t]*)[^\r\n{[\]},#]+?(?=\s*:\s)/,
 		lookbehind: true,
 		alias: 'atrule'
 	},


### PR DESCRIPTION
The YAML highlighter would fail to highlight a key if it occurred on
the first line of a `<code>` block, as in:

    <pre><code>somekey: somevalue
    anotherkey: anothervalue</pre></code>

This adds "beginning of file" as an acceptable marker for the start of
a key.

Resolves #942 and, it turns out, #649.