### PR TITLE
Website: Updated page styles to not interfere with themes

### DIFF
--- a/style.css
+++ b/style.css
@@ -24,7 +24,6 @@ footer p {
 * {
 	margin: 0;
 	padding: 0;
-	font-weight: normal;
 }
 
 body {
@@ -75,6 +74,10 @@ p {
 section h1,
 h2 {
 	margin: 1em 0 .3em;
+}
+
+h2 {
+	font-weight: normal;
 }
 
 dt {


### PR DESCRIPTION
This changes the `style.css` to not interfere with themes. 

The problem was that `* { ...; font-weight: normal; }` caused markdowns bold text to not be rendered as bold. 

<details>
<summary>Style inheritance</summary>

![image](https://user-images.githubusercontent.com/20878432/60092675-e90e2000-9747-11e9-8b16-73bf3e219001.png)

</details>

The fix is quite simple: I just removed the `font-weight: normal;` line. The only elements (besides the bold tokens) that changed were `h2`s, so they get a new rule. In a side-to-side comparison, I wasn't able to spot any other differences.

Result:

![image](https://user-images.githubusercontent.com/20878432/60092899-5e79f080-9748-11e9-955c-bd3645fc018e.png)
