### PR TITLE
Excel formulas: recognize formula names with dots

### DIFF
--- a/components/prism-excel-formula.js
+++ b/components/prism-excel-formula.js
@@ -38,7 +38,7 @@ Prism.languages['excel-formula'] = {
 		}
 	},
 	'function-name': {
-		pattern: /\b[A-Z]\w*(?=\()/i,
+		pattern: /\b[A-Z][\w.]*(?=\()/i,
 		alias: 'keyword'
 	},
 	'range': {


### PR DESCRIPTION
If an Excel formula name has dots in it, only the part after the last dot was recognized