### PR TITLE
Tests: Fixed polynomial backtracking test

### DIFF
--- a/tests/helper/util.js
+++ b/tests/helper/util.js
@@ -9,7 +9,7 @@ const { RegExpParser } = require('regexpp');
  */
 
 
-const parser = new RegExpParser({ strict: false, ecmaVersion: 5 });
+const parser = new RegExpParser();
 /** @type {Map<string, LiteralAST>} */
 const astCache = new Map();
 


### PR DESCRIPTION
Before this fix, parsing a regex required the regex the be a valid ES5 regex. This used to be fine as only language definition regexes were parsed but this changed recently with #2688. Now, all regexes and regex usages are tested. This makes everything safe but introduced a new problem.

When using `"str".split(/regex/)`, the JS engine will create a temporary new regex [with the `y` flag added](https://tc39.es/ecma262/#sec-regexp.prototype-@@split). Obviously, the `y` flag isn't valid in ES5, so our backtracking tests fail for seemingly no reason. 

The fix is simple: allow regexes of later JS versions.

I will immediately merge this because this blocks #2885.