### PR TITLE
Update the list of keywords for dockerfiles

### DIFF
--- a/components/prism-docker.js
+++ b/components/prism-docker.js
@@ -1,6 +1,6 @@
 Prism.languages.docker = {
 	'keyword': {
-		pattern: /(^\s*)(?:ONBUILD|FROM|MAINTAINER|RUN|EXPOSE|ENV|ADD|COPY|VOLUME|USER|WORKDIR|CMD|LABEL|ENTRYPOINT)(?=\s)/mi,
+		pattern: /(^\s*)(?:ADD|ARG|CMD|COPY|ENTRYPOINT|ENV|EXPOSE|FROM|HEALTHCHECK|LABEL|MAINTAINER|ONBUILD|RUN|SHELL|STOPSIGNAL|USER|VOLUME|WORKDIR)(?=\s)/mi,
 		lookbehind: true
 	},
 	'string': /("|')(?:(?!\1)[^\\\r\n]|\\(?:\r\n|[\s\S]))*?\1/,


### PR DESCRIPTION
This PR just adds a few missing keywords for [Dockerfiles](https://docs.docker.com/engine/reference/builder/) and reorders them to be in alphabetical order for easier future diffs.