### PR TITLE
Replace my.cdn in code sample with example.com

### DIFF
--- a/index.html
+++ b/index.html
@@ -188,20 +188,20 @@ window.Prism.manual = true;
 	<p>In combination with CDNs, we recommend using the <a href="plugins/autoloader">Autoloader plugin</a> which automatically loads languages when necessary.</p>
 
 	<p>The setup of the Autoloader, will look like the following. You can also add your own themes of course.</p>
-		
+
 	<pre><code>&lt;!DOCTYPE html>
 &lt;html>
 &lt;head>
 	...</code>
-	<code class="highlight">&lt;link href="https://example.com/prism@v1.x/themes/prism.css" rel="stylesheet" /></code>
+	<code class="highlight">&lt;link href="https://{{cdn}}/prism@v1.x/themes/prism.css" rel="stylesheet" /></code>
 <code>&lt;/head>
 &lt;body>
 	...</code>
-<code class="highlight" style="display: inline-block; outline-offset: .2em; margin-bottom: .2em;">	&lt;script src="https://example.com/prism@v1.x/components/prism-core.min.js"&gt;&lt;/script&gt;
-	&lt;script src="https://example.com/prism@v1.x/plugins/autoloader/prism-autoloader.min.js"&gt;&lt;/script&gt;</code>
+<code class="highlight" style="display: inline-block; outline-offset: .2em; margin-bottom: .2em;">	&lt;script src="https://{{cdn}}/prism@v1.x/components/prism-core.min.js"&gt;&lt;/script&gt;
+	&lt;script src="https://{{cdn}}/prism@v1.x/plugins/autoloader/prism-autoloader.min.js"&gt;&lt;/script&gt;</code>
 <code>&lt;/body>
 &lt;/html></code></pre>
-	
+
 	<p>Please note that links in the above code sample serves as a placeholder. You would have to replace them with valid links to CDNs of your choice.</p>
 	
 	<p>CDNs which provide PrismJS are e.g. <a href="https://cdnjs.com/libraries/prism">cdnjs</a>, <a href="https://www.jsdelivr.com/package/npm/prismjs">jsDelivr</a>, and <a href="https://unpkg.com/browse/prismjs@1/">UNPKG</a>.</p>

--- a/index.html
+++ b/index.html
@@ -202,7 +202,7 @@ window.Prism.manual = true;
 <code>&lt;/body>
 &lt;/html></code></pre>
 
-	<p>Please note that links in the above code sample serves as a placeholder. You would have to replace them with valid links to CDNs of your choice.</p>
+	<p>Please note that links in the above code sample serve as placeholders. You have to replace them with valid links to the CDN of your choice.</p>
 	
 	<p>CDNs which provide PrismJS are e.g. <a href="https://cdnjs.com/libraries/prism">cdnjs</a>, <a href="https://www.jsdelivr.com/package/npm/prismjs">jsDelivr</a>, and <a href="https://unpkg.com/browse/prismjs@1/">UNPKG</a>.</p>
 

--- a/index.html
+++ b/index.html
@@ -188,20 +188,22 @@ window.Prism.manual = true;
 	<p>In combination with CDNs, we recommend using the <a href="plugins/autoloader">Autoloader plugin</a> which automatically loads languages when necessary.</p>
 
 	<p>The setup of the Autoloader, will look like the following. You can also add your own themes of course.</p>
-
+		
 	<pre><code>&lt;!DOCTYPE html>
 &lt;html>
 &lt;head>
 	...</code>
-	<code class="highlight">&lt;link href="https://my.cdn/prism@v1.x/themes/prism.css" rel="stylesheet" /></code>
+	<code class="highlight">&lt;link href="https://example.com/prism@v1.x/themes/prism.css" rel="stylesheet" /></code>
 <code>&lt;/head>
 &lt;body>
 	...</code>
-<code class="highlight" style="display: inline-block; outline-offset: .2em; margin-bottom: .2em;">	&lt;script src="https://my.cdn/prism@v1.x/components/prism-core.min.js"&gt;&lt;/script&gt;
-	&lt;script src="https://my.cdn/prism@v1.x/plugins/autoloader/prism-autoloader.min.js"&gt;&lt;/script&gt;</code>
+<code class="highlight" style="display: inline-block; outline-offset: .2em; margin-bottom: .2em;">	&lt;script src="https://example.com/prism@v1.x/components/prism-core.min.js"&gt;&lt;/script&gt;
+	&lt;script src="https://example.com/prism@v1.x/plugins/autoloader/prism-autoloader.min.js"&gt;&lt;/script&gt;</code>
 <code>&lt;/body>
 &lt;/html></code></pre>
-
+	
+	<p>Please note that links in the above code sample serves as a placeholder. You would have to replace them with valid links to CDNs of your choice.</p>
+	
 	<p>CDNs which provide PrismJS are e.g. <a href="https://cdnjs.com/libraries/prism">cdnjs</a>, <a href="https://www.jsdelivr.com/package/npm/prismjs">jsDelivr</a>, and <a href="https://unpkg.com/browse/prismjs@1/">UNPKG</a>.</p>
 
 	<h2 id="basic-usage-bundlers">Usage with Webpack, Browserify, & Other Bundlers</h2>


### PR DESCRIPTION
The code samples in [Usage with CDN](https://prismjs.com/#basic-usage-cdn) is not clear enough. One might copy paste it and expect to work. Which would not, since the links are placeholders and needs to be replaced with actual entries from CDN.

This PR aims to make it little more obvious that, they are example links.

I used example.com because,
- It is a reserved domain for such cases, [more info in this wiki page](https://en.wikipedia.org/wiki/Example.com).
- It would provide a nice feedback to the user while reading the code it self.
- Visiting the  urls won't result in an error, and give a page stating that it is used for example purpose.

As a bonus, am wondering if this also future proofs it, in case somebody do register my.cdn and use the link for malicious purpose.