### PR TITLE
Update prism-apl.js

### DIFF
--- a/components/prism-apl.js
+++ b/components/prism-apl.js
@@ -17,7 +17,7 @@ Prism.languages.apl = {
 		alias: 'operator'
 	},
 	'dyadic-operator': {
-		pattern: /[.⍣⍠⍤∘⌸]/,
+		pattern: /[.⍣⍠⍤∘⌸@⌺]/,
 		alias: 'operator'
 	},
 	'assignment': {


### PR DESCRIPTION
Add @ (At) and ⌺ (Stencil), two new dyadic operators coming in Dyalog APL version 16.0.