### PR TITLE
Added link to Q&A to issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,4 @@
+contact_links:
+    - name: Questions and Help
+      url: https://github.com/PrismJS/prism/discussions/categories/q-a
+      about: This issue tracker is not for support questions. Please refer to the Prism's Discussion tab.


### PR DESCRIPTION
People that have a question and want to create a new issue will now be referred to our discussions tab. This should help to separate issues from questions.
