### PR TITLE
Travis: Updated NodeJS versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js:
-- '8'
 - '10'
+- '12'
 - 'node'
 # Build all branches
 branches:


### PR DESCRIPTION
NodeJS 8 has [reached its EOL](https://github.com/nodejs/Release#end-of-life-releases), so I removed it from our Travis config and added NodeJS 12.