### PR TITLE
Added .github folder to npm ignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -4,6 +4,7 @@
 hide-*.js
 .DS_Store
 CNAME
+.github/
 examples/
 img/
 templates/


### PR DESCRIPTION
While browsing the [Prism directory on UNPKG](https://unpkg.com/browse/prismjs@1.17.1/), I noticed that our releases include the `.github` folder since 1.16.0.

Also, should the changelog.md really be part of the npm release?