### PR TITLE
Add Python triple-quoted strings "known failure"

### DIFF
--- a/examples/prism-python.html
+++ b/examples/prism-python.html
@@ -49,3 +49,16 @@ are supported.'''</code></pre>
 if __name__ == '__main__':
     import doctest
     doctest.testmod()</code></pre>
+
+<h2>Known failures</h2>
+<p>There are certain edge cases where Prism will fail.
+	There are always such cases in every regex-based syntax highlighter.
+	However, Prism dares to be open and honest about them.
+	If a failure is listed here, it doesn’t mean it will never be fixed. This is more of a “known bugs” list, just with a certain type of bug.
+</p>
+
+<h3>Triple-quoted strings with what look like strings inside</h3>
+<pre><code>def antique(string):
+    """Replace anachronistic Latin "j" with "i"."""
+    return string.replace("j", "i").replace("J", "I")
+    </code></pre>

--- a/examples/prism-python.html
+++ b/examples/prism-python.html
@@ -58,7 +58,7 @@ if __name__ == '__main__':
 </p>
 
 <h3>Triple-quoted strings with what look like strings inside</h3>
-<pre><code>def antique(string):
+<pre class="language-python"><code>def antique(string):
     """Replace anachronistic Latin "j" with "i"."""
     return string.replace("j", "i").replace("J", "I")
     </code></pre>


### PR DESCRIPTION
Documenting a failure that several of our users have run into,
since I’m not sure at first glance how to repair prism.js’s
Python rules without maybe breaking normal strings.