### PR TITLE
Improved test page performance for Chromium

### DIFF
--- a/test.html
+++ b/test.html
@@ -134,9 +134,22 @@ pre.show-tokens {
 
 <script>
 (function() {
-var form = $('form'), code = $('code', form),
-    languages = components.languages,
-    highlightCode = function() { Prism.highlightElement(code); };
+/** @type {HTMLFormElement} */
+var form = $('form');
+/** @type {HTMLElement} */
+var code = $('code', form);
+var languages = components.languages;
+
+function highlightCode() {
+	var newCode = document.createElement('code');
+	newCode.textContent = code.textContent;
+	newCode.className = code.className;
+
+	Prism.highlightElement(newCode);
+
+	code.parentElement.replaceChild(newCode, code);
+	code = newCode;
+};
 
 
 function updateHashLanguage(lang) {


### PR DESCRIPTION
This does the same improvement to the test page as #1907 did for the download page.
The only downside to this change is that browsers will now be unable to remember the scroll state of the highlighted code but I think that that's a small price to pay for a usable test page.

Edge and FF stay as fast as they were before.