### PR TITLE
Revert "Fix spelling mistake for copy-to-clipboard plugin page"

### DIFF
--- a/plugins/copy-to-clipboard/index.html
+++ b/plugins/copy-to-clipboard/index.html
@@ -28,7 +28,7 @@
 	<p>In addition to including the plugin file with your PrismJS build, ensure <a href="https://clipboardjs.com/">Clipboard.js</a> is loaded before the plugin.</p>
 
 	<p>The simplest way to include Clipboard.js is to use any of the
-		<a href="https://github.com/zenorocha/clipboard.js/wiki/CDN-Providers">recommended CDNs</a>. If you're using Browserify, Clipboard.js will be loaded automatically
+		<a href="https://github.com/zenorocha/clipboard.js/wiki/CDN-Providers">recommended CDNs</a>. If you're using Browserify, Clipboard.js will be loaded auotmatically
 		if it's included in your <code>package.json</code>.
 		If you don't load Clipboard.js yourself, the plugin will load it from a CDN for you.</p>
 


### PR DESCRIPTION
Reverts PrismJS/prism#1866