### PR TITLE
Fixes to compatibility of line number and line higlight plugins

### DIFF
--- a/plugins/line-highlight/prism-line-highlight.css
+++ b/plugins/line-highlight/prism-line-highlight.css
@@ -42,3 +42,8 @@ pre[data-line] {
 		top: auto;
 		bottom: .4em;
 	}
+
+.line-numbers .line-highlight:before,
+.line-numbers .line-highlight:after {
+	content: none;
+}

--- a/plugins/line-highlight/prism-line-highlight.js
+++ b/plugins/line-highlight/prism-line-highlight.js
@@ -36,11 +36,14 @@ var isLineHeightRounded = (function() {
 }());
 
 function highlightLines(pre, lines, classes) {
+	lines = lines || pre.getAttribute('data-line');
+	
 	var ranges = lines.replace(/\s+/g, '').split(','),
 	    offset = +pre.getAttribute('data-line-offset') || 0;
 
 	var parseMethod = isLineHeightRounded() ? parseInt : parseFloat;
 	var lineHeight = parseMethod(getComputedStyle(pre).lineHeight);
+	var hasLineNumbers = hasClass(pre, 'line-numbers');
 
 	for (var i=0, range; range = ranges[i++];) {
 		range = range.split('-');
@@ -48,25 +51,36 @@ function highlightLines(pre, lines, classes) {
 		var start = +range[0],
 		    end = +range[1] || start;
 
-		var line = document.createElement('div');
+		var line = pre.querySelector('.line-highlight') || document.createElement('div');
 
 		line.textContent = Array(end - start + 2).join(' \n');
 		line.setAttribute('aria-hidden', 'true');
 		line.className = (classes || '') + ' line-highlight';
 
 		//if the line-numbers plugin is enabled, then there is no reason for this plugin to display the line numbers
-		if(!hasClass(pre, 'line-numbers')) {
+		if(hasLineNumbers && Prism.plugins.lineNumbers) {
+			var startNode = Prism.plugins.lineNumbers.getLine(pre, start);
+			var endNode = Prism.plugins.lineNumbers.getLine(pre, end);
+			
+			if (startNode) {
+				line.style.top = startNode.offsetTop + 'px';
+			}
+			
+			if (endNode) {
+				line.style.height = (endNode.offsetTop - startNode.offsetTop) + endNode.offsetHeight + 'px';
+			}
+		} else {
 			line.setAttribute('data-start', start);
 
 			if(end > start) {
 				line.setAttribute('data-end', end);
 			}
+			
+			line.style.top = (start - offset - 1) * lineHeight + 'px';
 		}
 
-		line.style.top = (start - offset - 1) * lineHeight + 'px';
-
 		//allow this to play nicely with the line-numbers plugin
-		if(hasClass(pre, 'line-numbers')) {
+		if(hasLineNumbers) {
 			//need to attack to pre as when line-numbers is enabled, the code tag is relatively which screws up the positioning
 			pre.appendChild(line);
 		} else {
@@ -148,5 +162,8 @@ Prism.hooks.add('complete', function(env) {
 });
 
 	window.addEventListener('hashchange', applyHash);
+	window.addEventListener('resize', function () {
+		Array.prototype.forEach.call(document.querySelectorAll('pre[data-line]'), highlightLines);
+	});
 
 })();

--- a/plugins/line-highlight/prism-line-highlight.js
+++ b/plugins/line-highlight/prism-line-highlight.js
@@ -36,7 +36,7 @@ var isLineHeightRounded = (function() {
 }());
 
 function highlightLines(pre, lines, classes) {
-	lines = lines || pre.getAttribute('data-line');
+	lines = typeof lines === 'string' ? lines : pre.getAttribute('data-line');
 	
 	var ranges = lines.replace(/\s+/g, '').split(','),
 	    offset = +pre.getAttribute('data-line-offset') || 0;

--- a/plugins/line-numbers/prism-line-numbers.js
+++ b/plugins/line-numbers/prism-line-numbers.js
@@ -109,13 +109,37 @@
 		lineNumbersWrapper.className = 'line-numbers-rows';
 		lineNumbersWrapper.innerHTML = lines;
 
-		if (pre.hasAttribute('data-start')) {
-			pre.style.counterReset = 'linenumber ' + (parseInt(pre.getAttribute('data-start'), 10) - 1);
+		if (pre.hasAttribute('data-line-numbers-start')) {
+			pre.style.counterReset = 'linenumber ' + (parseInt(pre.getAttribute('data-line-numbers-start'), 10) - 1);
 		}
 
 		env.element.appendChild(lineNumbersWrapper);
 
 		_resizeElement(pre);
 	});
+	
+	/**
+	 * Global exports
+	 */
+	Prism.plugins.lineNumbers = {
+		/**
+		 * Get node for provided line number
+		 * @param {Element} element pre element
+		 * @param {Number} number line number
+		 * @return {Element|undefined}
+		 */
+		getLine: function (element, number) {
+			if (element.tagName !== 'PRE' || !element.classList.contains(PLUGIN_CLASS)) {
+				return;
+			}
+			
+			var lineNumberStart = element.getAttribute('data-line-numbers-start') || 0;
+			var lineNumberRows = element.querySelector('.line-numbers-rows');
+			
+			number = Math.abs(lineNumberStart) + number;
+			
+			return lineNumberRows.children[number];
+		}
+	};
 
 }());

--- a/plugins/line-numbers/prism-line-numbers.js
+++ b/plugins/line-numbers/prism-line-numbers.js
@@ -22,14 +22,13 @@
 	 */
 	var _resizeElement = function (element) {
 		var codeStyles = getStyles(element);
-		var code = element.querySelector('code');
 		var whiteSpace = codeStyles['white-space'];
 
 		if (whiteSpace === 'pre-wrap' || whiteSpace === 'pre-line') {
 			var codeElement = element.querySelector('code');
 			var lineNumbersWrapper = element.querySelector('.line-numbers-rows');
 			var lineNumberSizer = element.querySelector('.line-numbers-sizer');
-			var codeLines = code.textContent.split(NEW_LINE_EXP);
+			var codeLines = codeElement.textContent.split(NEW_LINE_EXP);
 
 			if (!lineNumberSizer) {
 				lineNumberSizer = document.createElement('span');
@@ -109,8 +108,8 @@
 		lineNumbersWrapper.className = 'line-numbers-rows';
 		lineNumbersWrapper.innerHTML = lines;
 
-		if (pre.hasAttribute('data-line-numbers-start')) {
-			pre.style.counterReset = 'linenumber ' + (parseInt(pre.getAttribute('data-line-numbers-start'), 10) - 1);
+		if (pre.hasAttribute('data-start')) {
+			pre.style.counterReset = 'linenumber ' + (parseInt(pre.getAttribute('data-start'), 10) - 1);
 		}
 
 		env.element.appendChild(lineNumbersWrapper);
@@ -133,7 +132,7 @@
 				return;
 			}
 			
-			var lineNumberStart = element.getAttribute('data-line-numbers-start') || 0;
+			var lineNumberStart = element.getAttribute('data-start') || 0;
 			var lineNumberRows = element.querySelector('.line-numbers-rows');
 			
 			number = Math.abs(lineNumberStart) + number;

--- a/plugins/line-numbers/prism-line-numbers.js
+++ b/plugins/line-numbers/prism-line-numbers.js
@@ -5,10 +5,10 @@
 	}
 
 	/**
-	 * Class name for <pre> which is activating the plugin
+	 * Plugin name which is used as a class name for <pre> which is activating the plugin
 	 * @type {String}
 	 */
-	var PLUGIN_CLASS = 'line-numbers';
+	var PLUGIN_NAME = 'line-numbers';
 	
 	/**
 	 * Regular expression used for determining line breaks
@@ -63,7 +63,7 @@
 	};
 
 	window.addEventListener('resize', function () {
-		Array.prototype.forEach.call(document.querySelectorAll('pre.' + PLUGIN_CLASS), _resizeElement);
+		Array.prototype.forEach.call(document.querySelectorAll('pre.' + PLUGIN_NAME), _resizeElement);
 	});
 
 	Prism.hooks.add('complete', function (env) {
@@ -115,6 +115,13 @@
 		env.element.appendChild(lineNumbersWrapper);
 
 		_resizeElement(pre);
+
+		Prism.hooks.run('line-numbers', env);
+	});
+
+	Prism.hooks.add('line-numbers', function (env) {
+		env.plugins = env.plugins || {};
+		env.plugins.lineNumbers = true;
 	});
 	
 	/**
@@ -128,16 +135,24 @@
 		 * @return {Element|undefined}
 		 */
 		getLine: function (element, number) {
-			if (element.tagName !== 'PRE' || !element.classList.contains(PLUGIN_CLASS)) {
+			if (element.tagName !== 'PRE' || !element.classList.contains(PLUGIN_NAME)) {
 				return;
 			}
-			
-			var lineNumberStart = element.getAttribute('data-start') || 0;
+
 			var lineNumberRows = element.querySelector('.line-numbers-rows');
-			
-			number = Math.abs(lineNumberStart) + number;
-			
-			return lineNumberRows.children[number];
+			var lineNumberStart = parseInt(element.getAttribute('data-start'), 10) || 1;
+			var lineNumberEnd = lineNumberStart + (lineNumberRows.children.length - 1);
+
+			if (number < lineNumberStart) {
+				number = lineNumberStart;
+			}
+			if (number > lineNumberEnd) {
+				number = lineNumberEnd;
+			}
+
+			var lineIndex = number - lineNumberStart;
+
+			return lineNumberRows.children[lineIndex];
 		}
 	};
 

--- a/plugins/line-numbers/prism-line-numbers.js
+++ b/plugins/line-numbers/prism-line-numbers.js
@@ -9,20 +9,27 @@
 	 * @type {String}
 	 */
 	var PLUGIN_CLASS = 'line-numbers';
+	
+	/**
+	 * Regular expression used for determining line breaks
+	 * @type {RegExp}
+	 */
+	var NEW_LINE_EXP = /\n(?!$)/g;
 
 	/**
 	 * Resizes line numbers spans according to height of line of code
-	 * @param  {Element} element <pre> element
+	 * @param {Element} element <pre> element
 	 */
 	var _resizeElement = function (element) {
 		var codeStyles = getStyles(element);
+		var code = element.querySelector('code');
 		var whiteSpace = codeStyles['white-space'];
 
 		if (whiteSpace === 'pre-wrap' || whiteSpace === 'pre-line') {
 			var codeElement = element.querySelector('code');
 			var lineNumbersWrapper = element.querySelector('.line-numbers-rows');
 			var lineNumberSizer = element.querySelector('.line-numbers-sizer');
-			var codeLines = element.textContent.split('\n');
+			var codeLines = code.textContent.split(NEW_LINE_EXP);
 
 			if (!lineNumberSizer) {
 				lineNumberSizer = document.createElement('span');
@@ -76,21 +83,21 @@
 			return;
 		}
 
-		if (env.element.querySelector(".line-numbers-rows")) {
+		if (env.element.querySelector('.line-numbers-rows')) {
 			// Abort if line numbers already exists
 			return;
 		}
 
 		if (clsReg.test(env.element.className)) {
-			// Remove the class "line-numbers" from the <code>
+			// Remove the class 'line-numbers' from the <code>
 			env.element.className = env.element.className.replace(clsReg, ' ');
 		}
 		if (!clsReg.test(pre.className)) {
-			// Add the class "line-numbers" to the <pre>
+			// Add the class 'line-numbers' to the <pre>
 			pre.className += ' line-numbers';
 		}
 
-		var match = env.code.match(/\n(?!$)/g);
+		var match = env.code.match(NEW_LINE_EXP);
 		var linesNum = match ? match.length + 1 : 1;
 		var lineNumbersWrapper;
 


### PR DESCRIPTION
Hello.

First of all, sorry about created compatibility issues with this plugins. But 2 years passed after that PR.. I've just missed this point :) 

In this PR:
* Fixes to line numbers plugin with the different line endings
* Renamed `data-start` attribute to `data-line-numbers-start` - because line highlight plugin is using this attribute as well
* Fixes compatibility between these two plugins

I've decided to not separate bug fix to into its own branch because it is tied up to each other.