### PR TITLE
Update .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -4,13 +4,23 @@
 hide-*.js
 
 CNAME
-img
-templates
+img/
+templates/
+tests/
+*.tgz
 *.html
 style.css
 favicon.png
 logo.svg
+bower.json
+composer.json
+components.js
 download.js
+examples.js
+gulpfile.js
 prefixfree.min.js
 utopia.js
 code.js
+.editorconfig
+.gitattributes
+.travis.yml


### PR DESCRIPTION
Trim the fat on the prism.js npm package.

Ignore:
tests/ - not necessary for production
.tgz - used while testing packages w/ `npm pack`
bower.json - not necessary in a NPM package
composer.json - not necessary in a NPM package
components.js - used internally
examples.js - used internally
gulpfile.js - used for dev only
.editorconfig - used for dev only
.gitattributes - used for dev only
.travis.yml - used for dev only