### PR TITLE
Change case of name in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "PrismJS/prism",
+  "name": "prismjs/prism",
   "description": "Lightweight, robust, elegant syntax highlighting. A spin-off project from Dabblet.",
   "type": "component",
   "license": "MIT",


### PR DESCRIPTION
I'm looking to add Prism to a Drupal 8 project via Composer. In setting up a Packagist repository off master, I was hit with errors, since the name of the project in composer.json must be lowercase. I changed this line from: `  "name": "PrismJS/prism",` to `  "name": "prismjs/prism",`.