### PR TITLE
Tests: Added regex test

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,9 @@
     "test:aliases": "mocha tests/aliases-test.js",
     "test:languages": "mocha tests/run.js",
     "test:plugins": "mocha tests/plugins/**/*.js",
+    "test:regex": "mocha tests/regex-tests.js",
     "test:runner": "mocha tests/testrunner-tests.js",
-    "test": "npm run test:runner && npm run test:languages && npm run test:plugins && npm run test:aliases"
+    "test": "npm run test:runner && npm run test:languages && npm run test:plugins && npm run test:aliases && npm run test:regex"
   },
   "repository": {
     "type": "git",

--- a/tests/regex-tests.js
+++ b/tests/regex-tests.js
@@ -1,0 +1,31 @@
+"use strict";
+
+const { assert } = require("chai");
+const PrismLoader = require('./helper/prism-loader');
+const { languages } = require('../components');
+
+for (const lang in languages) {
+	if (lang === 'meta') {
+		continue;
+	}
+
+	describe(`Testing regular expressions of '${lang}'`, function () {
+
+		const Prism = PrismLoader.createInstance(lang);
+
+		it('- should not match the empty string', function () {
+			let lastToken = '<unknown>';
+
+			Prism.languages.DFS(Prism.languages, function (name, value) {
+				if (typeof this === 'object' && !Array.isArray(this) && name !== 'pattern') {
+					lastToken = name;
+				}
+
+				if (Prism.util.type(value) === 'RegExp') {
+					assert.notMatch('', value, `Token '${lastToken}': ${value} should not match the empty string.`);
+				}
+			});
+
+		});
+	});
+}


### PR DESCRIPTION
This PR adds a test which will fail if any of the regexes in any language match the empty string.
Patterns which match the empty string can create an infinite number of empty tokens.

This is a followup of #1775.

This does not include a test for lookbehinds and lookaheads. I actually implemented it and not only did it not find any more patterns which match the empty string, it even found a false positive: the [`specifier` pattern of AsciiDoc](https://github.com/PrismJS/prism/blob/master/components/prism-asciidoc.js#L38).