### PR TITLE
Add a loadComponents function for easy component loading on NodeJS

### DIFF
--- a/components/index.js
+++ b/components/index.js
@@ -1,0 +1,24 @@
+var components = require('../components.js');
+
+function loadLanguages(arr) {
+	// If no argument is passed, load all components
+	if (!arr) {
+		arr = Object.keys(components.languages).filter(function (lang) {
+			return lang !== 'meta';
+		});
+	}
+
+	if (!Array.isArray(arr)) {
+		arr = [arr];
+	}
+	arr.forEach(function(language) {
+		// Load dependencies first
+		if (components.languages[language] && components.languages[language].require) {
+			loadLanguages(components.languages[language].require);
+		}
+
+		require('./prism-' + language);
+	});
+}
+
+module.exports = loadLanguages;


### PR DESCRIPTION
This PR adds the `loadComponents` function mentionned in #972.

Usage:

```js
var Prism = require('./components/prism-core.js');
var loadComponents = require('./components/index.js');
loadComponents(['c', 'javascript']);
```