### PR TITLE
Added a test for color contrast

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -695,6 +695,16 @@
         "object-visit": "^1.0.0"
       }
     },
+    "color": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/color/-/color-3.1.2.tgz",
+      "integrity": "sha512-vXTJhHebByxZn3lDvDJYw4lR5+uB3vuoHsuYA5AKuxRVn5wzzIfQKGLBmgdVRHKTJYeK5rvJcHnrd0Li49CFpg==",
+      "dev": true,
+      "requires": {
+        "color-convert": "^1.9.1",
+        "color-string": "^1.5.2"
+      }
+    },
     "color-convert": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
@@ -709,6 +719,16 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
+    },
+    "color-string": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.3.tgz",
+      "integrity": "sha512-dC2C5qeWoYkxki5UAXapdjqO672AM4vZuPGRQfO8b5HKuKGBbKWpITyDYN7TOFKvRW7kOgAn3746clDBMDJyQw==",
+      "dev": true,
+      "requires": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
     },
     "color-support": {
       "version": "1.1.3",
@@ -816,6 +836,26 @@
         "which": "^1.2.9"
       }
     },
+    "css": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/css/-/css-2.2.4.tgz",
+      "integrity": "sha512-oUnjmWpy0niI3x/mPL8dVEI1l7MnG3+HHyRPHf+YFSbK+svOhXpmSOcDURUh2aOCgl2grzrOPt1nHLuCVFULLw==",
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.3",
+        "source-map": "^0.6.1",
+        "source-map-resolve": "^0.5.2",
+        "urix": "^0.1.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
+      }
+    },
     "cssom": {
       "version": "0.3.6",
       "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.6.tgz",
@@ -840,6 +880,12 @@
         "es5-ext": "^0.10.50",
         "type": "^1.0.1"
       }
+    },
+    "d3-color": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-1.4.0.tgz",
+      "integrity": "sha512-TzNPeJy2+iEepfiL92LAAB7fvnp/dV2YwANPVHdDWmYMm23qIJBYww3qT8I8C1wXrmrg4UWs7BKc2tKIgyjzHg==",
+      "dev": true
     },
     "dashdash": {
       "version": "1.14.1",
@@ -4312,6 +4358,23 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
           "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "dev": true
+        }
+      }
+    },
+    "simple-swizzle": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+      "integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
+      "dev": true,
+      "requires": {
+        "is-arrayish": "^0.3.1"
+      },
+      "dependencies": {
+        "is-arrayish": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
+          "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
           "dev": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "style": "themes/prism.css",
   "scripts": {
     "test:aliases": "mocha tests/aliases-test.js",
+    "test:contrast": "mocha tests/contrast-test.js",
     "test:core": "mocha tests/core/**/*.js",
     "test:dependencies": "mocha tests/dependencies-test.js",
     "test:examples": "mocha tests/examples-test.js",
@@ -13,7 +14,7 @@
     "test:patterns": "mocha tests/pattern-tests.js",
     "test:plugins": "mocha tests/plugins/**/*.js",
     "test:runner": "mocha tests/testrunner-tests.js",
-    "test": "npm run test:runner && npm run test:core && npm run test:dependencies && npm run test:languages && npm run test:plugins && npm run test:aliases && npm run test:patterns && npm run test:examples"
+    "test": "npm run test:runner && npm run test:core && npm run test:dependencies && npm run test:languages && npm run test:plugins && npm run test:aliases && npm run test:patterns && npm run test:examples && npm run test:contrast"
   },
   "repository": {
     "type": "git",
@@ -31,6 +32,8 @@
   },
   "devDependencies": {
     "chai": "^4.2.0",
+    "color": "^3.1.2",
+    "css": "^2.2.4",
     "gulp": "^4.0.2",
     "gulp-concat": "^2.3.4",
     "gulp-header": "^2.0.7",

--- a/tests/contrast-test.js
+++ b/tests/contrast-test.js
@@ -1,0 +1,160 @@
+const fs = require('fs');
+const css = require('css');
+const path = require('path');
+const Color = require('color');
+const { assert } = require('chai');
+const { themes } = require('../components');
+
+
+/**
+ * @typedef {import("color")} Color
+ */
+
+/**
+ * Analyzes the given CSS source code to find low-contrast colors and returns an array the found colors, the line they
+ * occur in, and a suggested high-contrast color with the same hue.
+ *
+ * Use `@contrast-background: <color>` on a line in a comment to tell this checker the background color. The background
+ * color is defined per scope.
+ *
+ * Use `@contrast-ignore` on a line in a comment within a rule to ignore the next property.
+ *
+ * @param {string} cssCode
+ * @returns {string[]}
+ */
+function analyseContrast(cssCode) {
+	/** @type {string[]} */
+	const errors = [];
+
+	const ast = css.parse(cssCode);
+	analyseRules(ast.stylesheet.rules);
+
+	/**
+	 * @param {string} comment
+	 */
+	function parseBackground(comment) {
+		const colorStr = (/^\s*(?:\*\s*)?@contrast-background:(.*)/m.exec(comment) || [, ''])[1].trim();
+		if (colorStr) {
+			return Color(colorStr);
+		}
+	}
+	/**
+	 * @param {string} comment
+	 */
+	function parseIgnore(comment) {
+		return /^\s*(?:\*\s*)?@contrast-ignore\s*$/m.test(comment);
+	}
+
+	/**
+	 * @param {import("css").StyleRules["rules"]} rules
+	 * @param {Color | undefined} [background]
+	 */
+	function analyseRules(rules, background) {
+		for (const element of rules) {
+			if ("comment" in element) {
+				background = parseBackground(element.comment) || background;
+			} else if ("rules" in element) {
+				analyseRules(element.rules, background);
+			} else if ("declarations" in element) {
+				analyseDeclarations(element.declarations, background);
+			}
+		}
+	}
+	/**
+	 * @param {import("css").Rule["declarations"]} declarations
+	 * @param {Color | undefined} background
+	 */
+	function analyseDeclarations(declarations, background) {
+		let ignore = false;
+		for (const decl of declarations) {
+			if ("comment" in decl) {
+				background = parseBackground(decl.comment) || background;
+				if (parseIgnore(decl.comment)) {
+					ignore = true;
+				}
+			} else if ("property" in decl) {
+				if (ignore) {
+					ignore = false;
+					continue;
+				}
+				if (decl.property !== "color") {
+					continue;
+				}
+
+				const line = `Line ${decl.position.start.line}`;
+
+				if (!background) {
+					errors.push(`${line}: There is no background defined for the color ${decl.value}.`);
+					continue;
+				}
+
+				const color = Color(decl.value);
+				const contrast = color.contrast(background);
+
+				if (contrast < 4.5 - 0.01 /* some epsilon for rounding errors */) {
+					const bg = `Background ${background.hex()}`;
+					const correctedColor = ensureContrast(color, background, 4.5);
+					const corrected = `${correctedColor.hex()} (${correctedColor.contrast(background).toFixed(2)})`;
+					errors.push(`${line}: ${bg}: The color ${decl.value} has a contrast of ${contrast.toFixed(2)} < 4.5. Use ${corrected} instead.`);
+				}
+			}
+		}
+	}
+
+	return errors;
+}
+
+/**
+ * @param {Color} color
+ * @param {Color} background
+ * @param {number} contrastGoal
+ * @returns {Color}
+ */
+function ensureContrast(color, background, contrastGoal) {
+	if (color.contrast(background) >= contrastGoal) {
+		return color.rgb();
+	}
+
+	color = color.lab();
+	const makeDarker = color.luminosity() < background.luminosity();
+	const ab = { a: color.object().a, b: color.object().b };
+
+	/** @type {number} */
+	let near = color.lab().object().l;
+	/** @type {number} */
+	let far = makeDarker ? 0 : 100;
+	while (Math.abs(near - far) > 0.00001) {
+		let middle = (near + far) / 2;
+		color = Color.lab({ l: middle, ...ab });
+
+		if (color.contrast(background) < contrastGoal) {
+			near = middle;
+		} else {
+			far = middle;
+		}
+	}
+
+	return color.rgb();
+}
+
+
+describe('Contrast', function () {
+
+	for (const theme in themes) {
+		if (theme === 'meta') {
+			continue;
+		}
+
+		const file = path.join(__dirname, `../themes/${theme}.css`);
+
+		it(`- ./themes/${theme}.css`, () => {
+			const source = fs.readFileSync(file, 'utf8');
+
+			const errors = analyseContrast(source);
+			if (errors.length > 0) {
+				assert.fail(`There are ${errors.length} contrast issues:\n\n` + errors.join('\n'));
+			}
+		});
+	}
+
+});

--- a/themes/prism-coy.css
+++ b/themes/prism-coy.css
@@ -4,6 +4,8 @@
  * @author Tim  Shedor
  */
 
+/* @contrast-background: #fdfdfd */
+
 code[class*="language-"],
 pre[class*="language-"] {
 	color: black;
@@ -141,6 +143,7 @@ pre[class*="language-"]:after {
 .token.entity,
 .token.url,
 .token.variable {
+	/* @contrast-background: white */
 	color: #a67f59;
 	background: rgba(255, 255, 255, 0.5);
 }
@@ -159,6 +162,7 @@ pre[class*="language-"]:after {
 
 .language-css .token.string,
 .style .token.string {
+	/* @contrast-background: white */
 	color: #a67f59;
 	background: rgba(255, 255, 255, 0.5);
 }
@@ -195,6 +199,7 @@ pre[class*="language-"]:after {
 .token.tab:not(:empty):before,
 .token.cr:before,
 .token.lf:before {
+	/* @contrast-ignore */
 	color: #e0d7d1;
 }
 

--- a/themes/prism-dark.css
+++ b/themes/prism-dark.css
@@ -4,6 +4,8 @@
  * @author Lea Verou
  */
 
+/* @contrast-background: hsl(30, 20%, 25%) */
+
 code[class*="language-"],
 pre[class*="language-"] {
 	color: white;

--- a/themes/prism-funky.css
+++ b/themes/prism-funky.css
@@ -4,6 +4,8 @@
  * @author Lea Verou
  */
 
+/* @contrast-background: black */
+
 code[class*="language-"],
 pre[class*="language-"] {
 	font-family: Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;

--- a/themes/prism-okaidia.css
+++ b/themes/prism-okaidia.css
@@ -4,6 +4,8 @@
  * @author ocodia
  */
 
+/* @contrast-background: #272822 */
+
 code[class*="language-"],
 pre[class*="language-"] {
 	color: #f8f8f2;

--- a/themes/prism-solarizedlight.css
+++ b/themes/prism-solarizedlight.css
@@ -28,6 +28,8 @@ cyan      #2aa198
 green     #859900
 */
 
+/* @contrast-background: #fdf6e3 */
+
 code[class*="language-"],
 pre[class*="language-"] {
 	color: #657b83; /* base00 */

--- a/themes/prism-tomorrow.css
+++ b/themes/prism-tomorrow.css
@@ -4,6 +4,8 @@
  * @author Rose Pritchard
  */
 
+/* @contrast-background: #2d2d2d */
+
 code[class*="language-"],
 pre[class*="language-"] {
 	color: #ccc;

--- a/themes/prism-twilight.css
+++ b/themes/prism-twilight.css
@@ -3,6 +3,9 @@
  * Based (more or less) on the Twilight theme originally of Textmate fame.
  * @author Remy Bach
  */
+
+/* @contrast-background: black */
+
 code[class*="language-"],
 pre[class*="language-"] {
 	color: white;

--- a/themes/prism.css
+++ b/themes/prism.css
@@ -4,6 +4,8 @@
  * @author Lea Verou
  */
 
+/* @contrast-background: white */
+
 code[class*="language-"],
 pre[class*="language-"] {
 	color: black;
@@ -74,6 +76,7 @@ pre[class*="language-"] {
 }
 
 .token.punctuation {
+	/* @contrast-ignore */
 	color: #999;
 }
 


### PR DESCRIPTION
This adds a new test to check the contrast of all colors against a background color. 

It works via checking all `color` properties against a fixed background color which is set via a comment for the current scope. The background color can be set for a whole file or just a specific rule. The whole file is processed from top to bottom, so it's also possible to override a background color within the scope. Example:

<details>

```css
/* @contrast-background: white */

.token.foo {
    color: white; /* this will not pass the check */
}

/* @contrast-background: black */

.token.foo {
    color: white; /* this will pass the check */
}
.token.bar {
    /* @contrast-ignore */
    color: black; /* this will be ignored */
}

@media (something) {
    /* Set the background color only within the @media rule.
     * @contrast-background: white 
     **/
    .token.bar {
        color: black; /* pass */
    }
}
```

</details>

The actual color checking is implemented using [color](https://www.npmjs.com/package/color) which conveniently can calculate the contrast for us and even supports LAB color mode.

For each low-contrast color, it will output the line of the low-contrast color, the contrast and a suggest color with the same hue but higher contrast (corrected in LAB color space). (The `ensureContrast` function)
That being said: I'm not a designer and have no idea about color, so if the correction might not be optimal.

---

I didn't fix any low-contrast colors as there are quite a few to fix.

Here's the current output of the test (only 2/8 themes pass):

<details>

```
  Contrast
    1) - ./themes/prism.css
    2) - ./themes/prism-dark.css
    √ - ./themes/prism-funky.css
    3) - ./themes/prism-okaidia.css
    √ - ./themes/prism-twilight.css
    4) - ./themes/prism-coy.css
    5) - ./themes/prism-solarizedlight.css
    6) - ./themes/prism-tomorrow.css


  2 passing (489ms)
  6 failing

  1) Contrast
       - ./themes/prism.css:
     AssertionError: There are 4 contrast issues:

Line 75: Background #FFFFFF: The color slategray has a contrast of 4.05 < 4.5. Use #697988 (4.50) instead.
Line 103: Background #FFFFFF: The color #690 has a contrast of 3.43 < 4.5. Use #508400 (4.50) instead.
Line 123: Background #FFFFFF: The color #DD4A68 has a contrast of 4.00 < 4.5. Use #D34060 (4.50) instead.
Line 129: Background #FFFFFF: The color #e90 has a contrast of 2.28 < 4.5. Use #AE6500 (4.50) instead.
      at Context.<anonymous> (tests\contrast-test.js:143:12)
      at processImmediate (internal/timers.js:456:21)

  2) Contrast
       - ./themes/prism-dark.css:
     AssertionError: There are 5 contrast issues:

Line 68: Background #4D4033: The color hsl(30, 20%, 50%) has a contrast of 2.69 < 4.5. Use #C4A98E (4.50) inst
Line 85: Background #4D4033: The color hsl(350, 40%, 70%) has a contrast of 4.04 < 4.5. Use #DB9DA7 (4.50) ins
Line 109: Background #4D4033: The color hsl(350, 40%, 70%) has a contrast of 4.04 < 4.5. Use #DB9DA7 (4.50) in
Line 114: Background #4D4033: The color #e90 has a contrast of 4.40 < 4.5. Use #F09B05 (4.50) instead.
Line 130: Background #4D4033: The color red has a contrast of 2.52 < 4.5. Use #FF9061 (4.50) instead.
      at Context.<anonymous> (tests\contrast-test.js:143:12)
      at processImmediate (internal/timers.js:456:21)

  3) Contrast
       - ./themes/prism-okaidia.css:
     AssertionError: There are 2 contrast issues:

Line 57: Background #272822: The color slategray has a contrast of 3.67 < 4.5. Use #7F8FA0 (4.50) instead.
Line 73: Background #272822: The color #f92672 has a contrast of 3.93 < 4.5. Use #FF4283 (4.50) instead.
      at Context.<anonymous> (tests\contrast-test.js:143:12)
      at processImmediate (internal/timers.js:456:21)

  4) Contrast
       - ./themes/prism-coy.css:
     AssertionError: There are 6 contrast issues:

Line 114: Background #FDFDFD: The color #7D8B99 has a contrast of 3.43 < 4.5. Use #697785 (4.50) instead.
Line 139: Background #FDFDFD: The color #2f9c0a has a contrast of 3.51 < 4.5. Use #0D8900 (4.50) instead.
Line 147: Background #FFFFFF: The color #a67f59 has a contrast of 3.62 < 4.5. Use #956F4A (4.50) instead.
Line 155: Background #FDFDFD: The color #1990b8 has a contrast of 3.61 < 4.5. Use #007FA6 (4.50) instead.
Line 160: Background #FDFDFD: The color #e90 has a contrast of 2.25 < 4.5. Use #AD6400 (4.50) instead.
Line 166: Background #FFFFFF: The color #a67f59 has a contrast of 3.62 < 4.5. Use #956F4A (4.50) instead.
      at Context.<anonymous> (tests\contrast-test.js:143:12)
      at processImmediate (internal/timers.js:456:21)

  5) Contrast
       - ./themes/prism-solarizedlight.css:
     AssertionError: There are 8 contrast issues:

Line 35: Background #FDF6E3: The color #657b83 has a contrast of 4.13 < 4.5. Use #5F757D (4.50) instead.
Line 89: Background #FDF6E3: The color #93a1a1 has a contrast of 2.48 < 4.5. Use #677474 (4.50) instead.
Line 107: Background #FDF6E3: The color #268bd2 has a contrast of 3.41 < 4.5. Use #0076BB (4.50) instead.
Line 117: Background #FDF6E3: The color #2aa198 has a contrast of 2.93 < 4.5. Use #007F77 (4.50) instead.
Line 121: Background #FDF6E3: The color #657b83 has a contrast of 4.13 < 4.5. Use #5F757D (4.50) instead.
Line 128: Background #FDF6E3: The color #859900 has a contrast of 2.97 < 4.5. Use #647A00 (4.50) instead.
Line 133: Background #FDF6E3: The color #b58900 has a contrast of 2.98 < 4.5. Use #926B00 (4.50) instead.
Line 139: Background #FDF6E3: The color #cb4b16 has a contrast of 4.27 < 4.5. Use #C64712 (4.50) instead.
      at Context.<anonymous> (tests\contrast-test.js:143:12)
      at processImmediate (internal/timers.js:456:21)

  6) Contrast
       - ./themes/prism-tomorrow.css:
     AssertionError: There are 2 contrast issues:

Line 72: Background #2D2D2D: The color #6196cc has a contrast of 4.42 < 4.5. Use #6297CD (4.50) instead.
Line 123: Background #2D2D2D: The color green has a contrast of 2.68 < 4.5. Use #42A832 (4.50) instead.
      at Context.<anonymous> (tests\contrast-test.js:143:12)
      at processImmediate (internal/timers.js:456:21)
```

</details>