### PR TITLE
Correct typo

### DIFF
--- a/themes/prism-coy.css
+++ b/themes/prism-coy.css
@@ -52,7 +52,7 @@ code[class*="language"] {
 	overflow: auto;
 }
 
-/* Margin bottom to accomodate shadow */
+/* Margin bottom to accommodate shadow */
 :not(pre) > code[class*="language-"],
 pre[class*="language-"] {
 	background-color: #fdfdfd;


### PR DESCRIPTION
Corrects “accomodate” to spell “accommodate”. Initially via https://github.com/google/pagespeed-inslides/pull/6.