### PR TITLE
Make plugins Command Line and Autoloader compatible

### DIFF
--- a/prism.js
+++ b/prism.js
@@ -267,7 +267,7 @@ var _ = _self.Prism = {
 
 			_.hooks.run('before-insert', env);
 
-			env.element.innerHTML = env.highlightedCode;
+			env.element.innerHTML = env.element.innerHTML.replace(code, env.highlightedCode);
 
 			callback && callback.call(element);
 


### PR DESCRIPTION
Command Line rendered before Autoloader, so, this is the problem. Code tags's content will be replaced when autoloader loaded. So, you maybe see Command Line appearing for a very short time, then disappeared. I just do some change in prism.js, using replace instead of '='. But i'm not sure that's the best solution.