### PR TITLE
Updated `eslint-plugin-regexp`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2329,16 +2329,16 @@
       }
     },
     "eslint-plugin-regexp": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-regexp/-/eslint-plugin-regexp-0.11.0.tgz",
-      "integrity": "sha512-+I/iCVkdjRRG+EPnw+hdbh1daNGkeiwEhPQuwM2AMOxvOuuI2nvjjg3PIPsdWsrVzUOzY0d7boLlSmFR7Z7G/Q==",
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-regexp/-/eslint-plugin-regexp-0.12.1.tgz",
+      "integrity": "sha512-kALWA1C1O/8kxLB42ypK9ildKydilhfaF2i/cSL3mvSVODgjumn9ILsfdkOpkZwjruioSn89Oe24M5tBXTU3kw==",
       "dev": true,
       "requires": {
         "comment-parser": "^1.1.2",
         "eslint-utils": "^3.0.0",
         "jsdoctypeparser": "^9.0.0",
         "refa": "^0.8.0",
-        "regexp-ast-analysis": "^0.2.0",
+        "regexp-ast-analysis": "^0.2.2",
         "regexpp": "^3.1.0"
       },
       "dependencies": {
@@ -2349,6 +2349,16 @@
           "dev": true,
           "requires": {
             "eslint-visitor-keys": "^2.0.0"
+          }
+        },
+        "regexp-ast-analysis": {
+          "version": "0.2.2",
+          "resolved": "https://registry.npmjs.org/regexp-ast-analysis/-/regexp-ast-analysis-0.2.2.tgz",
+          "integrity": "sha512-inLIbwizLLAZkpC9/8zp8CeSkJJPsRaqXGDVpxEbNRZD10E+OP6vRDHt7OS9JjWECQLvOI2EmHx7DgdpyAvdrQ==",
+          "dev": true,
+          "requires": {
+            "refa": "^0.8.0",
+            "regexpp": "^3.1.0"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "docdash": "^1.2.0",
     "eslint": "^7.22.0",
     "eslint-plugin-jsdoc": "^32.3.0",
-    "eslint-plugin-regexp": "^0.11.0",
+    "eslint-plugin-regexp": "^0.12.1",
     "gulp": "^4.0.2",
     "gulp-concat": "^2.3.4",
     "gulp-header": "^2.0.7",


### PR DESCRIPTION
This updates the regexp ESLint to the latest version.

I'll just merge after CI passes because I want to make PRs based on the new rules added in v0.12.0.