### PR TITLE
Make line-numbers styles more specific

### DIFF
--- a/plugins/line-numbers/prism-line-numbers.css
+++ b/plugins/line-numbers/prism-line-numbers.css
@@ -1,12 +1,12 @@
-pre.line-numbers {
+pre[class*="language-"].line-numbers {
 	position: relative;
 	padding-left: 3.8em;
 	counter-reset: linenumber;
 }
 
-pre.line-numbers > code {
+pre[class*="language-"].line-numbers > code {
 	position: relative;
-    white-space: inherit;
+	white-space: inherit;
 }
 
 .line-numbers .line-numbers-rows {


### PR DESCRIPTION
The padding added to `pre.line-numbers` in the line-number's CSS is
overwritten by the theme's CSS if the theme is loaded second. This
ensures the CSS can come in any order without specificity issues.

I ran into this problem in the settings page for WP-Gistpen, where the
user can toggle the theme and enabled plugins. Switching between themes
removes the CSS for the previous theme from the head and injects the new
theme into the head, so the line-numbers CSS actually appears in the
head _first_. The theme CSS that sets the padding uses `pre` while the
line-numbers `pre.line-numbers`, and who "wins" is whomever
comes second.

There's also some whitespace cleanup here as well.

I think this is unlikely to be a breaking change, but interested in feedback on this.