### PR TITLE
Fixed one of the Custom Class examples

### DIFF
--- a/plugins/custom-class/index.html
+++ b/plugins/custom-class/index.html
@@ -133,7 +133,7 @@ Prism.plugins.customClass.prefix('pr-');</code></pre>
 	&lt;span class=&quot;pr-token pr-special-keyword&quot;&gt;var&lt;/span&gt;
 	foo
 	&lt;span class=&quot;pr-token pr-operator&quot;&gt;=&lt;/span&gt;
-	&lt;span class=&quot;pr-my-string&quot;&gt;'bar'&lt;/span&gt;
+	&lt;span class=&quot;pr-token pr-my-string&quot;&gt;'bar'&lt;/span&gt;
 	&lt;span class=&quot;pr-token pr-punctuation&quot;&gt;;&lt;/span&gt;
 &lt;/code&gt;&lt;/pre&gt;</code></pre>
 


### PR DESCRIPTION
All tokens still have a `.token` class (or `.pr-token` in this case).