### PR TITLE
Show invisibles: changed color

### DIFF
--- a/plugins/show-invisibles/prism-show-invisibles.css
+++ b/plugins/show-invisibles/prism-show-invisibles.css
@@ -9,23 +9,24 @@
 .token.cr:before,
 .token.lf:before,
 .token.space:before {
-	color: hsl(24, 20%, 85%);
+	color: inherit;
+	opacity: 0.4;
 	position: absolute;
 }
 
 .token.tab:not(:empty):before {
-    content: '\21E5';
+	content: '\21E5';
 }
 
 .token.cr:before {
-    content: '\240D';
+	content: '\240D';
 }
 
 .token.crlf:before {
-    content: '\240D\240A';
+	content: '\240D\240A';
 }
 .token.lf:before {
-    content: '\240A';
+	content: '\240A';
 }
 
 .token.space:before {


### PR DESCRIPTION
This PR changes the color of the placeholders of invisible characters.
They will now use the default text color of the theme as the base and blend in instead of a fixed color for all themes.

(I also used tabs for indentation.)

### Before

Default:
![image](https://user-images.githubusercontent.com/20878432/48344181-a3975980-e674-11e8-83aa-691145919ca2.png)

Tomorrow night:
![image](https://user-images.githubusercontent.com/20878432/48344218-b1e57580-e674-11e8-9fb1-08af4a4bdaab.png)

### After

Default:
![image](https://user-images.githubusercontent.com/20878432/48344274-e0fbe700-e674-11e8-84ff-15a915bd59b8.png)

Tomorrow night:
![image](https://user-images.githubusercontent.com/20878432/48344310-f7a23e00-e674-11e8-87e1-ac824f6d44b6.png)
