### PR TITLE
check existence of document: static site generator breaking on nested code blocks

### DIFF
--- a/components/prism-markdown.js
+++ b/components/prism-markdown.js
@@ -351,11 +351,13 @@
 			}
 		} else {
 			// get the textContent of the given env HTML
-			var tempContainer = document.createElement('div');
-			tempContainer.innerHTML = env.content;
-			var code = tempContainer.textContent;
+			if (typeof document !== 'undefined') {
+				var tempContainer = document.createElement('div');
+				tempContainer.innerHTML = env.content;
+				var code = tempContainer.textContent;
 
-			env.content = Prism.highlight(code, grammar, codeLang);
+				env.content = Prism.highlight(code, grammar, codeLang);
+			}
 		}
 	});
 


### PR DESCRIPTION
I don't understand exactly what would have changed, but recently the `gridsome` static site generator started breaking when processing nested syntax code blocks. This presumably occurred with the latest release.

It can be fixed by adding a check for whether `document` exists in the current context.

See:
https://github.com/PrismJS/prism/issues/2976
https://github.com/gridsome/gridsome/issues/1524