### PR TITLE
Scroll 'Coy' background with contents

### DIFF
--- a/themes/prism-coy.css
+++ b/themes/prism-coy.css
@@ -30,15 +30,18 @@ pre[class*="language-"] {
 pre[class*="language-"] {
 	position: relative;
 	margin: .5em 0;
-	box-shadow: -1px 0px 0px 0px #358ccb, 0px 0px 0px 1px #dfdfdf;
+	overflow: visible;
+	padding: 0;
+}
+pre[class*="language-"]>code {
+	position: relative;
 	border-left: 10px solid #358ccb;
+	box-shadow: -1px 0px 0px 0px #358ccb, 0px 0px 0px 1px #dfdfdf;
 	background-color: #fdfdfd;
 	background-image: linear-gradient(transparent 50%, rgba(69, 142, 209, 0.04) 50%);
 	background-size: 3em 3em;
 	background-origin: content-box;
 	background-attachment: local;
-	overflow: auto;
-	padding: 0;
 }
 
 code[class*="language"] {
@@ -46,7 +49,7 @@ code[class*="language"] {
 	height: 100%;
 	padding: 0 1em;
 	display: block;
-	overflow: visible;
+	overflow: auto;
 }
 
 /* Margin bottom to accomodate shadow */

--- a/themes/prism-coy.css
+++ b/themes/prism-coy.css
@@ -36,7 +36,8 @@ pre[class*="language-"] {
 	background-image: linear-gradient(transparent 50%, rgba(69, 142, 209, 0.04) 50%);
 	background-size: 3em 3em;
 	background-origin: content-box;
-	overflow: visible;
+	background-attachment: local;
+	overflow: auto;
 	padding: 0;
 }
 
@@ -45,7 +46,7 @@ code[class*="language"] {
 	height: 100%;
 	padding: 0 1em;
 	display: block;
-	overflow: auto;
+	overflow: visible;
 }
 
 /* Margin bottom to accomodate shadow */


### PR DESCRIPTION
Fix on <code>themes/prism-coy.css</code>: attaches &lt;pre&gt; background (alternating line colors) to &lt;code&gt; contents when in limited-height &lt;pre&gt; that requires scrolling.

Example: http://prismjs.com/ with 'Coy' theme selected; most evident on smallest scroll, such as the SVG logo highlight.