### PR TITLE
Ensure Previewers popup is visible across themes

### DIFF
--- a/plugins/previewers/prism-previewers.css
+++ b/plugins/previewers/prism-previewers.css
@@ -13,6 +13,7 @@
 	width: 32px;
 	height: 32px;
 	margin-left: -16px;
+	z-index: 10;
 
 	opacity: 0;
 	-webkit-transition: opacity .25s;


### PR DESCRIPTION
Some themes set a positive z-index for some of their parts, such as the `.token`s in Twilight. This makes the Previewers popup appear underneath the code, which is silly. This PR sets a higher z-index for the popup itself (10), so theme creators can still play around with z-index in their themes, without obscuring the popup if the Previewers plugin were to be used.

This closes #3074.