### PR TITLE
Deleted prism-hdl.min.js

### DIFF
--- a/components/prism-hdl.min.js
+++ b/components/prism-hdl.min.js
@@ -1,1 +1,0 @@
-Prism.languages.hdl={comment:[{pattern:/(^|[^\\])\/\*[\s\S]*?(?:\*\/|$)/,lookbehind:!0},{pattern:/(^|[^\\:])\/\/.*/,lookbehind:!0,greedy:!0}],keyword:/\b(?:CHIP|IN|OUT|PARTS|BUILTIN|CLOCKED)\b/,"boolean":/\b(?:true|false)\b/,number:/\b\d+\b/i,operator:/=/,punctuation:/[{}[\];(),.:]/};


### PR DESCRIPTION
This deletes `prism-hdl.min` as pointed out [here](https://github.com/PrismJS/prism/pull/1710#issuecomment-455257120).