### PR TITLE
Toolbar: Fixed styles being applies to nested elements

### DIFF
--- a/plugins/toolbar/prism-toolbar.css
+++ b/plugins/toolbar/prism-toolbar.css
@@ -20,15 +20,15 @@ div.code-toolbar:focus-within > .toolbar {
 	opacity: 1;
 }
 
-div.code-toolbar > .toolbar .toolbar-item {
+div.code-toolbar > .toolbar > .toolbar-item {
 	display: inline-block;
 }
 
-div.code-toolbar > .toolbar a {
+div.code-toolbar > .toolbar > .toolbar-item > a {
 	cursor: pointer;
 }
 
-div.code-toolbar > .toolbar button {
+div.code-toolbar > .toolbar > .toolbar-item > button {
 	background: none;
 	border: 0;
 	color: inherit;
@@ -41,9 +41,9 @@ div.code-toolbar > .toolbar button {
 	-ms-user-select: none;
 }
 
-div.code-toolbar > .toolbar a,
-div.code-toolbar > .toolbar button,
-div.code-toolbar > .toolbar span {
+div.code-toolbar > .toolbar > .toolbar-item > a,
+div.code-toolbar > .toolbar > .toolbar-item > button,
+div.code-toolbar > .toolbar > .toolbar-item > span {
 	color: #bbb;
 	font-size: .8em;
 	padding: 0 .5em;
@@ -53,12 +53,12 @@ div.code-toolbar > .toolbar span {
 	border-radius: .5em;
 }
 
-div.code-toolbar > .toolbar a:hover,
-div.code-toolbar > .toolbar a:focus,
-div.code-toolbar > .toolbar button:hover,
-div.code-toolbar > .toolbar button:focus,
-div.code-toolbar > .toolbar span:hover,
-div.code-toolbar > .toolbar span:focus {
+div.code-toolbar > .toolbar > .toolbar-item > a:hover,
+div.code-toolbar > .toolbar > .toolbar-item > a:focus,
+div.code-toolbar > .toolbar > .toolbar-item > button:hover,
+div.code-toolbar > .toolbar > .toolbar-item > button:focus,
+div.code-toolbar > .toolbar > .toolbar-item > span:hover,
+div.code-toolbar > .toolbar > .toolbar-item > span:focus {
 	color: inherit;
 	text-decoration: none;
 }


### PR DESCRIPTION
This fixes #2974.

The problem was that Toolbar's styles didn't expect toolbar items to have child elements. This is a problem because #2789 added a child element to Copy-to-Clipboard's `<button>`. So the styles got applied to both:

![image](https://user-images.githubusercontent.com/20878432/124288578-9f841700-db51-11eb-859c-d3b077086335.png)

This fix is pretty simple. I just added a few `>`s to the selectors and that's it. All styles for items now only get applied to the direct children (typically there's only one) of the `div.toolbar-item` wrappers.

![image](https://user-images.githubusercontent.com/20878432/124288861-f1c53800-db51-11eb-80ae-43c882f22b14.png)
