### PR TITLE
Remove multi-line comments from Ruby edge case failure examples

### DIFF
--- a/examples/prism-ruby.html
+++ b/examples/prism-ruby.html
@@ -41,10 +41,3 @@ end</code></pre>
 
 <h3>Comments that look like interpolation show as ruby code</h3>
 <pre><code>#{my_var}</code></pre>
-
-<h3>Multi-line comments are not supported</h3>
-<pre><code>=begin
-************************
-This is a comment block
-************************
-=end</code></pre>


### PR DESCRIPTION
In #1121 the failing edge case for Ruby multi-line comments was fixed, but the listing for multi-line comments was not removed from the "Known failures" section of the examples/prism-ruby.html documentation file. This patch does so, since it's no longer a known failure.
