### PR TITLE
Add yarn.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ hide-*.js
 node_modules
 .idea/
 .DS_Store
+yarn.lock


### PR DESCRIPTION
Many people will start using [yarn](https://github.com/yarnpkg/yarn) to install Node packages, let's make sure the lock file doesn't commited accidentally