### PR TITLE
gulp: Refactoring

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -69,9 +69,12 @@ function minifyPlugins(cb) {
 	pump([src(paths.plugins), ...minifyJS(), rename({ suffix: '.min' }), dest('plugins')], cb);
 }
 function build(cb) {
-	pump([src(paths.main), header('\n/* **********************************************\n' +
-		'     Begin <%= file.relative %>\n' +
-		'********************************************** */\n\n'), concat('prism.js'), dest('./')], cb);
+	pump([src(paths.main), header(`
+/* **********************************************
+     Begin <%= file.relative %>
+********************************************** */
+
+`), concat('prism.js'), dest('./')], cb);
 }
 
 function componentsJsonToJs(cb) {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,110 +1,98 @@
-var gulp   = require('gulp'),
-	rename = require('gulp-rename'),
-	uglify = require('gulp-uglify'),
-	header = require('gulp-header'),
-	concat = require('gulp-concat'),
-	replace = require('gulp-replace'),
-	pump = require('pump'),
-	fs = require('fs'),
+// @ts-check
 
-	paths  = {
-		componentsFile: 'components.json',
-		componentsFileJS: 'components.js',
-		components: ['components/**/*.js', '!components/index.js', '!components/**/*.min.js'],
-		main: [
-			'components/prism-core.js',
-			'components/prism-markup.js',
-			'components/prism-css.js',
-			'components/prism-clike.js',
-			'components/prism-javascript.js',
-			'plugins/file-highlight/prism-file-highlight.js'
-		],
-		plugins: ['plugins/**/*.js', '!plugins/**/*.min.js'],
-		showLanguagePlugin: 'plugins/show-language/prism-show-language.js',
-		autoloaderPlugin: 'plugins/autoloader/prism-autoloader.js',
-		changelog: 'CHANGELOG.md'
-	},
+const { src, dest, series, parallel, watch } = require('gulp');
 
-	componentsPromise = new Promise(function (resolve, reject) {
-		fs.readFile(paths.componentsFile, {
-			encoding: 'utf-8'
-		}, function (err, data) {
-			if (!err) {
-				resolve(JSON.parse(data));
-			} else {
-				reject(err);
-			}
-		});
-	}),
+const rename = require('gulp-rename');
+const uglify = require('gulp-uglify');
+const header = require('gulp-header');
+const concat = require('gulp-concat');
+const replace = require('gulp-replace');
+const pump = require('pump');
+const fs = require('fs');
 
-	inlineRegexSource = function () {
-		return replace(
-			/\/((?:[^\n\r[\\\/]|\\.|\[(?:[^\n\r\\\]]|\\.)*\])*)\/\.source\b/g,
-			function (m, source) {
-				// escape backslashes
-				source = source.replace(/\\/g, '\\\\');
-				// escape single quotes
-				source = source.replace(/'/g, "\\'");
-				// unescape characters like \\n and \\t to \n and \t
-				source = source.replace(/(^|[^\\])\\\\([nrt0])/g, '$1\\$2');
-				// wrap source in single quotes
-				return "'" + source + "'";
-			}
-		);
-	};
+const paths = {
+	componentsFile: 'components.json',
+	componentsFileJS: 'components.js',
+	components: ['components/**/*.js', '!components/index.js', '!components/**/*.min.js'],
+	main: [
+		'components/prism-core.js',
+		'components/prism-markup.js',
+		'components/prism-css.js',
+		'components/prism-clike.js',
+		'components/prism-javascript.js',
+		'plugins/file-highlight/prism-file-highlight.js'
+	],
+	plugins: ['plugins/**/*.js', '!plugins/**/*.min.js'],
+	showLanguagePlugin: 'plugins/show-language/prism-show-language.js',
+	autoloaderPlugin: 'plugins/autoloader/prism-autoloader.js',
+	changelog: 'CHANGELOG.md'
+};
 
-gulp.task('components', function(cb) {
-	pump(
-		[
-			gulp.src(paths.components),
-			inlineRegexSource(),
-			uglify(),
-			rename({ suffix: '.min' }),
-			gulp.dest('components')
-		],
-		cb
-	);
-});
-
-gulp.task('build', function() {
-	return gulp.src(paths.main)
-		.pipe(header('\n/* **********************************************\n' +
-			'     Begin <%= file.relative %>\n' +
-			'********************************************** */\n\n'))
-		.pipe(concat('prism.js'))
-		.pipe(gulp.dest('./'));
-});
-
-function plugins(cb) {
-	pump(
-		[
-			gulp.src(paths.plugins),
-			inlineRegexSource(),
-			uglify(),
-			rename({ suffix: '.min' }),
-			gulp.dest('plugins')
-		],
-		cb
-	);
-}
-
-gulp.task('components-json', function (cb) {
-	componentsPromise.then(function (data) {
-		data = 'var components = ' + JSON.stringify(data) + ';\n' +
-			'if (typeof module !== \'undefined\' && module.exports) { module.exports = components; }';
-		fs.writeFile(paths.componentsFileJS, data, cb);
+const componentsPromise = new Promise((resolve, reject) => {
+	fs.readFile(paths.componentsFile, {
+		encoding: 'utf-8'
+	}, (err, data) => {
+		if (!err) {
+			resolve(JSON.parse(data));
+		} else {
+			reject(err);
+		}
 	});
 });
 
-gulp.task('watch', function() {
-	gulp.watch(paths.components, gulp.parallel('components', 'build'));
-	gulp.watch(paths.plugins, gulp.parallel('plugins', 'build'));
-});
+function inlineRegexSource() {
+	return replace(
+		/\/((?:[^\n\r[\\\/]|\\.|\[(?:[^\n\r\\\]]|\\.)*\])*)\/\.source\b/g,
+		(m, source) => {
+			// escape backslashes
+			source = source.replace(/\\/g, '\\\\');
+			// escape single quotes
+			source = source.replace(/'/g, "\\'");
+			// unescape characters like \\n and \\t to \n and \t
+			source = source.replace(/(^|[^\\])\\\\([nrt0])/g, '$1\\$2');
+			// wrap source in single quotes
+			return "'" + source + "'";
+		}
+	);
+}
 
-gulp.task('languages-plugins', function (cb) {
-	componentsPromise.then(function (data) {
-		var languagesMap = {};
-		var dependenciesMap = {};
+function minifyJS() {
+	return [
+		inlineRegexSource(),
+		uglify()
+	];
+}
+
+
+function minifyComponents(cb) {
+	pump([src(paths.components), ...minifyJS(), rename({ suffix: '.min' }), dest('components')], cb);
+}
+function minifyPlugins(cb) {
+	pump([src(paths.plugins), ...minifyJS(), rename({ suffix: '.min' }), dest('plugins')], cb);
+}
+function build(cb) {
+	pump([src(paths.main), header('\n/* **********************************************\n' +
+		'     Begin <%= file.relative %>\n' +
+		'********************************************** */\n\n'), concat('prism.js'), dest('./')], cb);
+}
+
+function componentsJsonToJs(cb) {
+	componentsPromise.then(data => {
+		const js = `var components = ${JSON.stringify(data)};
+if (typeof module !== 'undefined' && module.exports) { module.exports = components; }`;
+		fs.writeFile(paths.componentsFileJS, js, cb);
+	});
+}
+
+function watchComponentsAndPlugins() {
+	watch(paths.components, parallel(minifyComponents, build));
+	watch(paths.plugins, parallel(minifyPlugins, build));
+}
+
+function languagePlugins(cb) {
+	componentsPromise.then(data => {
+		const languagesMap = {};
+		const dependenciesMap = {};
 
 		/**
 		 * Tries to guess the name of a language given its id.
@@ -127,13 +115,13 @@ gulp.task('languages-plugins', function (cb) {
 			}
 		}
 
-		for (var p in data.languages) {
+		for (const p in data.languages) {
 			if (p !== 'meta') {
-				var title = data.languages[p].displayTitle || data.languages[p].title;
+				const title = data.languages[p].displayTitle || data.languages[p].title;
 
 				addLanguageTitle(p, title);
 
-				for (var name in data.languages[p].aliasTitles) {
+				for (const name in data.languages[p].aliasTitles) {
 					addLanguageTitle(name, data.languages[p].aliasTitles[name]);
 				}
 
@@ -153,52 +141,56 @@ gulp.task('languages-plugins', function (cb) {
 			}
 		}
 
-		var jsonLanguagesMap = JSON.stringify(languagesMap);
-		var jsonDependenciesMap = JSON.stringify(dependenciesMap);
+		const jsonLanguagesMap = JSON.stringify(languagesMap);
+		const jsonDependenciesMap = JSON.stringify(dependenciesMap);
 
-		var tasks = [
-			{plugin: paths.showLanguagePlugin, map: jsonLanguagesMap},
-			{plugin: paths.autoloaderPlugin, map: jsonDependenciesMap}
+		const tasks = [
+			{ plugin: paths.showLanguagePlugin, map: jsonLanguagesMap },
+			{ plugin: paths.autoloaderPlugin, map: jsonDependenciesMap }
 		];
 
-		var cpt = 0;
-		var l = tasks.length;
-		var done = function() {
+		let cpt = 0;
+		const l = tasks.length;
+		const done = () => {
 			cpt++;
-			if(cpt === l) {
+			if (cpt === l) {
 				cb && cb();
 			}
 		};
 
-		tasks.forEach(function(task) {
-			var stream = gulp.src(task.plugin)
+		for (const task of tasks) {
+			const stream = src(task.plugin)
 				.pipe(replace(
 					/\/\*languages_placeholder\[\*\/[\s\S]*?\/\*\]\*\//,
 					'/*languages_placeholder[*/' + task.map + '/*]*/'
 				))
-				.pipe(gulp.dest(task.plugin.substring(0, task.plugin.lastIndexOf('/'))));
+				.pipe(dest(task.plugin.substring(0, task.plugin.lastIndexOf('/'))));
 
 			stream.on('error', done);
 			stream.on('end', done);
-		});
+		}
 	});
-});
+}
 
-gulp.task('plugins', gulp.series('languages-plugins', plugins));
-
-gulp.task('changelog', function (cb) {
-	return gulp.src(paths.changelog)
-		.pipe(replace(
+function changelog(cb) {
+	return pump([
+		src(paths.changelog),
+		replace(
 			/#(\d+)(?![\d\]])/g,
 			'[#$1](https://github.com/PrismJS/prism/issues/$1)'
-		))
-		.pipe(replace(
+		),
+		replace(
 			/\[[\da-f]+(?:, *[\da-f]+)*\]/g,
-			function (match) {
-				return match.replace(/([\da-f]{7})[\da-f]*/g, '[`$1`](https://github.com/PrismJS/prism/commit/$1)');
-			}
-		))
-		.pipe(gulp.dest('.'));
-});
+			m => m.replace(/([\da-f]{7})[\da-f]*/g, '[`$1`](https://github.com/PrismJS/prism/commit/$1)')
+		),
+		dest('.')
+	], cb);
+}
 
-gulp.task('default', gulp.parallel('components', 'components-json', 'plugins', 'build'));
+const components = minifyComponents;
+const plugins = series(languagePlugins, minifyPlugins);
+
+
+exports.watch = watchComponentsAndPlugins;
+exports.default = parallel(components, plugins, componentsJsonToJs, build);
+exports.changelog = changelog;

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,5 +1,3 @@
-// @ts-check
-
 const { src, dest, series, parallel, watch } = require('gulp');
 
 const rename = require('gulp-rename');


### PR DESCRIPTION
Since we just switched to gulp v4 (#1779) and dropped support for Node 4 some time ago, I took the chance to refactor our `gulpfile.js`.

I used ES6 syntax and removed [`gulp.task`](https://gulpjs.com/docs/en/api/task) which is not recommended anymore.

(Let's see if Node v6 can handle the changes. _Edit:_ It worked.)