### PR TITLE
Gulp: Inline ALL regexes

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -38,7 +38,7 @@ var gulp   = require('gulp'),
 
 	inlineRegexSource = function () {
 		return replace(
-			/\/((?:[^\n\r[\\\/]|\\.|\[(?:[^\n\r\\\]]|\\.)*\])*)\/\.source\b/,
+			/\/((?:[^\n\r[\\\/]|\\.|\[(?:[^\n\r\\\]]|\\.)*\])*)\/\.source\b/g,
 			function (m, source) {
 				// escape backslashes
 				source = source.replace(/\\/g, '\\\\');


### PR DESCRIPTION
This fixes that only the first regex of the form `/regex/.source` was inlined.

(I forgot the `g` flag...)