### PR TITLE
Set dummy domain for CDN

### DIFF
--- a/index.html
+++ b/index.html
@@ -193,12 +193,12 @@ window.Prism.manual = true;
 &lt;html>
 &lt;head>
 	...</code>
-	<code class="highlight">&lt;link href="https://myCDN.com/prism@v1.x/themes/prism.css" rel="stylesheet" /></code>
+	<code class="highlight">&lt;link href="https://my.cdn/prism@v1.x/themes/prism.css" rel="stylesheet" /></code>
 <code>&lt;/head>
 &lt;body>
 	...</code>
-<code class="highlight" style="display: inline-block; outline-offset: .2em; margin-bottom: .2em;">	&lt;script src="https://myCDN.com/prism@v1.x/components/prism-core.min.js"&gt;&lt;/script&gt;
-	&lt;script src="https://myCDN.com/prism@v1.x/plugins/autoloader/prism-autoloader.min.js"&gt;&lt;/script&gt;</code>
+<code class="highlight" style="display: inline-block; outline-offset: .2em; margin-bottom: .2em;">	&lt;script src="https://my.cdn/prism@v1.x/components/prism-core.min.js"&gt;&lt;/script&gt;
+	&lt;script src="https://my.cdn/prism@v1.x/plugins/autoloader/prism-autoloader.min.js"&gt;&lt;/script&gt;</code>
 <code>&lt;/body>
 &lt;/html></code></pre>
 


### PR DESCRIPTION
The goal here is to provide a placeholder for the CDN, not link to an actual
CDN, so let's replace it with a dummy domain that doesn't work.