### PR TITLE
fixed an rendering issue for encoded urls

### DIFF
--- a/plugins/autolinker/prism-autolinker.js
+++ b/plugins/autolinker/prism-autolinker.js
@@ -71,6 +71,7 @@ Prism.hooks.add('wrap', function(env) {
 		
 		env.attributes.href = href;
 	}
+	env.content = decodeURIComponent(env.content);
 });
 
 })();


### PR DESCRIPTION
If a url contains some special characters, like space or "<", it needs to be encoded in order to be recognized as a valid url. Adding a decoding step allows these urls to render correctly.

For example, a url
```
http://example.com?q=a AND b
```
will be rendered by autolinker as a wrong url which breaks before the first space.

we can use this encoded one to get around it

```
http://example.com?q=a%20AND%20b
```

The rendered url works, but does not decode the special characters.

This simple one line should fix this issue.
