### PR TITLE
Download page: Fixed Edge's word wrap

### DIFF
--- a/download.html
+++ b/download.html
@@ -107,7 +107,6 @@ section.download {
 	}
 	#download pre {
 		height: 20em;
-		word-wrap: break-word;
 	}
 	#download .download-button {
 		cursor: pointer;


### PR DESCRIPTION
For some reason, Edge wraps the code on the download page. All other browsers don't.
This PR makes Edge consistent will all other browsers.

### Before
![image](https://user-images.githubusercontent.com/20878432/58504038-189e2c80-818a-11e9-898a-bdf1876d60d7.png)

### After
![image](https://user-images.githubusercontent.com/20878432/58504044-1c31b380-818a-11e9-96db-f5a4056adfca.png)
