### PR TITLE
Line Numbers plugin instructions clarifications

### DIFF
--- a/plugins/line-numbers/index.html
+++ b/plugins/line-numbers/index.html
@@ -27,9 +27,9 @@
   <h1>How to use</h1>
 
   <p>Obviously, this is supposed to work only for code blocks (<code>&lt;pre>&lt;code></code>) and not for inline code.</p>
-  <p>Add class <strong>line-numbers</strong> to your desired <code>&lt;pre></code> and line-numbers plugin will take care.</p>
+  <p>Add the <strong>line-numbers</strong> class to your desired <code>&lt;pre></code>, and the line-numbers plugin will take care of the rest.</p>
   <p>Optional: You can specify the <code>data-start</code> (Number) attribute on the <code>&lt;pre></code> element. It will shift the line counter.</p>
-  <p>Optional: To support multiline line numbers using soft wrap add css <code>white-space</code> to <code>pre-line</code> or <code>pre-wrap</code>.</p>
+  <p>Optional: To support multiline line numbers using soft wrap, apply the CSS <code>white-space: pre-line;</code> or <code>white-space: pre-wrap;</code> to your desired <code>&lt;pre></code>.</p>
 </section>
 
 <section>
@@ -52,6 +52,7 @@ but it still has
 line numbers</code></pre>
 
   <h2>Soft wrap support</h2>
+  <p>Please note the <code>style="white-space:pre-wrap;"</code> in the code below.</p>
   <pre class="line-numbers" data-src="plugins/line-numbers/index.html" data-start="-5" style="white-space:pre-wrap;"></pre>
 
 </section>

--- a/plugins/line-numbers/index.html
+++ b/plugins/line-numbers/index.html
@@ -49,7 +49,7 @@
   <pre class="language-none line-numbers"><code>This raw text
 is not highlighted
 but it still has
-lines numbers</code></pre>
+line numbers</code></pre>
 
   <h2>Soft wrap support</h2>
   <pre class="line-numbers" data-src="plugins/line-numbers/index.html" data-start="-5" style="white-space:pre-wrap;"></pre>


### PR DESCRIPTION
* Fix a typo.
* Clarify some of the instructions, including in "How to use" and by adding a note to "Soft wrap support" that is in the same spirit as the `data-start` note that appears under the "HTML" heading.