### PR TITLE
Fixed Danger CI for forks

### DIFF
--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -1,8 +1,7 @@
 name: Danger
 
-on: 
-  pull_request:
-    branches: [ master ]
+on:
+  pull_request_target:
 
 jobs:
   run:
@@ -13,6 +12,11 @@ jobs:
       - uses: actions/checkout@v1
         with:
           fetch-depth: 0
+      # create a new branch called pr from the remote PR branch
+      - run: git remote add pr_repo $PR_URL && git fetch pr_repo $PR_REF && git branch pr pr_repo/$PR_REF
+        env:
+          PR_URL: ${{github.event.pull_request.head.repo.clone_url}}
+          PR_REF: ${{github.event.pull_request.head.ref}}
       - run: npm ci
       - name: Danger
         run: npx danger ci


### PR DESCRIPTION
I think this fixes #2627.

The basic problem with Danger and forks is that Github doesn't give Danger access to big-boy stuff like making comments. This is for security reasons. Without this limitation, malicious parties could make a fork of any repo with GH actions and then have full access to the original repo by making a PR with changed workflows. They recently added [this](https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/) way around the limitation. 

`pull_request_target` makes it possible to write comments even for PRs from forks but is __less secure__. The basic idea is that the problem with PRs from forks is that we run untrusted code (that's why it only has read-only access). So, if we never checkout the PR code and instead run the workflow on the base branch, then we will only run trusted code. This means that we can't execute malicious code (at least not without downloading it ourselves).

Problem solved?
Not quite. Since we don't actually have the code of the PR, it's hard to implement anything CI-like (like linters, etc.). To work around this, I make a local branch of the PR but never check it out. The PR will only exist in git's storage. All interactions with the PR files will be through git. This means that we can get the file contents of the PR files but we can't execute them. This should make it secure to use (the workflow literally has full access to our repo, so it better be secure).

I also want to point out that `pull_request_target` has another problem. Since we never execute any files from PRs, it will hard to change the workflow and dangerfile in future PRs because we can only test them __after__ merging them into master. Not ideal. We will have to review changes to those files especially carefully.
(This is also the reason why there's no message for this PR.)

You can this approach work [here](https://github.com/RunDevelopment/DangerCITestSetup/pull/9).

One more thing. Existing PRs won't get a message either. The trigger seems to ignore them.