### PR TITLE
GitHub API calls now use the master branch

### DIFF
--- a/download.js
+++ b/download.js
@@ -10,7 +10,7 @@ var minified = true;
 
 var dependencies = {};
 
-var treeURL = 'https://api.github.com/repos/PrismJS/prism/git/trees/gh-pages?recursive=1';
+var treeURL = 'https://api.github.com/repos/PrismJS/prism/git/trees/master?recursive=1';
 var treePromise = new Promise(function(resolve) {
 	$u.xhr({
 		url: treeURL,

--- a/examples.js
+++ b/examples.js
@@ -6,7 +6,7 @@
 
 var examples = {};
 
-var treeURL = 'https://api.github.com/repos/PrismJS/prism/git/trees/gh-pages?recursive=1';
+var treeURL = 'https://api.github.com/repos/PrismJS/prism/git/trees/master?recursive=1';
 var treePromise = new Promise(function (resolve) {
 	$u.xhr({
 		url: treeURL,


### PR DESCRIPTION
This resolves #1624.

It fixes the missing examples for newly added language in the [example page](https://prismjs.com/examples.html).