### PR TITLE
Dangerfile: Fixed how changed files are determined

### DIFF
--- a/dangerfile.js
+++ b/dangerfile.js
@@ -24,6 +24,25 @@ function readPRFile(path) {
 	return git.show([`pr:${path}`]);
 }
 
+/**
+ * Returns the relative paths of all files changed in the PR.
+ *
+ * @returns {Promise<string[]>}
+ */
+const getChangedFiles = async () => {
+	// Determine the merge base between master and the PR branch.
+	// If files changed in master since PR was branched they would show in the diff otherwise.
+	// https://stackoverflow.com/questions/25071579/list-all-files-changed-in-a-pull-request-in-git-github
+	const mergeBase = await git.raw(['merge-base', 'pr', 'HEAD']);
+	const result = await git.diff(['--name-only', '--no-renames', 'pr', mergeBase]);
+	return (result || '').split(/\r?\n/g);
+};
+
+const getChangedMinifiedFiles = async () => {
+	const changed = await getChangedFiles();
+	return changed.filter(file => file.endsWith('.min.js'));
+};
+
 // https://stackoverflow.com/questions/15900485/correct-way-to-convert-size-in-bytes-to-kb-mb-gb-in-javascript
 const formatBytes = (bytes, decimals = 2) => {
 	if (bytes === 0) return '0 Bytes';
@@ -63,11 +82,6 @@ const getSummary = (rows, totalMasterFileSize, totalFileSize) => {
 
 	return `A total of ${numFiles} file${maybeS} have changed, with a combined diff of ${byteDiff} (${percentDiff}).`;
 }
-
-const getChangedMinifiedFiles = async () => {
-	const result = await git.diff(['--name-only', '--no-renames', 'pr', 'HEAD']);
-	return (result || '').split(/\r?\n/g).filter(file => file.endsWith('.min.js'));
-};
 
 const run = async () => {
 	const minified = await getChangedMinifiedFiles();


### PR DESCRIPTION
I'm sure some of you noticed that the bundle size messages our bot procured sometimes contained files that were not changed in the current PR. This PR fixed that issue.

The cause of this problem was the `git diff` command. `git diff` simply returns a list of files that are different between two commits/branches. However, this is now what we want. The problem is that this did not account for commits added to master after the PR branch was branched off master. The solution is to find the proper merge base commit before diffing.

(I also moved up the function definition so it's closer to other git functions.)