### PR TITLE
Set opacity to 1 when focus is within

### DIFF
--- a/plugins/toolbar/prism-toolbar.css
+++ b/plugins/toolbar/prism-toolbar.css
@@ -14,6 +14,12 @@ div.code-toolbar:hover > .toolbar {
 	opacity: 1;
 }
 
+/* Separate line b/c rules are thrown out if selector is invalid.
+   IE11 and old Edge versions don't support :focus-within. */
+div.code-toolbar:focus-within > .toolbar {
+	opacity: 1;
+}
+
 div.code-toolbar > .toolbar .toolbar-item {
 	display: inline-block;
 }


### PR DESCRIPTION
This ensures interacting with the toolbar with the keyboard
makes it visible to the user.