### PR TITLE
Add `es6` alias for `javascript` language.

### DIFF
--- a/components/prism-javascript.js
+++ b/components/prism-javascript.js
@@ -46,3 +46,4 @@ if (Prism.languages.markup) {
 }
 
 Prism.languages.js = Prism.languages.javascript;
+Prism.languages.es6 = Prism.languages.javascript;


### PR DESCRIPTION
I'm currently working on a PR @ https://github.com/Automattic/wp-calypso/pull/10359 which implements Prism for the DevDocs of the [Calypso](https://github.com/Automattic/wp-calypso) project.

One issue that I've noticed is that ` ```es6` is not processed by Prism.
I may be wrong here as I am fairly new to Prism but since `es6` support is already quite good in `prism-javascript.js` it seems to make sense to just add an alias.

Alternatively we could replace all instances of ` ```es6` with ` ```js` but I feel that this may cause some issues with syntax highlighting on GitHub.com.
Another alternative might be to set the alias ourselves, but I feel other projects might benefit from having the alias set up upstream.

TIA :)
