### PR TITLE
npm: Fixed `test` script

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "prism.js",
   "style": "themes/prism.css",
   "scripts": {
-    "test": "mocha tests/testrunner-tests.js && mocha tests/run.js && mocha tests/plugins/**/*.js"
+    "test": "mocha tests/testrunner-tests.js && mocha tests/plugins/**/*.js && mocha tests/run.js"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "test:runner": "mocha tests/testrunner-tests.js",
     "test:languages": "mocha tests/run.js",
     "test:plugins": "mocha tests/plugins/**/*.js",
-    "test": "npm run test:tests && npm run test:languages && npm run test:plugins"
+    "test": "npm run test:runner && npm run test:languages && npm run test:plugins"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,10 @@
   "main": "prism.js",
   "style": "themes/prism.css",
   "scripts": {
-    "test": "mocha tests/testrunner-tests.js && mocha tests/plugins/**/*.js && mocha tests/run.js"
+    "test:tests": "mocha tests/testrunner-tests.js",
+    "test:languages": "mocha tests/run.js",
+    "test:plugins": "mocha tests/plugins/**/*.js",
+    "test": "npm run test:tests && npm run test:languages && npm run test:plugins"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "prism.js",
   "style": "themes/prism.css",
   "scripts": {
-    "test:tests": "mocha tests/testrunner-tests.js",
+    "test:runner": "mocha tests/testrunner-tests.js",
     "test:languages": "mocha tests/run.js",
     "test:plugins": "mocha tests/plugins/**/*.js",
     "test": "npm run test:tests && npm run test:languages && npm run test:plugins"

--- a/test-suite.html
+++ b/test-suite.html
@@ -30,8 +30,8 @@
 	<section id="running-tests-for-specific-languages">
 		<h2>Running tests for specific languages</h2>
 
-		<p>To run the tests only for one language, you can use the <code>language</code> parameter: <code class="language-bash">npm test -- --language=markup</code>.</p>
-		<p>You can even specify multiple languages: <code class="language-bash">npm test -- --language=markup --language=css</code>.</p>
+		<p>To run the tests only for one language, you can use the <code>language</code> parameter: <code class="language-bash">npm run test:languages -- --language=markup</code>.</p>
+		<p>You can even specify multiple languages: <code class="language-bash">npm run test:languages -- --language=markup --language=css</code>.</p>
 	</section>
 </section>
 
@@ -121,7 +121,7 @@ This is a comment explaining this test case.</code></pre>
 			<li>All empty structures are removed.</li>
 		</ul>
 		<p>To get a pretty-printed version of the simplified token stream of a failed test, add the <code>--pretty</code> modifier. Keep in mind that the pretty-printed token stream is indented using spaces, you may need to convert these to tabs. (Most editors today have an option which handles the conversion for you.)<br>
-			E.g. <code class="language-bash">npm test -- --pretty</code>.</p>
+			E.g. <code class="language-bash">npm run test:languages -- --pretty</code>.</p>
 		<p>For further information: reading the tests of the test runner (<code>tests/testrunner-tests.js</code>) will help you understand the transformation.</p>
 	</section>
 </section>


### PR DESCRIPTION
Because of #1646 the command `mocha tests/run.js` was no longer the last command in the chain which means that arguments like `npm test -- --language=css` were not passed to it.
This fixes the issue.