### PR TITLE
fix(themes): Highlight `.token.null`

### DIFF
--- a/themes/prism-coy.css
+++ b/themes/prism-coy.css
@@ -118,6 +118,7 @@ pre[class*="language-"]:after {
 .token.property,
 .token.tag,
 .token.boolean,
+.token.null,
 .token.number,
 .token.function-name,
 .token.constant,

--- a/themes/prism-dark.css
+++ b/themes/prism-dark.css
@@ -76,6 +76,7 @@ pre[class*="language-"] {
 .token.property,
 .token.tag,
 .token.boolean,
+.token.null,
 .token.number,
 .token.constant,
 .token.symbol {

--- a/themes/prism-funky.css
+++ b/themes/prism-funky.css
@@ -65,6 +65,7 @@ code[class*="language-"] {
 .token.property,
 .token.tag,
 .token.boolean,
+.token.null,
 .token.number,
 .token.constant,
 .token.symbol {

--- a/themes/prism-okaidia.css
+++ b/themes/prism-okaidia.css
@@ -71,6 +71,7 @@ pre[class*="language-"] {
 }
 
 .token.boolean,
+.token.null,
 .token.number {
 	color: #ae81ff;
 }

--- a/themes/prism-solarizedlight.css
+++ b/themes/prism-solarizedlight.css
@@ -97,6 +97,7 @@ pre[class*="language-"] {
 .token.property,
 .token.tag,
 .token.boolean,
+.token.null,
 .token.number,
 .token.constant,
 .token.symbol,

--- a/themes/prism-tomorrow.css
+++ b/themes/prism-tomorrow.css
@@ -70,6 +70,7 @@ pre[class*="language-"] {
 }
 
 .token.boolean,
+.token.null,
 .token.number,
 .token.function {
 	color: #f08d49;

--- a/themes/prism-twilight.css
+++ b/themes/prism-twilight.css
@@ -90,6 +90,7 @@ code[class*="language-"]::selection, code[class*="language-"] ::selection {
 
 .token.tag,
 .token.boolean,
+.token.null,
 .token.number,
 .token.deleted {
 	color: hsl(14, 58%, 55%); /* #CF6A4C */

--- a/themes/prism.css
+++ b/themes/prism.css
@@ -83,6 +83,7 @@ pre[class*="language-"] {
 .token.property,
 .token.tag,
 .token.boolean,
+.token.null,
 .token.number,
 .token.constant,
 .token.symbol,


### PR DESCRIPTION
The&nbsp;**JSON** syntax highlighting uses `.token.null` to style `null`: https://github.com/PrismJS/prism/blob/4362e42cd4c0271abd976145a85098092a51db80/components/prism-json.js#L15

This updates the&nbsp;Prism stylesheet to&nbsp;style it&nbsp;using the&nbsp;style for&nbsp;`.token.boolean` and&nbsp;`.token.number`.