### PR TITLE
Allows uppercase prefixes in JS number literals

### DIFF
--- a/components/prism-javascript.js
+++ b/components/prism-javascript.js
@@ -1,6 +1,6 @@
 Prism.languages.javascript = Prism.languages.extend('clike', {
 	'keyword': /\b(as|async|await|break|case|catch|class|const|continue|debugger|default|delete|do|else|enum|export|extends|finally|for|from|function|get|if|implements|import|in|instanceof|interface|let|new|null|of|package|private|protected|public|return|set|static|super|switch|this|throw|try|typeof|var|void|while|with|yield)\b/,
-	'number': /\b-?(0x[\dA-Fa-f]+|0b[01]+|0o[0-7]+|\d*\.?\d+([Ee][+-]?\d+)?|NaN|Infinity)\b/,
+	'number': /\b-?(0[xX][\dA-Fa-f]+|0[bB][01]+|0[oO][0-7]+|\d*\.?\d+([Ee][+-]?\d+)?|NaN|Infinity)\b/,
 	// Allow for all non-ASCII characters (See http://stackoverflow.com/a/2008444)
 	'function': /[_$a-zA-Z\xA0-\uFFFF][_$a-zA-Z0-9\xA0-\uFFFF]*(?=\()/i,
 	'operator': /-[-=]?|\+[+=]?|!=?=?|<<?=?|>>?>?=?|=(?:==?|>)?|&[&=]?|\|[|=]?|\*\*?=?|\/=?|~|\^=?|%=?|\?|\.{3}/


### PR DESCRIPTION
JavaScript allows both lowercase and uppercase prefixes in number literals:

```js
const hex1 = 0x2A;      // 42
const hex2 = 0X2A;      // 42

const bin1 = 0b101010;  // 42
const bin2 = 0B101010;  // 42

const oct1 = 0o52;      // 42
const oct2 = 0O52;      // 42
```

This PR introduces support for `0X`, `0B`, and `0O`.