### PR TITLE
Component module require fix

### DIFF
--- a/components/index.js
+++ b/components/index.js
@@ -36,13 +36,13 @@ function loadLanguages(languages) {
 			return;
 		}
 
-		const pathToLanguage = './prism-' + lang;
+		const pathToLanguage = '/prism-' + lang;
 
 		// remove from require cache and from Prism
 		delete require.cache[require.resolve(pathToLanguage)];
 		delete Prism.languages[lang];
 
-		require(pathToLanguage);
+		require("prismjs/components" + pathToLanguage);
 
 		loadedLanguages.add(lang);
 	});


### PR DESCRIPTION
The require function looks for the component modules relatively within the current directory `E.g: require("./prismjs/components/prism-java");`. This is not working with `create-react-app` as the dependency cannot be resolved properly. 

The fix modifies the require function to check for the module globally.