### PR TITLE
ESLint: Added `root` to config to prevent warning

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,5 +1,6 @@
 /** @type {import('eslint').Linter.Config} */
 module.exports = {
+	root: true,
 	extends: 'eslint:recommended',
 	rules: {
 		// I turned this rule off because we use `hasOwnProperty` in a lot of places


### PR DESCRIPTION
In #2831, I forgot to add the `root: true` property to the config. This resulted in a warning being logged every time ESLint was run.

```
(node:15456) [ESLINT_PERSONAL_CONFIG_SUPPRESS] DeprecationWarning: '~/.eslintrc.*' config files have been deprecated. Please remove it or add 'root:true' to the config files in your projects in order to avoid loading '~/.eslintrc.*' accidentally. (found in "..\..\.eslintrc")
```

This was a simple mistake and this is a simple fix. I will merge this immediately as the warning is quite annoying and the fix is quite simple.