### PR TITLE
Tests: Included `console` in VM context

### DIFF
--- a/tests/helper/prism-loader.js
+++ b/tests/helper/prism-loader.js
@@ -153,6 +153,9 @@ module.exports = {
 	 * @returns {*}
 	 */
 	runFileWithContext(fileSource, context = {}) {
+		// we don't have to pass our console but it's the only way these scripts can talk
+		// not supplying console here means that all references to `console` inside them will refer to a no-op console
+		context.console = console;
 		vm.runInNewContext(fileSource, context);
 		return context;
 	}


### PR DESCRIPTION
This includes the global `console` object into the VM context of every script. Scripts can now log text to the terminal which makes debugging and developing Prism Core. With this, you can just make some changes to `prism-core.js` that log what interests you, and run `npm run test:languages` or `npm run test:patterns` to log whatever you like for all languages.