### PR TITLE
Test page: use Core instead of prism.js

### DIFF
--- a/test.html
+++ b/test.html
@@ -127,7 +127,7 @@ pre.show-tokens {
 <footer data-src="templates/footer.html" data-type="text/html"></footer>
 
 <script src="scripts/utopia.js"></script>
-<script src="prism.js"></script>
+<script src="components/prism-core.js"></script>
 <script src="components.js"></script>
 <script src="scripts/code.js"></script>
 <script src="scripts/vendor/promise.js"></script>


### PR DESCRIPTION
This changes the test page to use `components/prism-core.js` instead of `prism.js`.

Changes to Markup, CSS, C-like, JavaScript, and core will now be instantly available to the local test page. 
Previously, changes to these components required you to rebuild Prism before you could test them. It's a little annoying that you have to do this every time while every other component is testable without a rebuild.