### PR TITLE
Add third-party tutorial for using Prism in Gutenberg

### DIFF
--- a/index.html
+++ b/index.html
@@ -239,6 +239,7 @@ var html = Prism.highlight(code, Prism.languages.haml, 'haml');</code></pre>
 		<li><a href="https://www.semisedlak.com/highlight-your-code-syntax-with-prismjs">Highlight your code syntax with Prism.js</a></li>
 		<li><a href="https://usetypo3.com/fs-code-snippet.html">A code snippet content element powered by Prism.js for TYPO3 CMS</a></li>
 		<li><a href="https://auralinna.blog/post/2017/code-syntax-highlighting-with-angular-and-prismjs">Code syntax highlighting with Angular and Prism.js</a></li>
+		<li><a href="https://mkaz.blog/wordpress/code-syntax-highlighting-in-gutenberg/">Code syntax highlighting in Gutenberg, WordPress block editor</a></li>
 	</ul>
 
 	<p>Please note that the tutorials listed here are not verified to contain correct information. Read at your risk and always check the official documentation here if something doesn’t work :)</p>


### PR DESCRIPTION
Adds a link to https://mkaz.blog/wordpress/code-syntax-highlighting-in-gutenberg/ which is a tutorial for extending the WordPress block editor (Gutenberg) to enable code syntax highlighting using Prism.js.