### PR TITLE
Removed the Prism.tokenize language parameter

### DIFF
--- a/components/prism-core.js
+++ b/components/prism-core.js
@@ -402,7 +402,7 @@ var _ = _self.Prism = {
 		}
 	},
 
-	tokenize: function(text, grammar, language) {
+	tokenize: function(text, grammar) {
 		var strarr = [text];
 
 		var rest = grammar.rest;

--- a/prism.js
+++ b/prism.js
@@ -407,7 +407,7 @@ var _ = _self.Prism = {
 		}
 	},
 
-	tokenize: function(text, grammar, language) {
+	tokenize: function(text, grammar) {
 		var strarr = [text];
 
 		var rest = grammar.rest;


### PR DESCRIPTION
The `language` parameter of `tokenize` was unused and the only one calling `tokenize` with a value for the said parameter is Markup-templating (removed in #1653).
It's not [documented](https://prismjs.com/extending.html#api) either.