### PR TITLE
Remove unneeded prefixed CSS

### DIFF
--- a/plugins/line-highlight/prism-line-highlight.css
+++ b/plugins/line-highlight/prism-line-highlight.css
@@ -11,9 +11,6 @@ pre[data-line] {
 	margin-top: 1em; /* Same as .prism’s padding-top */
 
 	background: hsla(24, 20%, 50%,.08);
-	background: -moz-linear-gradient(to right, hsla(24, 20%, 50%,.1) 70%, hsla(24, 20%, 50%,0));
-	background: -webkit-linear-gradient(to right, hsla(24, 20%, 50%,.1) 70%, hsla(24, 20%, 50%,0));
-	background: -o-linear-gradient(to right, hsla(24, 20%, 50%,.1) 70%, hsla(24, 20%, 50%,0));
 	background: linear-gradient(to right, hsla(24, 20%, 50%,.1) 70%, hsla(24, 20%, 50%,0));
 
 	pointer-events: none;

--- a/plugins/previewer-angle/prism-previewer-angle.css
+++ b/plugins/previewer-angle/prism-previewer-angle.css
@@ -1,6 +1,4 @@
 .prism-previewer-angle:before {
-	-webkit-border-radius: 50%;
-	-moz-border-radius: 50%;
 	border-radius: 50%;
 	background: #fff;
 }

--- a/plugins/previewer-base/prism-previewer-base.css
+++ b/plugins/previewer-base/prism-previewer-base.css
@@ -14,13 +14,8 @@
 	height: 32px;
 	margin-left: -16px;
 
-	-ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=$opacity)";
-	filter: alpha(opacity=0);
-	-khtml-opacity: 0;
-	-moz-opacity: 0;
 	opacity: 0;
 	-webkit-transition: opacity .25s;
-	-moz-transition: opacity .25s;
 	-o-transition: opacity .25s;
 	transition: opacity .25s;
 }
@@ -39,14 +34,8 @@
 	right: -5px;
 	left: -5px;
 	bottom: -5px;
-	-webkit-border-radius: 10px;
-	-moz-border-radius: 10px;
 	border-radius: 10px;
 	border: 5px solid #fff;
-	-webkit-box-shadow: 0 0 3px rgba(0, 0, 0, 0.5) inset, 0 0 10px rgba(0, 0, 0, 0.75);
-	-moz-box-shadow: 0 0 3px rgba(0, 0, 0, 0.5) inset, 0 0 10px rgba(0, 0, 0, 0.75);
-	-ms-box-shadow: 0 0 3px rgba(0, 0, 0, 0.5) inset, 0 0 10px rgba(0, 0, 0, 0.75);
-	-o-box-shadow: 0 0 3px rgba(0, 0, 0, 0.5) inset, 0 0 10px rgba(0, 0, 0, 0.75);
 	box-shadow: 0 0 3px rgba(0, 0, 0, 0.5) inset, 0 0 10px rgba(0, 0, 0, 0.75);
 }
 
@@ -68,9 +57,5 @@
 	border-bottom-color: #fff;
 }
 .prism-previewer.active {
-	-ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=$opacity)";
-	filter: alpha(opacity=1);
-	-khtml-opacity: 1;
-	-moz-opacity: 1;
 	opacity: 1;
 }

--- a/plugins/previewer-gradient/prism-previewer-gradient.css
+++ b/plugins/previewer-gradient/prism-previewer-gradient.css
@@ -15,13 +15,7 @@
 	left: -5px;
 	right: -5px;
 	bottom: -5px;
-	-webkit-border-radius: 10px;
-	-moz-border-radius: 10px;
 	border-radius: 10px;
 	border: 5px solid #fff;
-	-webkit-box-shadow: 0 0 3px rgba(0, 0, 0, 0.5) inset, 0 0 10px rgba(0, 0, 0, 0.75);
-	-moz-box-shadow: 0 0 3px rgba(0, 0, 0, 0.5) inset, 0 0 10px rgba(0, 0, 0, 0.75);
-	-ms-box-shadow: 0 0 3px rgba(0, 0, 0, 0.5) inset, 0 0 10px rgba(0, 0, 0, 0.75);
-	-o-box-shadow: 0 0 3px rgba(0, 0, 0, 0.5) inset, 0 0 10px rgba(0, 0, 0, 0.75);
 	box-shadow: 0 0 3px rgba(0, 0, 0, 0.5) inset, 0 0 10px rgba(0, 0, 0, 0.75);
 }

--- a/plugins/previewer-time/prism-previewer-time.css
+++ b/plugins/previewer-time/prism-previewer-time.css
@@ -59,8 +59,6 @@
 }
 
 .prism-previewer-time:before {
-	-webkit-border-radius: 50%;
-	-moz-border-radius: 50%;
 	border-radius: 50%;
 	background: #fff;
 }

--- a/plugins/show-language/prism-show-language.css
+++ b/plugins/show-language/prism-show-language.css
@@ -18,8 +18,6 @@ div.prism-show-language > div.prism-show-language-label {
 	padding: 0 0.5em;
 	text-shadow: none;
 	z-index: 1;
-	-webkit-box-shadow: none;
-	-moz-box-shadow: none;
 	box-shadow: none;
 	-webkit-transform: none;
 	-moz-transform: none;

--- a/themes/prism-coy.css
+++ b/themes/prism-coy.css
@@ -30,15 +30,9 @@ pre[class*="language-"] {
 pre[class*="language-"] {
 	position: relative;
 	margin: .5em 0;
-	-webkit-box-shadow: -1px 0px 0px 0px #358ccb, 0px 0px 0px 1px #dfdfdf;
-	-moz-box-shadow: -1px 0px 0px 0px #358ccb, 0px 0px 0px 1px #dfdfdf;
 	box-shadow: -1px 0px 0px 0px #358ccb, 0px 0px 0px 1px #dfdfdf;
 	border-left: 10px solid #358ccb;
 	background-color: #fdfdfd;
-	background-image: -webkit-linear-gradient(transparent 50%, rgba(69, 142, 209, 0.04) 50%);
-	background-image: -moz-linear-gradient(transparent 50%, rgba(69, 142, 209, 0.04) 50%);
-	background-image: -ms-linear-gradient(transparent 50%, rgba(69, 142, 209, 0.04) 50%);
-	background-image: -o-linear-gradient(transparent 50%, rgba(69, 142, 209, 0.04) 50%);
 	background-image: linear-gradient(transparent 50%, rgba(69, 142, 209, 0.04) 50%);
 	background-size: 3em 3em;
 	background-origin: content-box;
@@ -68,10 +62,6 @@ pre[class*="language-"] {
 :not(pre) > code[class*="language-"] {
 	position: relative;
 	padding: .2em;
-	-webkit-border-radius: 0.3em;
-	-moz-border-radius: 0.3em;
-	-ms-border-radius: 0.3em;
-	-o-border-radius: 0.3em;
 	border-radius: 0.3em;
 	color: #c92c2c;
 	border: 1px solid rgba(0, 0, 0, 0.1);
@@ -90,8 +80,6 @@ pre[class*="language-"]:after {
 	width: 40%;
 	height: 20%;
 	max-height: 13em;
-	-webkit-box-shadow: 0px 13px 8px #979797;
-	-moz-box-shadow: 0px 13px 8px #979797;
 	box-shadow: 0px 13px 8px #979797;
 	-webkit-transform: rotate(-2deg);
 	-moz-transform: rotate(-2deg);
@@ -193,8 +181,6 @@ pre[class*="language-"]:after {
 	pre[class*="language-"]:before,
 	pre[class*="language-"]:after {
 		bottom: 14px;
-		-webkit-box-shadow: none;
-		-moz-box-shadow: none;
 		box-shadow: none;
 	}
 

--- a/themes/prism-twilight.css
+++ b/themes/prism-twilight.css
@@ -158,9 +158,6 @@ pre[data-line] {
 }
 
 .line-highlight {
-	background: -moz-linear-gradient(to right, hsla(0, 0%, 33%, .1) 70%, hsla(0, 0%, 33%, 0)); /* #545454 */
-	background: -o-linear-gradient(to right, hsla(0, 0%, 33%, .1) 70%, hsla(0, 0%, 33%, 0)); /* #545454 */
-	background: -webkit-linear-gradient(to right, hsla(0, 0%, 33%, .1) 70%, hsla(0, 0%, 33%, 0)); /* #545454 */
 	background: hsla(0, 0%, 33%, 0.25); /* #545454 */
 	background: linear-gradient(to right, hsla(0, 0%, 33%, .1) 70%, hsla(0, 0%, 33%, 0)); /* #545454 */
 	border-bottom: 1px dashed hsl(0, 0%, 33%); /* #545454 */


### PR DESCRIPTION
This PR removes
– prefixed `linear-gradient`
– prefixed `box-shadow`
– prefixed `border-radius`
– prefixed `opacity` + legacy IE alternatives
– `-moz-transition` ([browser support](http://caniuse.com/css-transitions))
from CSS files.