### PR TITLE
Okaidia: Update comment text color to meet WCAG contrast recommendations to AA level

### DIFF
--- a/themes/prism-okaidia.css
+++ b/themes/prism-okaidia.css
@@ -52,7 +52,7 @@ pre[class*="language-"] {
 .token.prolog,
 .token.doctype,
 .token.cdata {
-	color: slategray;
+	color: #8292a2;
 }
 
 .token.punctuation {


### PR DESCRIPTION
Hi everyone,
Text color for comments used in the Okaidia theme is slightly falling behind the minimum text contrast level required by [WCAG guidelines](https://developer.mozilla.org/en-US/docs/Web/Accessibility/Understanding_WCAG/Perceivable/Color_contrast). 

This PR changes the text color slightly to meet the 4.5 requirement. 

Please see the comparison below:

![image](https://user-images.githubusercontent.com/811553/79042130-4e6fc680-7c1f-11ea-82f4-223f5a930b52.png)


|Color|WCAG score|hex|rgb|hsl|lch
|---|---|---|---|---|---|
|**Current**|3.67|708090|112, 128, 144|210, 13%, 50%|52.697% 11.234 253.001
|~**New**~|~**4.54**~|~**81909e**~|~**129**, 144, **158**~|~**209**, 13%, **56**%~|~58.928% 9.916 250.732~|
|**Latest**|**4.66**|**8292a2**|130, 146, 162|210, 15%, 57%|**59.697%** 11.234 253.001|

Fingers crossed this can be merged and release, but I'd be happy to make any further changes if necessary. 

Thank you, and stay safe 🙏🏽.

Edit: The first version of this PR suggested to use color `#81909e`, but it turns out to be a not good measurement to make lightness improvements. That commit was force-pushed to use the new color `#8292a2`, which only makes lightness increments until it meets to the WCAG recommendation, and then converted to the nearest hex color.