### PR TITLE
JSDoc: Fixed line ends

### DIFF
--- a/gulpfile.js/docs.js
+++ b/gulpfile.js/docs.js
@@ -45,7 +45,16 @@ function docsRemoveExcessFiles() {
 	return del(jsDoc.junk);
 }
 
-const docs = series(docsClean, docsCreate, docsRemoveExcessFiles, docsAddFavicon);
+function docsFixLineEnds(cb) {
+	// https://github.com/jsdoc/jsdoc/issues/1837
+	return pump([
+		src('docs/*.html'),
+		replace(/\r\n?|\n/g, '\n'),
+		dest('docs/')
+	], cb);
+}
+
+const docs = series(docsClean, docsCreate, docsRemoveExcessFiles, docsAddFavicon, docsFixLineEnds);
 
 module.exports = {
 	docs,


### PR DESCRIPTION
In [two](https://github.com/PrismJS/prism/pull/2505#discussion_r468180842) [recent](https://github.com/PrismJS/prism/pull/2520#discussion_r471158872) pull requests, we had [this issue](https://github.com/jsdoc/jsdoc/issues/1837).

This is a temporary fix to adjust the wrong line ends until the issue is fixed upstream.

I would like to merge this soon because it can really hinder contributors because is prevents the CI from passing (which is a requirement to merge any pull request).

@mAAdhaTTah 