### PR TITLE
Set default indentation size

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,6 +4,7 @@ root = true
 insert_final_newline = false
 charset = utf-8
 indent_style = tab
+indent_size = 4
 
 [tests/languages/**.test]
 end_of_line = crlf


### PR DESCRIPTION
so a tab is four characters wide on GitHub.