### PR TITLE
Fixed typo in Funky theme

### DIFF
--- a/themes/prism-funky.css
+++ b/themes/prism-funky.css
@@ -84,7 +84,7 @@ code[class*="language-"] {
 .token.entity,
 .token.url,
 .language-css .token.string,
-.toke.variable,
+.token.variable,
 .token.inserted {
 	color: yellowgreen;
 }


### PR DESCRIPTION
I was wondering why the Funky theme doesn't highlight `variable` tokens and then I found this.

I also checked the other themes. This is the only occurrence of this typo.