### PR TITLE
Be safe: encode ">" character too

### DIFF
--- a/components/prism-core.js
+++ b/components/prism-core.js
@@ -64,7 +64,7 @@ var _ = {
 			} else if (Array.isArray(tokens)) {
 				return tokens.map(encode);
 			} else {
-				return tokens.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/\u00a0/g, ' ');
+				return tokens.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/\u00a0/g, ' ');
 			}
 		},
 


### PR DESCRIPTION
Although standard says it is _Anything else_
https://www.w3.org/TR/html52/syntax.html#data-state

```html
<span class="token operator">></span>
```

... is valid HTML but looks misleading.