### PR TITLE
Tests: Fixed all type errors

### DIFF
--- a/tests/dependencies-test.js
+++ b/tests/dependencies-test.js
@@ -255,7 +255,7 @@ describe('components.json', function () {
 			// and an alias, so we force the lazy alias resolver to check all aliases
 			allIds.push('js');
 
-			getLoader(components, allIds).getIds();
+			getLoader(/** @type {any} */(components), allIds).getIds();
 		} catch (error) {
 			assert.fail(error.toString());
 		}

--- a/tests/helper/checks.js
+++ b/tests/helper/checks.js
@@ -9,6 +9,9 @@ function testFunction(name, object, tester) {
 	};
 }
 
+/**
+ * @param {import('../../components/prism-core')} Prism
+ */
 module.exports = (Prism) => {
 
 	function extendTest(id, redef) {

--- a/tests/helper/prism-loader.js
+++ b/tests/helper/prism-loader.js
@@ -16,7 +16,7 @@ const coreChecks = require('./checks');
 
 /** @type {Map<string, string>} */
 const fileSourceCache = new Map();
-/** @type {() => any} */
+/** @type {() => any | null} */
 let coreSupplierFunction = null;
 /** @type {Map<string, (Prism: any) => void>} */
 const languageCache = new Map();
@@ -53,7 +53,7 @@ module.exports = {
 			languages = [languages];
 		}
 
-		getLoader(components, languages, [...context.loaded]).load(id => {
+		getLoader(/** @type {any} */(components), languages, [...context.loaded]).load(id => {
 			if (!languagesCatalog[id]) {
 				throw new Error(`Language '${id}' not found.`);
 			}
@@ -79,7 +79,7 @@ module.exports = {
 	 * Creates a new empty prism instance
 	 *
 	 * @private
-	 * @returns {Prism}
+	 * @returns {import('../../components/prism-core')}
 	 */
 	createEmptyPrism() {
 		if (!coreSupplierFunction) {

--- a/tests/helper/test-case.js
+++ b/tests/helper/test-case.js
@@ -96,7 +96,7 @@ module.exports = {
 	 * @param {import('../../components/prism-core')} Prism The Prism instance which will tokenize `code`.
 	 * @param {string} code The code to tokenize.
 	 * @param {string} language The language id.
-	 * @returns {Array<string|Array<string|any[]>>}
+	 * @returns {import('./types').SimplifiedTokenStream}
 	 */
 	simpleTokenize(Prism, code, language) {
 		const env = {
@@ -120,7 +120,6 @@ module.exports = {
 	 * There should only be one language with an exclamation mark.
 	 *
 	 * @param {string} languageIdentifier
-	 *
 	 * @returns {{languages: string[], mainLanguage: string}}
 	 */
 	parseLanguageNames(languageIdentifier) {
@@ -160,7 +159,6 @@ module.exports = {
 	 *
 	 * @private
 	 * @param {string} filePath
-	 * @returns {{testSource: string, expectedTokenStream: Array<string[]>, comment:string?}|null}
 	 */
 	parseTestCaseFile(filePath) {
 		const testCaseSource = fs.readFileSync(filePath, "utf8");

--- a/tests/helper/test-discovery.js
+++ b/tests/helper/test-discovery.js
@@ -13,7 +13,7 @@ module.exports = {
 	 * @returns {Object<string, string[]>}
 	 */
 	loadAllTests(rootDir) {
-		/** @type {Object.<string, string[]>} */
+		/** @type {Object<string, string[]>} */
 		const testSuite = {};
 
 		for (const language of this.getAllDirectories(rootDir)) {
@@ -31,7 +31,7 @@ module.exports = {
 	 * @returns {Object<string, string[]>}
 	 */
 	loadSomeTests(rootDir, languages) {
-		/** @type {Object.<string, string[]>} */
+		/** @type {Object<string, string[]>} */
 		const testSuite = {};
 
 		for (const language of this.getSomeDirectories(rootDir, languages)) {

--- a/tests/helper/token-stream-transformer.js
+++ b/tests/helper/token-stream-transformer.js
@@ -54,7 +54,6 @@ module.exports = {
 	},
 
 	/**
-	 *
 	 * @param {Readonly<SimplifiedTokenStream>} tokenStream
 	 * @param {number} [indentationLevel]
 	 */

--- a/tests/helper/types.d.ts
+++ b/tests/helper/types.d.ts
@@ -1,0 +1,2 @@
+export type SimplifiedToken = [string, string | SimplifiedTokenStream];
+export type SimplifiedTokenStream = (string | SimplifiedToken)[];

--- a/tests/run.js
+++ b/tests/run.js
@@ -8,7 +8,7 @@ const { argv } = require("yargs");
 
 const testSuite =
 	(argv.language)
-		? TestDiscovery.loadSomeTests(__dirname + "/languages", argv.language)
+		? TestDiscovery.loadSomeTests(__dirname + "/languages", /** @type {any} */(argv.language))
 		// load complete test suite
 		: TestDiscovery.loadAllTests(__dirname + "/languages");
 

--- a/tests/testrunner-tests.js
+++ b/tests/testrunner-tests.js
@@ -7,12 +7,17 @@ const TestCase = require("./helper/test-case");
 
 describe("The token stream transformer", function () {
 
+	/**
+	 * @typedef {import('./helper/types').SimplifiedTokenStream} SimplifiedTokenStream
+	 */
+
 	it("should handle all kinds of simple transformations", function () {
 		const tokens = [
 			{ type: "type", content: "content" },
 			"string"
 		];
 
+		/** @type {SimplifiedTokenStream} */
 		const expected = [
 			["type", "content"],
 			"string"
@@ -37,6 +42,7 @@ describe("The token stream transformer", function () {
 			}
 		];
 
+		/** @type {SimplifiedTokenStream} */
 		const expected = [
 			["type", [
 				["insideType", [
@@ -57,6 +63,7 @@ describe("The token stream transformer", function () {
 			" "
 		];
 
+		/** @type {SimplifiedTokenStream} */
 		const expectedSimplified = [];
 
 		assert.deepEqual(TokenStreamTransformer.simplify(tokenStream), expectedSimplified);
@@ -76,6 +83,7 @@ describe("The token stream transformer", function () {
 			""
 		];
 
+		/** @type {SimplifiedTokenStream} */
 		const expectedSimplified = [
 			["type", [
 				["nested", []]
@@ -92,6 +100,7 @@ describe("The token stream transformer", function () {
 			{ type: "type", content: "content", alias: "alias" }
 		];
 
+		/** @type {SimplifiedTokenStream} */
 		const expectedSimplified = [
 			["type", "content"]
 		];


### PR DESCRIPTION
This fixes all type errors in our test files. I just added and changed comments, so no functional changes.

The most "controversial" part of this might be the `types.d.ts` file I added. Some types cannot be expressed in JSDoc, so I just added a small declaration file and imported the types I need from there.
(Btw. the feature not supported in JSDoc is recursive type definitions.)