### PR TITLE
Tests: Always pretty-print token streams

### DIFF
--- a/test-suite.html
+++ b/test-suite.html
@@ -125,9 +125,8 @@ This is a comment explaining this test case.</code></pre>
 		<li>All strings that are either empty or only contain whitespace, are removed from the token stream.</li>
 		<li>All empty structures are removed.</li>
 	</ul>
-	<p>To get a pretty-printed version of the simplified token stream of a failed test, add the <code>--pretty</code> modifier. Keep in mind that the pretty-printed token stream is indented using spaces, you may need to convert these to tabs. (Most editors today have an option which handles the conversion for you.)</p>
 
-	<pre><code class="language-bash">npm run test:languages -- --pretty</code></pre>
+	<p>Note: The pretty-printed simplified token stream is indented using 4 spaces. You have to convert these to tabs after you copy-pasted the JSON. (Most editors today have an option that handles the conversion for you.)</p>
 
 	<p>For further information: reading the tests of the test runner (<code>tests/testrunner-tests.js</code>) will help you understand the transformation.</p>
 </section>

--- a/tests/helper/test-case.js
+++ b/tests/helper/test-case.js
@@ -49,9 +49,8 @@ module.exports = {
 	 *
 	 * @param {string} languageIdentifier
 	 * @param {string} filePath
-	 * @param {boolean} [pretty=false]
 	 */
-	runTestCase(languageIdentifier, filePath, pretty = false) {
+	runTestCase(languageIdentifier, filePath) {
 		const testCase = this.parseTestCaseFile(filePath);
 		const usedLanguages = this.parseLanguageNames(languageIdentifier);
 
@@ -79,7 +78,7 @@ module.exports = {
 		const columnNumber = expectedJsonLines.pop().length + 1;
 		const lineNumber = testCase.expectedLineOffset + expectedJsonLines.length;
 
-		const tokenStreamStr = pretty ? TokenStreamTransformer.prettyprint(simplifiedTokenStream) : actual;
+		const tokenStreamStr = TokenStreamTransformer.prettyprint(simplifiedTokenStream);
 		const message = "\n\nActual Token Stream:" +
 			"\n-----------------------------------------\n" +
 			tokenStreamStr +

--- a/tests/run.js
+++ b/tests/run.js
@@ -27,7 +27,7 @@ for (const language in testSuite) {
 
 				it("– should pass test case '" + fileName + "'", function () {
 					if (path.extname(filePath) === '.test') {
-						TestCase.runTestCase(language, filePath, true);
+						TestCase.runTestCase(language, filePath);
 					} else {
 						TestCase.runTestsWithHooks(language, require(filePath));
 					}

--- a/tests/run.js
+++ b/tests/run.js
@@ -11,7 +11,6 @@ const testSuite =
 		? TestDiscovery.loadSomeTests(__dirname + "/languages", argv.language)
 		// load complete test suite
 		: TestDiscovery.loadAllTests(__dirname + "/languages");
-const pretty = 'pretty' in argv;
 
 // define tests for all tests in all languages in the test suite
 for (const language in testSuite) {
@@ -28,7 +27,7 @@ for (const language in testSuite) {
 
 				it("– should pass test case '" + fileName + "'", function () {
 					if (path.extname(filePath) === '.test') {
-						TestCase.runTestCase(language, filePath, pretty);
+						TestCase.runTestCase(language, filePath, true);
 					} else {
 						TestCase.runTestsWithHooks(language, require(filePath));
 					}


### PR DESCRIPTION
When I added [pretty-printed token streams](https://github.com/PrismJS/prism/pull/1801), I made the feature opt-in because I thought that long token streams would cause long unwieldy logs. As it turns out, the diff mocha adds is much more of a hassle to scroll through and it seems like people don't know this feature exists (I see a lot of manually formatted token streams in PRs).

For these reasons, I made it so that token streams are now always pretty-printed. 
This should make it easier for contributors to write tests.