### PR TITLE
Plugins fixes (unescaped-markup, line-numbers)

### DIFF
--- a/plugins/line-numbers/index.html
+++ b/plugins/line-numbers/index.html
@@ -44,6 +44,14 @@
   <p>Please note the <code>data-start="-5"</code> in the code below.</p>
   <pre class="line-numbers" data-src="plugins/line-numbers/index.html" data-start="-5"></pre>
 
+	<h2>Inline HTML unescaped</h2>
+  <p>Please note the <code>data-start="10"</code> in the code below.</p>
+  <script class="language-markup language-html line-numbers other-class" type="text/plain" data-start="10">
+		<h2>HTML</h2>
+		<p>Please note the <code>data-start="-5"</code> in the code below.</p>
+		<pre class="line-numbers" data-src="plugins/line-numbers/index.html" data-start="-5"></pre>
+	</script>
+
   <h2>Unknown languages</h2>
   <pre class="language-none line-numbers"><code>This raw text
 is not highlighted
@@ -55,6 +63,8 @@ lines numbers</code></pre>
 
 <script src="prism.js"></script>
 <script src="plugins/line-numbers/prism-line-numbers.js"></script>
+<script src="plugins/normalize-whitespace/prism-normalize-whitespace.js"></script>
+<script src="plugins/unescaped-markup/prism-unescaped-markup.js"></script>
 <script src="utopia.js"></script>
 <script src="components.js"></script>
 <script src="code.js"></script>

--- a/plugins/line-numbers/prism-line-numbers.js
+++ b/plugins/line-numbers/prism-line-numbers.js
@@ -27,7 +27,7 @@ Prism.hooks.add('complete', function (env) {
 
 	if (clsReg.test(env.element.className)) {
 		// Remove the class "line-numbers" from the <code>
-		env.element.className = env.element.className.replace(clsReg, '');
+		env.element.className = env.element.className.replace(clsReg, ' ');
 	}
 	if (!clsReg.test(pre.className)) {
 		// Add the class "line-numbers" to the <pre>

--- a/plugins/unescaped-markup/prism-unescaped-markup.js
+++ b/plugins/unescaped-markup/prism-unescaped-markup.js
@@ -22,6 +22,14 @@
 
 			pre.className = code.className = env.element.className;
 
+			if (env.element.dataset) {
+				Object.keys(env.element.dataset).forEach(function (key) {
+					if (Object.prototype.hasOwnProperty.call(env.element.dataset, key)) {
+						pre.dataset[key] = env.element.dataset[key];
+					}
+				});
+			}
+
 			env.code = env.code.replace(/&lt;\/script(>|&gt;)/gi, "</scri" + "pt>");
 			code.textContent = env.code;
 


### PR DESCRIPTION
Store data attributes in unescaped-markup plugin. For example data-start for line-numbers plugin.
Fix removing line-numbers class form code. It removed space between other classes in code.
