### PR TITLE
.npmignore: Unignore components.js

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -14,4 +14,3 @@ download.js
 prefixfree.min.js
 utopia.js
 code.js
-components.js


### PR DESCRIPTION
For the trick suggested by @apfelbox in https://github.com/PrismJS/prism/issues/593#issuecomment-219856317 to work, we need both of these files to be in the NPM package:

* /components.js
* /tests/helper/components.js