### PR TITLE
Line Highlight: Fixed print background color

### DIFF
--- a/plugins/line-highlight/prism-line-highlight.css
+++ b/plugins/line-highlight/prism-line-highlight.css
@@ -19,6 +19,17 @@ pre[data-line] {
 	white-space: pre;
 }
 
+@media print {
+	.line-highlight {
+		/*
+		 * This will prevent browsers from replacing the background color with white.
+		 * It's necessary because the element is layered on top of the displayed code.
+		 */
+		-webkit-print-color-adjust: exact;
+		color-adjust: exact;
+	}
+}
+
 	.line-highlight:before,
 	.line-highlight[data-end]:after {
 		content: attr(data-start);


### PR DESCRIPTION
This fixes #2666.

Browsers try to save ink when printing a page by replacing the background color of most elements with opaque white. This is a problem because the `.line-highlight` is layered above the displayed code which blocks its view.

The fix has been tested on Chrome and Firefox.

### Fixed example

![image](https://user-images.githubusercontent.com/20878432/101162406-9cb05a80-3632-11eb-8478-dfa876d9b3f9.png)
