### PR TITLE
C#: Removed invalid strings from example

### DIFF
--- a/examples/prism-csharp.html
+++ b/examples/prism-csharp.html
@@ -5,12 +5,9 @@ comment */</code></pre>
 
 <h2>Strings</h2>
 <pre><code>"foo \"bar\" baz"
-'foo \'bar\' baz'
 @"Verbatim strings"
 @"Luis: ""Patrick, where did you get that overnight bag?""
     Patrick: ""Jean Paul Gaultier.""";
-@'Luis: ''Patrick, where did you get that overnight bag?''
-    Patrick: ''Jean Paul Gaultier.''';
 </code></pre>
 
 <h2>Full example</h2>


### PR DESCRIPTION
C#'s example page contained some invalid strings.