### PR TITLE
Travis: changed tested Node versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: node_js
 node_js:
-- '4'
 - '6'
 - '8'
-- '9'
+- '10'
+- 'node'
 # Build all branches
 branches:
   only:


### PR DESCRIPTION
Since it came up again in #1646 and because #1559 is pretty much stale I changed the tested Node versions.

This removes Node 4 and Node 9 because both are [end-of-life](https://github.com/nodejs/Release#end-of-life-releases).
Node 10 and Node current (right now v11) were added.