### PR TITLE
Highlight diff lines with only + or -

### DIFF
--- a/components/prism-diff.js
+++ b/components/prism-diff.js
@@ -9,8 +9,8 @@ Prism.languages.diff = {
 	],
 
 	// Match inserted and deleted lines. Support both +/- and >/< styles.
-	'deleted': /^[-<].+$/m,
-	'inserted': /^[+>].+$/m,
+	'deleted': /^[-<].*$/m,
+	'inserted': /^[+>].*$/m,
 
 	// Match "different" lines (prefixed with "!") in context diff.
 	'diff': {


### PR DESCRIPTION
Diff can contain lines with only a `+` or a `-`, indicating empty lines were deleted. This updates the 2 regexes to also highlight such lines.