### PR TITLE
Update refa, regexpp, and scslre

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2351,6 +2351,15 @@
             "eslint-visitor-keys": "^2.0.0"
           }
         },
+        "refa": {
+          "version": "0.8.0",
+          "resolved": "https://registry.npmjs.org/refa/-/refa-0.8.0.tgz",
+          "integrity": "sha512-qOf9zk1McAuGPtQ16nzuWCUg9zx3Quc48i6oD6nxWJdrFeh3Do0vCpIGYLij/1ysAbh5rxdUNg+YzSVBRycX5g==",
+          "dev": true,
+          "requires": {
+            "regexpp": "^3.1.0"
+          }
+        },
         "regexp-ast-analysis": {
           "version": "0.2.2",
           "resolved": "https://registry.npmjs.org/regexp-ast-analysis/-/regexp-ast-analysis-0.2.2.tgz",
@@ -6199,12 +6208,12 @@
       }
     },
     "refa": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/refa/-/refa-0.8.0.tgz",
-      "integrity": "sha512-qOf9zk1McAuGPtQ16nzuWCUg9zx3Quc48i6oD6nxWJdrFeh3Do0vCpIGYLij/1ysAbh5rxdUNg+YzSVBRycX5g==",
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/refa/-/refa-0.9.1.tgz",
+      "integrity": "sha512-egU8LgFq2VXlAfUi8Jcbr5X38wEOadMFf8tCbshgcpVCYlE7k84pJOSlnvXF+muDB4igkdVMq7Z/kiNPqDT9TA==",
       "dev": true,
       "requires": {
-        "regexpp": "^3.1.0"
+        "regexpp": "^3.2.0"
       }
     },
     "regenerator-runtime": {
@@ -6224,19 +6233,19 @@
       }
     },
     "regexp-ast-analysis": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/regexp-ast-analysis/-/regexp-ast-analysis-0.2.0.tgz",
-      "integrity": "sha512-ZVNwBF65Gn4CbRdPNYle8NAPFSDbbJ83svYUk4Mpqmr1QTUx2M06my9x7o8Hw/oFXDwXrJo/7W+ijLfFM5oG2Q==",
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/regexp-ast-analysis/-/regexp-ast-analysis-0.2.4.tgz",
+      "integrity": "sha512-8L7kOZQaKPxKKAwGuUZxTQtlO3WZ+tiXy4s6G6PKL6trbOXcZoumwC3AOHHFtI/xoSbNxt7jgLvCnP1UADLWqg==",
       "dev": true,
       "requires": {
-        "refa": "^0.8.0",
-        "regexpp": "^3.1.0"
+        "refa": "^0.9.0",
+        "regexpp": "^3.2.0"
       }
     },
     "regexpp": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.1.0.tgz",
-      "integrity": "sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
+      "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
       "dev": true
     },
     "regextras": {
@@ -6537,14 +6546,14 @@
       }
     },
     "scslre": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/scslre/-/scslre-0.1.3.tgz",
-      "integrity": "sha512-bJLnVqL3J3j+IwQGcOD81Ze2qdNH8IrjKz07MsxGV0EUE/OmlrFqfKHFUSUUkwefMwzZrGbuNlfQEDN9U9+a3A==",
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/scslre/-/scslre-0.1.6.tgz",
+      "integrity": "sha512-JORxVRlQTfjvlOAaiQKebgFElyAm5/W8b50lgaZ0OkEnKnagJW2ufDh3xRfU75UD9z3FGIu1gL1IyR3Poa6Qmw==",
       "dev": true,
       "requires": {
-        "refa": "^0.8.0",
-        "regexp-ast-analysis": "^0.2.0",
-        "regexpp": "^3.1.0"
+        "refa": "^0.9.0",
+        "regexp-ast-analysis": "^0.2.3",
+        "regexpp": "^3.2.0"
       }
     },
     "secure-compare": {

--- a/package.json
+++ b/package.json
@@ -54,9 +54,9 @@
     "mocha": "^6.2.0",
     "npm-run-all": "^4.1.5",
     "pump": "^3.0.0",
-    "refa": "^0.8.0",
-    "regexpp": "^3.1.0",
-    "scslre": "^0.1.3",
+    "refa": "^0.9.1",
+    "regexpp": "^3.2.0",
+    "scslre": "^0.1.6",
     "simple-git": "^1.107.0",
     "webfont": "^9.0.0",
     "yargs": "^13.2.2"


### PR DESCRIPTION
There have been some improvements and fixes in refa, regexpp, scslre, and regexp-ast-analysis. 

One of the improvements is that scslre has better support for word boundary assertions, so it can now potentially find more cases of polynomial backtracking. However, (luckily) it didn't.