### PR TITLE
Auto provide language if undefined in highlight function

### DIFF
--- a/components/prism-core.js
+++ b/components/prism-core.js
@@ -245,6 +245,16 @@ var _ = _self.Prism = {
 	},
 
 	highlight: function (text, grammar, language) {
+
+		// find language name by grammar if undefined
+		if (typeof language === 'undefined') {
+			for (var key in _.languages) {
+				if (grammar.__id === _.languages[key].__id) {
+					language = key;
+				}
+			}
+		}
+
 		var tokens = _.tokenize(text, grammar);
 		return Token.stringify(_.util.encode(tokens), language);
 	},


### PR DESCRIPTION
As discussed in #947, I suggest a solution to provide the `language` parameter if it is undefined (mostly because we call it directly, as listed in API documentation).

This `language` parameter should be provided in order to be passed to `Token.stringify` below and available in hooks.