### PR TITLE
Website: Fix typo on homepage by adding missing word "add"

### DIFF
--- a/index.html
+++ b/index.html
@@ -164,7 +164,7 @@ window.Prism.manual = true;
 
 	<p>In combination with CDNs, we recommend using the <a href="plugins/autoloader">Autoloader plugin</a> which automatically loads languages when necessary.</p>
 
-	<p>The setup of the Autoloader, will look like the following. You can also your own themes of course.</p>
+	<p>The setup of the Autoloader, will look like the following. You can also add your own themes of course.</p>
 
 	<pre><code>&lt;!DOCTYPE html>
 &lt;html>


### PR DESCRIPTION
Hello. I encountered this typo on [Line 167](https://github.com/PrismJS/prism/blob/master/index.html#L167) of the website homepage `index.html`. 

Before: 
- "You can also your own themes of course." - missing word "add".

After: 
- "You can also add your own themes of course." - proposed fix.