### PR TITLE
Download page: Added options

### DIFF
--- a/download.html
+++ b/download.html
@@ -8,7 +8,8 @@
 <link rel="stylesheet" href="style.css" />
 <link rel="stylesheet" href="themes/prism.css" data-noprefix />
 <style>
-form label {
+form #components label,
+form > p:first-of-type > label {
 	display: block;
 	padding: .2em;
 	padding-left: 1.9em;
@@ -17,16 +18,17 @@ form label {
 	-webkit-column-break-inside: avoid;
 }
 
-	form label .name {
+	form #components label .name {
 		margin-right: .3em;
 	}
 
-	form label a.owner {
+	form #components label a.owner {
 		margin-left: 0;
 		hyphens: none;
 	}
 
-	form label input {
+	form #components label input,
+	form > p:first-of-type > label input {
 		margin-right: .7em;
 		margin-left: -1.7em;
 	}
@@ -54,7 +56,8 @@ section.options {
 }
 
 section.options#category-languages,
-section.options#category-plugins {
+section.options#category-plugins,
+section#options {
 	width: 100%;
 	float: none;
 	column-count: 3;
@@ -63,11 +66,13 @@ section.options#category-plugins {
 }
 
 	section.options#category-languages label,
-	section.options#category-plugins label {
+	section.options#category-plugins label,
+	section#options #option-container > div {
 		break-inside: avoid;
 	}
 	section.options#category-languages > h1,
-	section.options#category-plugins > h1 {
+	section.options#category-plugins > h1,
+	section#options > h1 {
 		margin-top: 0;
 		column-span: all;
 	}
@@ -90,6 +95,36 @@ section.options#category-themes {
 	section.options#category-themes > h1 {
 		column-span: all;
 	}
+
+
+#option-container > div,
+#option-container > div {
+	padding: 0 1em .5em 0;
+}
+
+#option-container label > span {
+	padding-right: .5em;
+}
+
+#option-container input[type="text"],
+#option-container input[type="number"] {
+	display: block;
+	padding: 0;
+	margin: 0;
+	width: 100%;
+	box-sizing: border-box;
+}
+
+.option-item {
+	position: relative;
+}
+
+#option-container .option-item-error {
+	color: #B61500;
+	font-size: 90%;
+	display: none;
+}
+
 
 section.download {
 	width: 50%;
@@ -147,6 +182,11 @@ section.download {
 		</p>
 
 		<section id="components"></section>
+
+		<section id="options">
+			<h1>Options</h1>
+			<div id="option-container"></div>
+		</section>
 
 		<p>
 			Total filesize: <strong id="filesize"></strong> (<strong id="percent-js"></strong> JavaScript + <strong id="percent-css"></strong> CSS)


### PR DESCRIPTION
This adds a new 'Options' section to the download page where plugins and Prism itself can be configured.

![image](https://user-images.githubusercontent.com/20878432/71840657-068c5100-30be-11ea-807c-a3df0e2565c1.png)

---

The basic idea here is that there are _options_ which are a collection of _option items_. An option can require any number of components and is only enabled if all required components are enabled. Only options that are enabled will be visible.

Every _option item_ translates to one label + one input element. An item is responsible for validating inputs. I added support for 3 types of inputs: boolean (-> `input[type=checkbox]`), number (-> `input[type=number]`), and string (-> `input[type=text]`). But right now, I don't use the number type.

The _option_ will then be used to apply changes to the JS and CSS source code according to the values of its _items_.

The _item_ values of all enabled _options_ will be stored in the URL if the value differs from the default value.

---

I added 3 options:

1. A small general option to disable automatic highlighting.
2. The Custom Class prefix option. (#1055)
3. Options for Filter HighlightAll to set `filterKnown` and to add CSS selectors. (not enabled in the image)

To apply the prefix to the theme, I used Prism's CSS language to tokenize the CSS code and get all selectors and replaced all token names using a regular expression.