### PR TITLE
Omit unnecessary space before language class

### DIFF
--- a/components/prism-core.js
+++ b/components/prism-core.js
@@ -183,13 +183,13 @@ var _ = _self.Prism = {
 		}
 
 		// Set language on the element, if not present
-		element.className = element.className.replace(lang, '').replace(/\s+/g, ' ') + ' language-' + language;
+		element.className = element.className.replace(lang, '').replace(/\s+/g, ' ').replace(/\S$/g, '$& ') + 'language-' + language;
 
 		// Set language on the parent, for styling
 		parent = element.parentNode;
 
 		if (/pre/i.test(parent.nodeName)) {
-			parent.className = parent.className.replace(lang, '').replace(/\s+/g, ' ') + ' language-' + language;
+			parent.className = parent.className.replace(lang, '').replace(/\s+/g, ' ').replace(/\S$/g, '$& ') + 'language-' + language;
 		}
 
 		var code = element.textContent;

--- a/prism.js
+++ b/prism.js
@@ -188,13 +188,13 @@ var _ = _self.Prism = {
 		}
 
 		// Set language on the element, if not present
-		element.className = element.className.replace(lang, '').replace(/\s+/g, ' ') + ' language-' + language;
+		element.className = element.className.replace(lang, '').replace(/\s+/g, ' ').replace(/\S$/g, '$& ') + 'language-' + language;
 
 		// Set language on the parent, for styling
 		parent = element.parentNode;
 
 		if (/pre/i.test(parent.nodeName)) {
-			parent.className = parent.className.replace(lang, '').replace(/\s+/g, ' ') + ' language-' + language;
+			parent.className = parent.className.replace(lang, '').replace(/\s+/g, ' ').replace(/\S$/g, '$& ') + 'language-' + language;
 		}
 
 		var code = element.textContent;


### PR DESCRIPTION
Suddenly I have mentioned that after applying Prism to `pre` element with only one language class in producing `pre` and `code` elements class attributes contain unnecessary space:
```html
<pre class=" language-javascript"><code class=" language-javascript">
...
</code></pre>
```
which simple could be fixed by applying additional replace pattern (as it already made for contiguous spaces).