### PR TITLE
Coy: Fixed line drift issue in Edge

### DIFF
--- a/themes/prism-coy.css
+++ b/themes/prism-coy.css
@@ -9,6 +9,7 @@ pre[class*="language-"] {
 	color: black;
 	background: none;
 	font-family: Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
+	font-size: 100%;
 	text-align: left;
 	white-space: pre;
 	word-spacing: normal;

--- a/themes/prism-coy.css
+++ b/themes/prism-coy.css
@@ -9,7 +9,7 @@ pre[class*="language-"] {
 	color: black;
 	background: none;
 	font-family: Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
-	font-size: 100%;
+	font-size: 1em;
 	text-align: left;
 	white-space: pre;
 	word-spacing: normal;

--- a/themes/prism-dark.css
+++ b/themes/prism-dark.css
@@ -10,6 +10,7 @@ pre[class*="language-"] {
 	background: none;
 	text-shadow: 0 -.1em .2em black;
 	font-family: Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
+	font-size: 1em;
 	text-align: left;
 	white-space: pre;
 	word-spacing: normal;

--- a/themes/prism-funky.css
+++ b/themes/prism-funky.css
@@ -7,6 +7,7 @@
 code[class*="language-"],
 pre[class*="language-"] {
 	font-family: Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
+	font-size: 1em;
 	text-align: left;
 	white-space: pre;
 	word-spacing: normal;

--- a/themes/prism-okaidia.css
+++ b/themes/prism-okaidia.css
@@ -10,6 +10,7 @@ pre[class*="language-"] {
 	background: none;
 	text-shadow: 0 1px rgba(0, 0, 0, 0.3);
 	font-family: Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
+	font-size: 1em;
 	text-align: left;
 	white-space: pre;
 	word-spacing: normal;

--- a/themes/prism-solarizedlight.css
+++ b/themes/prism-solarizedlight.css
@@ -32,6 +32,7 @@ code[class*="language-"],
 pre[class*="language-"] {
 	color: #657b83; /* base00 */
 	font-family: Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
+	font-size: 1em;
 	text-align: left;
 	white-space: pre;
 	word-spacing: normal;

--- a/themes/prism-tomorrow.css
+++ b/themes/prism-tomorrow.css
@@ -9,6 +9,7 @@ pre[class*="language-"] {
 	color: #ccc;
 	background: none;
 	font-family: Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
+	font-size: 1em;
 	text-align: left;
 	white-space: pre;
 	word-spacing: normal;

--- a/themes/prism-twilight.css
+++ b/themes/prism-twilight.css
@@ -8,6 +8,7 @@ pre[class*="language-"] {
 	color: white;
 	background: none;
 	font-family: Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
+	font-size: 1em;
 	text-align: left;
 	text-shadow: 0 -.1em .2em black;
 	white-space: pre;

--- a/themes/prism.css
+++ b/themes/prism.css
@@ -10,6 +10,7 @@ pre[class*="language-"] {
 	background: none;
 	text-shadow: 0 1px white;
 	font-family: Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
+	font-size: 1em;
 	text-align: left;
 	white-space: pre;
 	word-spacing: normal;


### PR DESCRIPTION
This PR fixes #1790.

The `line-height: 1.5em`-fix doesn't solve the underlying issue which is the font-size.
The font-size will now be the same across browsers.

![image](https://user-images.githubusercontent.com/20878432/53825047-a8f71780-3f75-11e9-8e6d-955bd57ae1d9.png)

I also fixed it for all other themes.