### PR TITLE
Autoloader: Fixed the directory of scripts

### DIFF
--- a/plugins/autoloader/index.html
+++ b/plugins/autoloader/index.html
@@ -125,9 +125,9 @@
 <script src="components.js"></script>
 <script src="scripts/code.js"></script>
 
-<script src="vendor/promise.js"></script>
-<script src="vendor/jszip.min.js"></script>
-<script src="vendor/FileSaver.min.js"></script>
+<script src="scripts/vendor/promise.js"></script>
+<script src="scripts/vendor/jszip.min.js"></script>
+<script src="scripts/vendor/FileSaver.min.js"></script>
 <script>
 	function getZip(files, elt) {
 		return new Promise(function (resolve, reject) {


### PR DESCRIPTION
This fixes the Autoloader's scripts directory I forgot to change in #1781.