### PR TITLE
Dangerfile: Trim merge base

### DIFF
--- a/dangerfile.js
+++ b/dangerfile.js
@@ -33,9 +33,9 @@ const getChangedFiles = async () => {
 	// Determine the merge base between master and the PR branch.
 	// If files changed in master since PR was branched they would show in the diff otherwise.
 	// https://stackoverflow.com/questions/25071579/list-all-files-changed-in-a-pull-request-in-git-github
-	const mergeBase = await git.raw(['merge-base', 'pr', 'HEAD']);
+	const mergeBase = (await git.raw(['merge-base', 'pr', 'HEAD'])).trim();
 	const result = await git.diff(['--name-only', '--no-renames', 'pr', mergeBase]);
-	return (result || '').split(/\r?\n/g);
+	return (result || '').trim().split(/\r?\n/g);
 };
 
 const getChangedMinifiedFiles = async () => {


### PR DESCRIPTION
I made a mistake in #2757. The merge base commit returned by git is followed by an extra newline character. I didn't catch this while testing and it caused the CI in #2759 to fail. 

The solution is to simply trim the extra newline character. I also trimmed the output of another git command for safety.

---

I will immediately merge this.