### PR TITLE
Test page: Show tokens option

### DIFF
--- a/test.html
+++ b/test.html
@@ -84,7 +84,6 @@ pre.show-tokens {
 	padding: 0 1px;
 }
 .show-tokens .token > .token > .token > .token > .token {
-	background-color: rgba(255,0,0,.5);
 	border: none;
 	border-left: 1px solid;
 	border-right: 1px solid;

--- a/test.html
+++ b/test.html
@@ -51,6 +51,47 @@ textarea {
 		column-span: all;
 	}
 
+
+pre.show-tokens {
+	line-height: calc(1.5em + 12px);
+}
+
+.show-tokens .token:not(:first-child) {
+	margin-left: 1px;
+}
+
+.show-tokens .token:empty {
+	background: red;
+}
+.show-tokens .token:empty::before {
+	color: white;
+	content: 'empty';
+	font-style: italic;
+	text-shadow: black 0 0 .3em;
+}
+
+.show-tokens .token {
+	border: 1px solid;
+	padding: 6px 1px;
+}
+.show-tokens .token > .token {
+	padding: 4px 1px;
+}
+.show-tokens .token > .token > .token {
+	padding: 2px 1px;
+}
+.show-tokens .token > .token > .token > .token {
+	padding: 0 1px;
+}
+.show-tokens .token > .token > .token > .token > .token {
+	background-color: rgba(255,0,0,.5);
+	border: none;
+	border-left: 1px solid;
+	border-right: 1px solid;
+	padding: 0;
+	margin: 0 1px;
+}
+
 </style>
 <script src="prefixfree.min.js"></script>
 
@@ -75,6 +116,9 @@ textarea {
 		<p>Result:</p>
 		<pre><code></code></pre>
 
+		<p id="options">
+			<label><input type="checkbox" id="option-show-tokens"> Show tokens</label>
+		</p>
 		<p id="language">
 			<strong>Language:</strong>
 		</p>
@@ -194,6 +238,15 @@ var textarea = $('textarea', form);
 	code.textContent = this.value || '';
 	highlightCode();
 }).call(textarea);
+
+$('#option-show-tokens').onchange = function (evt) {
+	var cls = 'show-tokens';
+	if (this.checked) {
+		$('pre').classList.add(cls);
+	} else {
+		$('pre').classList.remove(cls);
+	}
+}
 
 })();
 

--- a/test.html
+++ b/test.html
@@ -238,14 +238,15 @@ var textarea = $('textarea', form);
 	highlightCode();
 }).call(textarea);
 
-$('#option-show-tokens').onchange = function (evt) {
+$('#option-show-tokens').onchange = function () {
 	var cls = 'show-tokens';
 	if (this.checked) {
 		$('pre').classList.add(cls);
 	} else {
 		$('pre').classList.remove(cls);
 	}
-}
+};
+$('#option-show-tokens').onchange();
 
 })();
 


### PR DESCRIPTION
This PR adds a _Show tokens_ option to the test page.

The purpose of this option is to make the nested structure and range of tokens visible. 
This is useful for both the developing and reviewing process because it visualizes the output token stream of Prism with greater detail than simple highlighting.

When enabled, it will surround each token with a solid 1px border and give it a 1px margin to other tokens. The border color is the font color of the token.

To enable the option, click the new checkbox:

![image](https://user-images.githubusercontent.com/20878432/53207714-c7374c00-3634-11e9-9eef-7b9a63590b5a.png)


## Images

Overview:

![image](https://user-images.githubusercontent.com/20878432/53207781-f5b52700-3634-11e9-8b72-fb729f58715f.png)

The nested structure of a `tag` token is clearly visible:

![image](https://user-images.githubusercontent.com/20878432/53207977-8ab82000-3635-11e9-9d46-f29b8074c574.png)

Empty tokens are made visible:

![image](https://user-images.githubusercontent.com/20878432/53208094-e2568b80-3635-11e9-9570-14d3ab0d8c42.png)

## Limitations

Only a maximum of 4 nested levels can be visualized using borders. Greater than level 4 tokens will be displayed like this:

![image](https://user-images.githubusercontent.com/20878432/53208438-09fa2380-3637-11e9-99f3-92404757ccfd.png)
![image](https://user-images.githubusercontent.com/20878432/53208650-d370d880-3637-11e9-96ad-3fa449a12ec0.png)

You have to try quite hard to get more than 4 nested levels of tokens, so this shouldn't happen too often.

## Browser support

Everything is tested and working on the latest versions of Chrome, Opera, Firefox, Edge, and IE11.