### PR TITLE
Added new Start Blogging 101 third-party tutorial which replaces former Crambler tutorial

### DIFF
--- a/index.html
+++ b/index.html
@@ -263,8 +263,8 @@ const html = Prism.highlight(code, Prism.languages.haml, 'haml');</code></pre>
 	<p>Several tutorials have been written by members of the community to help you integrate Prism into multiple different website types and configurations:</p>
 
 	<ul>
+		<li><a href="https://startblogging101.com/how-to-add-prism-js-syntax-highlighting-wordpress/">How to Add Prism.js Syntax Highlighting to Your WordPress Site</a></li>
 		<li><a href="https://websitebeaver.com/escape-html-inside-code-or-pre-tag-to-entities-to-display-raw-code-with-prismjs">Escape HTML Inside &lt;code&gt; or &lt;pre&gt; Tag to Entities to Display Raw Code with PrismJS</a></li>
-		<li><a href="http://crambler.com/how-to-implement-prism-js-syntax-highlighting-into-your-wordpress-site/">How To Implement Prism.js Syntax Highlighting Into Your WordPress Site</a></li>
 		<li><a href="http://wp.tutsplus.com/tutorials/plugins/adding-a-syntax-highlighter-shortcode-using-prism-js/">Adding a Syntax Highlighter Shortcode Using Prism.js | WPTuts+</a></li>
 		<li><a href="https://www.stramaxon.com/2012/07/prism-syntax-highlighter-for-blogger.html">Implement PrismJs Syntax Highlighting to your Blogger/BlogSpot</a></li>
 		<li><a href="https://schier.co/blog/2013/01/07/how-to-re-run-prismjs-on-ajax-content.html">How To Re-Run Prism.js On AJAX Content</a></li>


### PR DESCRIPTION
I reached out to Lea Verou and let her know that I completely revamped a former third-party tutorial that I wrote. The tutorial used to be located at https://crambler.com/how-to-implement-prism-js-syntax-highlighting-into-your-wordpress-site/ but you will see that I have it redirecting to a brand new site I built which is solely focused on WordPress. 

The new tutorial can be found at https://startblogging101.com/how-to-add-prism-js-syntax-highlighting-wordpress/

Lea gave me permission to swap out my old tutorial and place the new one in the first spot as it is the most up-to-date and detailed tutorial out there for implementing Prism JS using any WordPress theme. 

Thanks to all the contributors on this fantastic project! 