### PR TITLE
JS: Regex example

### DIFF
--- a/examples/prism-javascript.html
+++ b/examples/prism-javascript.html
@@ -49,7 +49,7 @@ var foo = /a/, bar = 3/4;</code></pre>
 
 <h2>ES6 features</h2>
 <pre><code>// Regex "y" and "u" flags
-/[a-zA-Z]+/gimyu
+var a = /[a-zA-Z]+/gimyu;
 
 // for..of loops
 for(let x of y) { }


### PR DESCRIPTION
This PR fixes a regex example which Prism does not highlight correctly because it is preceded by a comment.

### Before
![image](https://user-images.githubusercontent.com/20878432/47285219-6f3afb00-d5ea-11e8-97a9-cb885f3032d4.png)

### After
![image](https://user-images.githubusercontent.com/20878432/47285225-77933600-d5ea-11e8-9d59-7123b5e7cd01.png)


