### PR TITLE
Minor improvement for default theme

### DIFF
--- a/themes/prism.css
+++ b/themes/prism.css
@@ -106,7 +106,6 @@ pre[class*="language-"] {
 .language-css .token.string,
 .style .token.string {
 	color: #9a6e3a;
-	background: hsla(0, 0%, 100%, .5);
 }
 
 .token.atrule,


### PR DESCRIPTION
While implementing the default theme on my website, I found this little issue with the background color on tokens. Here is the way it looks before applying the change proposed in this PR for JavaScript syntax:
<img width="221" alt="before" src="https://user-images.githubusercontent.com/2190603/79053479-84e31c80-7bf2-11ea-9719-cd637b440d7b.png">
Notice that behind `=` and `||` there is a slight difference in the background color. This is how it looks after applying this change:
<img width="217" alt="after" src="https://user-images.githubusercontent.com/2190603/79053495-b0660700-7bf2-11ea-9e82-18c604f56375.png">

Although I believe this doesn't depend on a specific syntax, here is example with Rust:

Before (look at the `=`):
<img width="313" alt="rust-before" src="https://user-images.githubusercontent.com/2190603/79053651-c45e3880-7bf3-11ea-8c23-dda52e478163.png">
After:
<img width="314" alt="rust-after" src="https://user-images.githubusercontent.com/2190603/79053652-ca541980-7bf3-11ea-8ad9-2dfcd6a7cf8d.png">


The change is minimal, just remove a `background` CSS rule from `theme/prism.css`. Just to give more context, I went through all the other template files (`theme/prism-*.css`) and realized they aren't specifying this rule.