### PR TITLE
Tests: Let runTestCase() pretty-print expected TokenStream too

### DIFF
--- a/tests/helper/test-case.js
+++ b/tests/helper/test-case.js
@@ -64,8 +64,8 @@ module.exports = {
 		// the first language is the main language to highlight
 		const simplifiedTokenStream = this.simpleTokenize(Prism, testCase.testSource, usedLanguages.mainLanguage);
 
-		const tzd = JSON.stringify(simplifiedTokenStream);
-		const exp = JSON.stringify(testCase.expectedTokenStream);
+		const tzd = pretty ? TokenStreamTransformer.prettyprint(simplifiedTokenStream) : JSON.stringify(simplifiedTokenStream);
+		const exp = pretty ? TokenStreamTransformer.prettyprint(testCase.expectedTokenStream) : JSON.stringify(testCase.expectedTokenStream);
 		let i = 0;
 		let j = 0;
 		let diff = "";
@@ -77,11 +77,12 @@ module.exports = {
 			j++;
 		}
 
-		const tokenStreamStr = pretty ? TokenStreamTransformer.prettyprint(simplifiedTokenStream) : tzd;
-		const message = "\nToken Stream: \n" + tokenStreamStr +
+		const message = "\n\nToken Stream:\n\n" + tzd +
 			"\n-----------------------------------------\n" +
-			"Expected Token Stream: \n" + exp +
-			"\n-----------------------------------------\n" + diff;
+			"Expected Token Stream:\n\n" + exp +
+			"\n-----------------------------------------\n" +
+			"First Difference: \n\n" + diff +
+			"\n-----------------------------------------\n\n";
 
 		assert.deepEqual(simplifiedTokenStream, testCase.expectedTokenStream, testCase.comment + message);
 	},

--- a/tests/helper/test-case.js
+++ b/tests/helper/test-case.js
@@ -65,23 +65,13 @@ module.exports = {
 		const simplifiedTokenStream = this.simpleTokenize(Prism, testCase.testSource, usedLanguages.mainLanguage);
 
 		const tzd = JSON.stringify(simplifiedTokenStream);
-		const exp = JSON.stringify(testCase.expectedTokenStream);
-		let i = 0;
-		let j = 0;
-		let diff = "";
-		while (j < tzd.length) {
-			if (exp[i] != tzd[j] || i == exp.length)
-				diff += tzd[j];
-			else
-				i++;
-			j++;
-		}
 
 		const tokenStreamStr = pretty ? TokenStreamTransformer.prettyprint(simplifiedTokenStream) : tzd;
-		const message = "\nToken Stream: \n" + tokenStreamStr +
+		const message = "\n\nActual Token Stream:" +
 			"\n-----------------------------------------\n" +
-			"Expected Token Stream: \n" + exp +
-			"\n-----------------------------------------\n" + diff;
+			tokenStreamStr +
+			"\n-----------------------------------------\n" +
+			"File: " + filePath + "\n\n";
 
 		assert.deepEqual(simplifiedTokenStream, testCase.expectedTokenStream, testCase.comment + message);
 	},

--- a/tests/helper/test-case.js
+++ b/tests/helper/test-case.js
@@ -64,8 +64,8 @@ module.exports = {
 		// the first language is the main language to highlight
 		const simplifiedTokenStream = this.simpleTokenize(Prism, testCase.testSource, usedLanguages.mainLanguage);
 
-		const tzd = pretty ? TokenStreamTransformer.prettyprint(simplifiedTokenStream) : JSON.stringify(simplifiedTokenStream);
-		const exp = pretty ? TokenStreamTransformer.prettyprint(testCase.expectedTokenStream) : JSON.stringify(testCase.expectedTokenStream);
+		const tzd = JSON.stringify(simplifiedTokenStream);
+		const exp = JSON.stringify(testCase.expectedTokenStream);
 		let i = 0;
 		let j = 0;
 		let diff = "";
@@ -77,12 +77,11 @@ module.exports = {
 			j++;
 		}
 
-		const message = "\n\nToken Stream:\n\n" + tzd +
+		const tokenStreamStr = pretty ? TokenStreamTransformer.prettyprint(simplifiedTokenStream) : tzd;
+		const message = "\nToken Stream: \n" + tokenStreamStr +
 			"\n-----------------------------------------\n" +
-			"Expected Token Stream:\n\n" + exp +
-			"\n-----------------------------------------\n" +
-			"First Difference: \n\n" + diff +
-			"\n-----------------------------------------\n\n";
+			"Expected Token Stream: \n" + exp +
+			"\n-----------------------------------------\n" + diff;
 
 		assert.deepEqual(simplifiedTokenStream, testCase.expectedTokenStream, testCase.comment + message);
 	},


### PR DESCRIPTION
Only the actual token stream was pretty-printed. This makes the helper function pretty-print the expected token stream as well (and the diff too). Also added some `\n` to separate it from the mocha output.