### PR TITLE
Add ⍥ (Circle diaeresis/Hoof)

### DIFF
--- a/components/prism-apl.js
+++ b/components/prism-apl.js
@@ -17,7 +17,7 @@ Prism.languages.apl = {
 		alias: 'operator'
 	},
 	'dyadic-operator': {
-		pattern: /[.⍣⍠⍤∘⌸@⌺]/,
+		pattern: /[.⍣⍠⍤⍥∘⌸@⌺]/,
 		alias: 'operator'
 	},
 	'assignment': {


### PR DESCRIPTION
This symbol is used by Dyalog APL 18.0 which is just about to be released.