### PR TITLE
Updated index.html to fix broken instructions

### DIFF
--- a/index.html
+++ b/index.html
@@ -188,7 +188,7 @@ var html = Prism.highlight(code, Prism.languages.javascript, 'javascript');</cod
 	<p>Example:</p>
 
 	<pre><code class="language-js">var Prism = require('prismjs');
-var loadLanguages = require('prismjs/components');
+var loadLanguages = require('prismjs/components/index.js');
 loadLanguages(['haml']);
 
 // The code snippet you want to highlight, as a string

--- a/index.html
+++ b/index.html
@@ -188,7 +188,7 @@ var html = Prism.highlight(code, Prism.languages.javascript, 'javascript');</cod
 	<p>Example:</p>
 
 	<pre><code class="language-js">var Prism = require('prismjs');
-var loadLanguages = require('prismjs/components/index.js');
+var loadLanguages = require('prismjs/components/');
 loadLanguages(['haml']);
 
 // The code snippet you want to highlight, as a string


### PR DESCRIPTION
Requiring components without the "index.js" part and calling "loadLanguages" results in a function not found error for me. Adding index.js, as commented by @golmote, fixes that error.

Ref: https://github.com/PrismJS/prism/issues/972