### PR TITLE
Fix passing of non-enumerable Error properties from the child test runner

### DIFF
--- a/tests/run-child.js
+++ b/tests/run-child.js
@@ -15,7 +15,10 @@ if (argv.language) {
 				}
 				process.send({success: true});
 			} catch (e) {
-				process.send({error: JSON.stringify(e)});
+				process.send({error: JSON.stringify({
+					message: e.message,
+					stack: e.stack
+				})});
 			}
 		}
 	});


### PR DESCRIPTION
Before I got an error like this when I had added tests for a language that hadn't yet been added to `components.js`:

```
     Error: the object {
  "uncaught": true
} was thrown, throw an Error :)
```

After this change it turned into:

```
Uncaught Error: Language 'csp' not found.
```