### PR TITLE
Website: Fix diff highlight plugin page title

### DIFF
--- a/plugins/diff-highlight/index.html
+++ b/plugins/diff-highlight/index.html
@@ -4,7 +4,7 @@
 <head>
 	<meta charset="utf-8" />
 	<link rel="icon" href="favicon.png" />
-	<title>Data-URI Highlight ▲ Prism plugins</title>
+	<title>Diff Highlight ▲ Prism plugins</title>
 	<base href="../.." />
 	<link rel="stylesheet" href="style.css" />
 	<link rel="stylesheet" href="themes/prism.css" data-noprefix />


### PR DESCRIPTION
https://prismjs.com/plugins/diff-highlight/ shows "Data-URI highlight" as page's `<title>`