### PR TITLE
Default Theme: Add a comment that declares the background color of `operator` tokens as intentional

### DIFF
--- a/themes/prism.css
+++ b/themes/prism.css
@@ -106,6 +106,7 @@ pre[class*="language-"] {
 .language-css .token.string,
 .style .token.string {
 	color: #9a6e3a;
+	/* This background color was intended by the author of this theme. */
 	background: hsla(0, 0%, 100%, .5);
 }
 


### PR DESCRIPTION
Since people seem to somewhat [regularly](https://github.com/PrismJS/prism/issues/1347) [report](https://github.com/PrismJS/prism/issues/1691) [and](https://github.com/PrismJS/prism/pull/1692) [fix](https://github.com/PrismJS/prism/pull/2308) the background color of `operator` tokens in the default theme, I added a little comment to clarify that it's indeed intentional.

NGL, when I first saw Prism, I also thought it's a bug.