### PR TITLE
gulp: Better error messages

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -4,6 +4,7 @@ var gulp   = require('gulp'),
 	header = require('gulp-header'),
 	concat = require('gulp-concat'),
 	replace = require('gulp-replace'),
+	pump = require('pump'),
 	fs = require('fs'),
 
 	paths  = {
@@ -52,12 +53,17 @@ var gulp   = require('gulp'),
 		);
 	};
 
-gulp.task('components', function() {
-	return gulp.src(paths.components)
-		.pipe(inlineRegexSource())
-		.pipe(uglify())
-		.pipe(rename({ suffix: '.min' }))
-		.pipe(gulp.dest('components'));
+gulp.task('components', function(cb) {
+	pump(
+		[
+			gulp.src(paths.components),
+			inlineRegexSource(),
+			uglify(),
+			rename({ suffix: '.min' }),
+			gulp.dest('components')
+		],
+		cb
+	);
 });
 
 gulp.task('build', function() {
@@ -69,12 +75,17 @@ gulp.task('build', function() {
 		.pipe(gulp.dest('./'));
 });
 
-gulp.task('plugins', ['languages-plugins'], function() {
-	return gulp.src(paths.plugins)
-		.pipe(inlineRegexSource())
-		.pipe(uglify())
-		.pipe(rename({ suffix: '.min' }))
-		.pipe(gulp.dest('plugins'));
+gulp.task('plugins', ['languages-plugins'], function(cb) {
+	pump(
+		[
+			gulp.src(paths.plugins),
+			inlineRegexSource(),
+			uglify(),
+			rename({ suffix: '.min' }),
+			gulp.dest('plugins')
+		],
+		cb
+	);
 });
 
 gulp.task('components-json', function (cb) {

--- a/package.json
+++ b/package.json
@@ -27,9 +27,10 @@
     "gulp-concat": "^2.3.4",
     "gulp-header": "^1.0.5",
     "gulp-rename": "^1.2.0",
-    "gulp-uglify": "^0.3.1",
     "gulp-replace": "^0.5.4",
+    "gulp-uglify": "^0.3.1",
     "mocha": "^2.2.5",
+    "pump": "^3.0.0",
     "yargs": "^3.26.0"
   },
   "jspm": {


### PR DESCRIPTION
After I tried (and failed) for half an hour to find the line that caused `uglify` to fail, I decided it's (finally) time for proper error messages using [`pump`](https://gulpjs.org/why-use-pump/).

### Example

`pump` will transform

```
... more gulp log ...
[15:12:04] Starting 'plugins'...
[15:12:04] Finished 'build' after 195 ms
[15:12:05] Finished 'plugins' after 676 ms

events.js:167
      throw er; // Unhandled 'error' event
      ^
Error
    at new JS_Parse_Error (D:\Documents\GitHub\prism\node_modules\uglify-js\lib\parse.js:196:18)
    at js_error (D:\Documents\GitHub\prism\node_modules\uglify-js\lib\parse.js:204:11)
    at parse_error (D:\Documents\GitHub\prism\node_modules\uglify-js\lib\parse.js:306:9)
    at Object.next_token [as input] (D:\Documents\GitHub\prism\node_modules\uglify-js\lib\parse.js:551:9)
    at next (D:\Documents\GitHub\prism\node_modules\uglify-js\lib\parse.js:649:25)
    at as_name (D:\Documents\GitHub\prism\node_modules\uglify-js\lib\parse.js:1259:9)
    at subscripts (D:\Documents\GitHub\prism\node_modules\uglify-js\lib\parse.js:1297:30)
    at expr_atom (D:\Documents\GitHub\prism\node_modules\uglify-js\lib\parse.js:1171:20)
    at maybe_unary (D:\Documents\GitHub\prism\node_modules\uglify-js\lib\parse.js:1334:19)
    at expr_ops (D:\Documents\GitHub\prism\node_modules\uglify-js\lib\parse.js:1369:24)
Emitted 'error' event at:
    at DestroyableTransform.onerror (D:\Documents\GitHub\prism\node_modules\gulp-replace\node_modules\readable-stream\lib\_stream_readable.js:640:52)
    at DestroyableTransform.emit (events.js:182:13)
    at onwriteError (D:\Documents\GitHub\prism\node_modules\gulp-uglify\node_modules\readable-stream\lib\_stream_writable.js:250:10)
    at onwrite (D:\Documents\GitHub\prism\node_modules\gulp-uglify\node_modules\readable-stream\lib\_stream_writable.js:268:5)
    at WritableState.onwrite (D:\Documents\GitHub\prism\node_modules\gulp-uglify\node_modules\readable-stream\lib\_stream_writable.js:106:5)
    at afterTransform (D:\Documents\GitHub\prism\node_modules\gulp-uglify\node_modules\readable-stream\lib\_stream_transform.js:104:5)
    at TransformState.afterTransform (D:\Documents\GitHub\prism\node_modules\gulp-uglify\node_modules\readable-stream\lib\_stream_transform.js:79:12)
    at DestroyableTransform.minify [as _transform] (D:\Documents\GitHub\prism\node_modules\gulp-uglify\index.js:55:11)
    at DestroyableTransform.Transform._read (D:\Documents\GitHub\prism\node_modules\gulp-uglify\node_modules\readable-stream\lib\_stream_transform.js:184:10)
    at DestroyableTransform.Transform._write (D:\Documents\GitHub\prism\node_modules\gulp-uglify\node_modules\readable-stream\lib\_stream_transform.js:172:12)
```
(Which task failed? Which file? Which line? Any hints as to what caused the error?)

into

```
... more gulp log ...
[15:10:42] 'components' errored after 864 ms
[15:10:42] Error in plugin 'gulp-uglify'
Message:
    Unexpected character '`'
Details:
    fileName: D:\Documents\GitHub\prism\components\prism-js-extras.js
    lineNumber: 67
```