### PR TITLE
Fixed empty link in extending

### DIFF
--- a/extending.html
+++ b/extending.html
@@ -137,7 +137,7 @@
 	}
 });</code></pre>
 	<p>Of course, to understand which hooks to use you would have to read Prism’s source. Imagine where you would add your code and then find the appropriate hook.
-	If there is no hook you can use, you may <a href="">request one to be added</a>, detailing why you need it there.
+	If there is no hook you can use, you may <a href="https://github.com/PrismJS/prism/issues">request one to be added</a>, detailing why you need it there.
 </section>
 
 <section id="api">


### PR DESCRIPTION
There was an empty link in `extending.html`.

I simply linked to the GitHub issues page of Prism.