### PR TITLE
Added missing .token selector

### DIFF
--- a/themes/prism-coy.css
+++ b/themes/prism-coy.css
@@ -178,7 +178,7 @@ pre[class*="language-"]:after {
 	cursor: help;
 }
 
-.namespace {
+.token.namespace {
 	opacity: .7;
 }
 

--- a/themes/prism-dark.css
+++ b/themes/prism-dark.css
@@ -70,7 +70,7 @@ pre[class*="language-"] {
 	opacity: .7;
 }
 
-.namespace {
+.token.namespace {
 	opacity: .7;
 }
 

--- a/themes/prism-funky.css
+++ b/themes/prism-funky.css
@@ -59,7 +59,7 @@ code[class*="language-"] {
 	color: #999;
 }
 
-.namespace {
+.token.namespace {
 	opacity: .7;
 }
 

--- a/themes/prism-okaidia.css
+++ b/themes/prism-okaidia.css
@@ -59,7 +59,7 @@ pre[class*="language-"] {
 	color: #f8f8f2;
 }
 
-.namespace {
+.token.namespace {
 	opacity: .7;
 }
 

--- a/themes/prism-solarizedlight.css
+++ b/themes/prism-solarizedlight.css
@@ -91,7 +91,7 @@ pre[class*="language-"] {
 	color: #586e75; /* base01 */
 }
 
-.namespace {
+.token.namespace {
 	opacity: .7;
 }
 

--- a/themes/prism-twilight.css
+++ b/themes/prism-twilight.css
@@ -85,7 +85,7 @@ code[class*="language-"]::selection, code[class*="language-"] ::selection {
 	opacity: .7;
 }
 
-.namespace {
+.token.namespace {
 	opacity: .7;
 }
 

--- a/themes/prism.css
+++ b/themes/prism.css
@@ -77,7 +77,7 @@ pre[class*="language-"] {
 	color: #999;
 }
 
-.namespace {
+.token.namespace {
 	opacity: .7;
 }
 


### PR DESCRIPTION
During the discussion in #1055 I noticed that some themes have lone `.namespace` rules without the `.token` component selector.