### PR TITLE
Copy to clipboard: Fixed highlighting.

### DIFF
--- a/plugins/copy-to-clipboard/index.html
+++ b/plugins/copy-to-clipboard/index.html
@@ -14,7 +14,7 @@
 	<script>var _gaq = [['_setAccount', 'UA-33746269-1'], ['_trackPageview']];</script>
 	<script src="https://www.google-analytics.com/ga.js" async></script>
 </head>
-<body class="language-markup">
+<body>
 
 <header data-plugin-header="copy-to-clipboard"></header>
 


### PR DESCRIPTION
Highlighting didn't work because all JS code blocks on the site were declared as `markup`.