### PR TITLE
cpp extend clike

### DIFF
--- a/components/prism-cpp.js
+++ b/components/prism-cpp.js
@@ -1,4 +1,4 @@
-Prism.languages.cpp = Prism.languages.extend('c', {
+Prism.languages.cpp = Prism.languages.extend('clike', {
 	'class-name': {
 		pattern: /(\b(?:class|enum|struct)\s+)\w+/,
 		lookbehind: true


### PR DESCRIPTION
Fix: prism-cpp load failed.

If cpp extend c, it will fallback to default language. 