### PR TITLE
Fixed sorted language list test

### DIFF
--- a/tests/dependencies-test.js
+++ b/tests/dependencies-test.js
@@ -327,7 +327,7 @@ describe('components.json', function () {
 				return comp;
 			}
 			// a and b have the same intermediate form (e.g. "C" => "C", "C++" => "C", "C#" => "C").
-			a.title.toLowerCase().localeCompare(b.title.toLowerCase())
+			return a.title.toLowerCase().localeCompare(b.title.toLowerCase());
 		});
 
 		assert.sameOrderedMembers(languages, sorted);


### PR DESCRIPTION
Look who forget a `return` keyword: I did. I will just merge this after the tests pass.

The tests in #2622 failed because of this.