### PR TITLE
The 'height' element makes code blocks the height of the browser canvas.

### DIFF
--- a/themes/prism-coy.css
+++ b/themes/prism-coy.css
@@ -46,7 +46,6 @@ pre[class*="language-"]>code {
 
 code[class*="language"] {
 	max-height: inherit;
-	height: 100%;
 	padding: 0 1em;
 	display: block;
 	overflow: auto;


### PR DESCRIPTION
Removing the height element - which does not seem to be in other themes - fixes this issue. See https://github.com/PrismJS/prism/issues/1223 for details and screenshots. Thanks!