### PR TITLE
Puppet highlighter: Fix over-greedy regexp detection

### DIFF
--- a/components/prism-puppet.js
+++ b/components/prism-puppet.js
@@ -41,7 +41,7 @@
 		},
 		'regex': {
 			// Must be prefixed with the keyword "node" or a non-word char
-			pattern: /((?:\bnode\s+|[^\s\w\\]\s*))\/(?:[^\/\\]|\\[\s\S])+\/(?:[imx]+\b|\B)/,
+			pattern: /((?:\bnode\s+|[~=\(\[\{,]\s*|[=+]>\s*|^\s*))\/(?:[^\/\\]|\\[\s\S])+\/(?:[imx]+\b|\B)/,
 			lookbehind: true,
 			inside: {
 				// Extended regexes must have the x flag. They can contain single-line comments.


### PR DESCRIPTION
The `regex` token was allowing /regexps/ to start after the word `node` or after
any non-word character. This ends up being too greedy! For example, take this
common code, using variable interpolation in a string that represents a file
path:

	file { "${master_config_dir}/.ssh":
	  ensure => file,
	  owner  => 'jenkins',
	  group  => 'jenkins',
	  mode   => '0600',
	}

The highlighter will start a regexp at `/.ssh`, in the middle of the string, and
continue for however many lines it takes to reach another slash.

So instead, let's be more conservative about where we might find a regexp. I
suggest:

- After `node`.
- After one of the following characters: `~=([{,`
	- This catches usage in variable assignment, the `=~`/`!~` operators,
	  function calls, case statement and selector blocks, arrays, and data type
	  objects that accept parameters (`Pattern[/.../]`, etc.).
- After `=>` (and the lesser-used `+>`) for hashes and resource attributes.
- At the start of a line, for, e.g., the LHS of the `in` operator. (I'm not 100%
  sure we should cover this case for a simple highlighter like Prism, and it's
  the one I'd most expect to cause problems later, but... I think it's ok...)

This commit appears to fix the worst of the mid-string blowouts.