### PR TITLE
Coy: Minor improvement

### DIFF
--- a/themes/prism-coy.css
+++ b/themes/prism-coy.css
@@ -45,7 +45,7 @@ pre[class*="language-"]>code {
 	background-attachment: local;
 }
 
-code[class*="language"] {
+code[class*="language-"] {
 	max-height: inherit;
 	height: inherit;
 	padding: 0 1em;
@@ -93,7 +93,6 @@ pre[class*="language-"]:after {
 	transform: rotate(-2deg);
 }
 
-:not(pre) > code[class*="language-"]:after,
 pre[class*="language-"]:after {
 	right: 0.75em;
 	left: auto;

--- a/themes/prism-coy.css
+++ b/themes/prism-coy.css
@@ -190,13 +190,6 @@ pre[class*="language-"]:after {
 
 }
 
-/* Plugin styles */
-.token.tab:not(:empty):before,
-.token.cr:before,
-.token.lf:before {
-	color: #e0d7d1;
-}
-
 /* Plugin styles: Line Numbers */
 pre[class*="language-"].line-numbers.line-numbers {
 	padding-left: 0;


### PR DESCRIPTION
Two minor improvements for the Coy theme:

1. It now consistently uses `[class*="language-"]`.
2. Removed the `:not(pre) > code[class*="language-"]:after` selector because `code` element don't have an after pseudo-element.