### PR TITLE
Use rel="icon" instead of rel="shortcut icon"

### DIFF
--- a/download.html
+++ b/download.html
@@ -3,7 +3,7 @@
 <head>
 
 <meta charset="utf-8" />
-<link rel="shortcut icon" href="favicon.png" />
+<link rel="icon" href="favicon.png" />
 <title>Download ▲ Prism</title>
 <link rel="stylesheet" href="style.css" />
 <link rel="stylesheet" href="themes/prism.css" data-noprefix />

--- a/examples.html
+++ b/examples.html
@@ -3,7 +3,7 @@
 <head>
 
 <meta charset="utf-8" />
-<link rel="shortcut icon" href="favicon.png" />
+<link rel="icon" href="favicon.png" />
 <title>Examples ▲ Prism</title>
 <link rel="stylesheet" href="style.css" />
 <link rel="stylesheet" href="themes/prism.css" data-noprefix />

--- a/extending.html
+++ b/extending.html
@@ -3,7 +3,7 @@
 <head>
 
 <meta charset="utf-8" />
-<link rel="shortcut icon" href="favicon.png" />
+<link rel="icon" href="favicon.png" />
 <title>Extending Prism ▲ Prism</title>
 <link rel="stylesheet" href="style.css" />
 <link rel="stylesheet" href="themes/prism.css" data-noprefix />

--- a/faq.html
+++ b/faq.html
@@ -3,7 +3,7 @@
 <head>
 
 <meta charset="utf-8" />
-<link rel="shortcut icon" href="favicon.png" />
+<link rel="icon" href="favicon.png" />
 <title>FAQ ▲ Prism</title>
 <link rel="stylesheet" href="style.css" />
 <link rel="stylesheet" href="themes/prism.css" data-noprefix />

--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
 	window.console && console.log('foo');
 </script>
 <meta charset="utf-8" />
-<link rel="shortcut icon" href="favicon.png" />
+<link rel="icon" href="favicon.png" />
 <title>Prism</title>
 <link rel="stylesheet" href="style.css" />
 <link rel="stylesheet" href="themes/prism.css" data-noprefix />

--- a/plugins/autolinker/index.html
+++ b/plugins/autolinker/index.html
@@ -3,7 +3,7 @@
 <head>
 
 <meta charset="utf-8" />
-<link rel="shortcut icon" href="favicon.png" />
+<link rel="icon" href="favicon.png" />
 <title>Autolinker ▲ Prism plugins</title>
 <base href="../.." />
 <link rel="stylesheet" href="style.css" />

--- a/plugins/autoloader/index.html
+++ b/plugins/autoloader/index.html
@@ -3,7 +3,7 @@
 <head>
 
 <meta charset="utf-8" />
-<link rel="shortcut icon" href="favicon.png" />
+<link rel="icon" href="favicon.png" />
 <title>Autoloader ▲ Prism plugins</title>
 <base href="../.." />
 <link rel="stylesheet" href="style.css" />

--- a/plugins/command-line/index.html
+++ b/plugins/command-line/index.html
@@ -3,7 +3,7 @@
 <head>
 
 <meta charset="utf-8" />
-<link rel="shortcut icon" href="favicon.png" />
+<link rel="icon" href="favicon.png" />
 <title>Command Line ▲ Prism plugins</title>
 <base href="../.." />
 <link rel="stylesheet" href="style.css" />

--- a/plugins/copy-to-clipboard/index.html
+++ b/plugins/copy-to-clipboard/index.html
@@ -3,7 +3,7 @@
 <head>
 
 	<meta charset="utf-8" />
-	<link rel="shortcut icon" href="favicon.png" />
+	<link rel="icon" href="favicon.png" />
 	<title>Copy to Clipboard ▲ Prism plugins</title>
 	<base href="../.." />
 	<link rel="stylesheet" href="style.css" />

--- a/plugins/custom-class/index.html
+++ b/plugins/custom-class/index.html
@@ -3,7 +3,7 @@
 <head>
 
 <meta charset="utf-8" />
-<link rel="shortcut icon" href="favicon.png" />
+<link rel="icon" href="favicon.png" />
 <title>Custom Class ▲ Prism plugins</title>
 <base href="../.." />
 <link rel="stylesheet" href="style.css" />

--- a/plugins/data-uri-highlight/index.html
+++ b/plugins/data-uri-highlight/index.html
@@ -3,7 +3,7 @@
 <head>
 
 <meta charset="utf-8" />
-<link rel="shortcut icon" href="favicon.png" />
+<link rel="icon" href="favicon.png" />
 <title>Data-URI Highlight ▲ Prism plugins</title>
 <base href="../.." />
 <link rel="stylesheet" href="style.css" />

--- a/plugins/file-highlight/index.html
+++ b/plugins/file-highlight/index.html
@@ -3,7 +3,7 @@
 <head>
 
 <meta charset="utf-8" />
-<link rel="shortcut icon" href="favicon.png" />
+<link rel="icon" href="favicon.png" />
 <title>File Highlight ▲ Prism plugins</title>
 <base href="../.." />
 <link rel="stylesheet" href="style.css" />

--- a/plugins/file-highlight/prism-file-highlight.js
+++ b/plugins/file-highlight/prism-file-highlight.js
@@ -21,7 +21,7 @@
 			var src = pre.getAttribute('data-src');
 
 			var language, parent = pre;
-			var lang = /\blang(?:uage)?-(?!\*)([\w-]+)\b/i;
+			var lang = /\blang(?:uage)?-([\w-]+)\b/i;
 			while (parent && !lang.test(parent.className)) {
 				parent = parent.parentNode;
 			}

--- a/plugins/highlight-keywords/index.html
+++ b/plugins/highlight-keywords/index.html
@@ -3,7 +3,7 @@
 <head>
 
 <meta charset="utf-8" />
-<link rel="shortcut icon" href="favicon.png" />
+<link rel="icon" href="favicon.png" />
 <title>Highlight Keywords ▲ Prism plugins</title>
 <base href="../.." />
 <link rel="stylesheet" href="style.css" />

--- a/plugins/index.html
+++ b/plugins/index.html
@@ -3,7 +3,7 @@
 <head>
 
 <meta charset="utf-8" />
-<link rel="shortcut icon" href="favicon.png" />
+<link rel="icon" href="favicon.png" />
 <title>Plugins ▲ Prism</title>
 <base href=".." />
 <link rel="stylesheet" href="style.css" />

--- a/plugins/jsonp-highlight/index.html
+++ b/plugins/jsonp-highlight/index.html
@@ -3,7 +3,7 @@
 <head>
 
 <meta charset="utf-8" />
-<link rel="shortcut icon" href="favicon.png" />
+<link rel="icon" href="favicon.png" />
 <title>JSONP Highlight ▲ Prism plugins</title>
 <base href="../.." />
 <link rel="stylesheet" href="style.css" />

--- a/plugins/keep-markup/index.html
+++ b/plugins/keep-markup/index.html
@@ -3,7 +3,7 @@
 <head>
 
 	<meta charset="utf-8" />
-	<link rel="shortcut icon" href="favicon.png" />
+	<link rel="icon" href="favicon.png" />
 	<title>Keep markup ▲ Prism plugins</title>
 	<base href="../.." />
 	<link rel="stylesheet" href="style.css" />

--- a/plugins/line-highlight/index.html
+++ b/plugins/line-highlight/index.html
@@ -3,7 +3,7 @@
 <head>
 
 <meta charset="utf-8" />
-<link rel="shortcut icon" href="favicon.png" />
+<link rel="icon" href="favicon.png" />
 <title>Line highlight ▲ Prism plugins</title>
 <base href="../.." />
 <link rel="stylesheet" href="style.css" />

--- a/plugins/line-numbers/index.html
+++ b/plugins/line-numbers/index.html
@@ -3,7 +3,7 @@
 <head>
 
 <meta charset="utf-8" />
-<link rel="shortcut icon" href="favicon.png" />
+<link rel="icon" href="favicon.png" />
 <title>Line Numbers ▲ Prism plugins</title>
 <base href="../.." />
 <link rel="stylesheet" href="style.css" />

--- a/plugins/normalize-whitespace/index.html
+++ b/plugins/normalize-whitespace/index.html
@@ -3,7 +3,7 @@
 <head>
 
 	<meta charset="utf-8" />
-	<link rel="shortcut icon" href="favicon.png" />
+	<link rel="icon" href="favicon.png" />
 	<title>Normalize Whitespace ▲ Prism plugins</title>
 	<base href="../.." />
 	<link rel="stylesheet" href="style.css" />

--- a/plugins/previewers/index.html
+++ b/plugins/previewers/index.html
@@ -3,7 +3,7 @@
 <head>
 
 	<meta charset="utf-8" />
-	<link rel="shortcut icon" href="favicon.png" />
+	<link rel="icon" href="favicon.png" />
 	<title>Previewers ▲ Prism plugins</title>
 	<base href="../.." />
 	<link rel="stylesheet" href="style.css" />

--- a/plugins/remove-initial-line-feed/index.html
+++ b/plugins/remove-initial-line-feed/index.html
@@ -3,7 +3,7 @@
 <head>
 
 	<meta charset="utf-8" />
-	<link rel="shortcut icon" href="favicon.png" />
+	<link rel="icon" href="favicon.png" />
 	<title>Remove initial line feed ▲ Prism plugins</title>
 	<base href="../.." />
 	<link rel="stylesheet" href="style.css" />

--- a/plugins/show-invisibles/index.html
+++ b/plugins/show-invisibles/index.html
@@ -3,7 +3,7 @@
 <head>
 
 <meta charset="utf-8" />
-<link rel="shortcut icon" href="favicon.png" />
+<link rel="icon" href="favicon.png" />
 <title>Show Invisibles ▲ Prism plugins</title>
 <base href="../.." />
 <link rel="stylesheet" href="style.css" />

--- a/plugins/show-language/index.html
+++ b/plugins/show-language/index.html
@@ -3,7 +3,7 @@
 <head>
 
 <meta charset="utf-8" />
-<link rel="shortcut icon" href="favicon.png" />
+<link rel="icon" href="favicon.png" />
 <title>Show Language ▲ Prism plugins</title>
 <base href="../.." />
 <link rel="stylesheet" href="style.css" />

--- a/plugins/toolbar/index.html
+++ b/plugins/toolbar/index.html
@@ -3,7 +3,7 @@
 <head>
 
 	<meta charset="utf-8" />
-	<link rel="shortcut icon" href="favicon.png" />
+	<link rel="icon" href="favicon.png" />
 	<title>Toolbar ▲ Prism plugins</title>
 	<base href="../.." />
 	<link rel="stylesheet" href="style.css" />

--- a/plugins/unescaped-markup/index.html
+++ b/plugins/unescaped-markup/index.html
@@ -3,7 +3,7 @@
 <head>
 
 	<meta charset="utf-8" />
-	<link rel="shortcut icon" href="favicon.png" />
+	<link rel="icon" href="favicon.png" />
 	<title>Unescaped markup ▲ Prism plugins</title>
 	<base href="../.." />
 	<link rel="stylesheet" href="style.css" />
@@ -51,7 +51,7 @@
 	<head>
 
 		<meta charset="utf-8" />
-		<link rel="shortcut icon" href="favicon.png" />
+		<link rel="icon" href="favicon.png" />
 		<title>Keep markup ▲ Prism plugins</title>
 		<base href="../.." />
 		<link rel="stylesheet" href="style.css" />
@@ -113,7 +113,7 @@
 <head>
 
 	<meta charset="utf-8" />
-	<link rel="shortcut icon" href="favicon.png" />
+	<link rel="icon" href="favicon.png" />
 	<title>Keep markup ▲ Prism plugins</title>
 	<base href="../.." />
 	<link rel="stylesheet" href="style.css" />

--- a/plugins/wpd/index.html
+++ b/plugins/wpd/index.html
@@ -3,7 +3,7 @@
 <head>
 
 <meta charset="utf-8" />
-<link rel="shortcut icon" href="favicon.png" />
+<link rel="icon" href="favicon.png" />
 <title>WebPlatform Docs ▲ Prism plugins</title>
 <base href="../.." />
 <link rel="stylesheet" href="style.css" />

--- a/test-suite.html
+++ b/test-suite.html
@@ -3,7 +3,7 @@
 <head>
 
 <meta charset="utf-8" />
-<link rel="shortcut icon" href="favicon.png" />
+<link rel="icon" href="favicon.png" />
 <title>Running the test suite ▲ Prism</title>
 <link rel="stylesheet" href="style.css" />
 <link rel="stylesheet" href="themes/prism.css" data-noprefix />

--- a/test.html
+++ b/test.html
@@ -3,7 +3,7 @@
 <head>
 
 <meta charset="utf-8" />
-<link rel="shortcut icon" href="favicon.png" />
+<link rel="icon" href="favicon.png" />
 <title>Test drive ▲ Prism</title>
 <link rel="stylesheet" href="style.css" />
 <link rel="stylesheet" href="themes/prism.css" data-noprefix />


### PR DESCRIPTION
`<link rel="shortcut icon"` is deprecated and `<link rel="icon"` should be used.

(Also, remove unneeded `(?!\*)` from the `lang` regex in `prism-file-highlight.js`.)