### PR TITLE
Test: Always use components.json

### DIFF
--- a/tests/aliases-test.js
+++ b/tests/aliases-test.js
@@ -2,7 +2,7 @@
 
 const { assert } = require("chai");
 const PrismLoader = require('./helper/prism-loader');
-const { languages } = require('./../components');
+const { languages } = require('./../components.json');
 
 
 function toArray(value) {

--- a/tests/dependencies-test.js
+++ b/tests/dependencies-test.js
@@ -1,6 +1,6 @@
 const { assert } = require('chai');
 const getLoader = require('../dependencies');
-const components = require('../components');
+const components = require('../components.json');
 
 
 describe('Dependency logic', function () {

--- a/tests/helper/prism-loader.js
+++ b/tests/helper/prism-loader.js
@@ -48,7 +48,6 @@ module.exports = {
 
 		getLoader(components, languages, [...context.loaded]).load(id => {
 			if (!languagesCatalog[id]) {
-				// Maybe `components.js` is outdated?
 				throw new Error(`Language '${id}' not found.`);
 			}
 

--- a/tests/helper/prism-loader.js
+++ b/tests/helper/prism-loader.js
@@ -3,7 +3,7 @@
 const fs = require("fs");
 const vm = require("vm");
 const { getAllFiles } = require("./test-discovery");
-const components = require("../../components");
+const components = require("../../components.json");
 const getLoader = require("../../dependencies");
 const languagesCatalog = components.languages;
 
@@ -48,6 +48,7 @@ module.exports = {
 
 		getLoader(components, languages, [...context.loaded]).load(id => {
 			if (!languagesCatalog[id]) {
+				// Maybe `components.js` is outdated?
 				throw new Error(`Language '${id}' not found.`);
 			}
 

--- a/tests/pattern-tests.js
+++ b/tests/pattern-tests.js
@@ -3,7 +3,7 @@
 const { assert } = require('chai');
 const PrismLoader = require('./helper/prism-loader');
 const { BFS, parseRegex } = require('./helper/util');
-const { languages } = require('../components');
+const { languages } = require('../components.json');
 const { visitRegExpAST } = require('regexpp');
 
 


### PR DESCRIPTION
All test files now consistently import `components.json` instead of `components.js`. The JS file is generated and can be outdated. This can be annoying when you're adding a language.