### PR TITLE
Increase selector specificities of plugin overrides in Twilight theme

### DIFF
--- a/themes/prism-twilight.css
+++ b/themes/prism-twilight.css
@@ -140,11 +140,6 @@ code[class*="language-"]::selection, code[class*="language-"] ::selection {
 	cursor: help;
 }
 
-pre[data-line] {
-	padding: 1em 0 1em 3em;
-	position: relative;
-}
-
 /* Markup */
 .language-markup .token.tag,
 .language-markup .token.attr-name,

--- a/themes/prism-twilight.css
+++ b/themes/prism-twilight.css
@@ -158,42 +158,17 @@ pre[data-line] {
 	z-index: 1;
 }
 
-.line-highlight {
+.line-highlight.line-highlight {
 	background: hsla(0, 0%, 33%, 0.25); /* #545454 */
 	background: linear-gradient(to right, hsla(0, 0%, 33%, .1) 70%, hsla(0, 0%, 33%, 0)); /* #545454 */
 	border-bottom: 1px dashed hsl(0, 0%, 33%); /* #545454 */
 	border-top: 1px dashed hsl(0, 0%, 33%); /* #545454 */
-	left: 0;
-	line-height: inherit;
 	margin-top: 0.75em; /* Same as .prism’s padding-top */
-	padding: inherit 0;
-	pointer-events: none;
-	position: absolute;
-	right: 0;
-	white-space: pre;
 	z-index: 0;
 }
 
-.line-highlight:before,
-.line-highlight[data-end]:after {
+.line-highlight.line-highlight:before,
+.line-highlight.line-highlight[data-end]:after {
 	background-color: hsl(215, 15%, 59%); /* #8794A6 */
-	border-radius: 999px;
-	box-shadow: 0 1px white;
 	color: hsl(24, 20%, 95%); /* #F5F2F0 */
-	content: attr(data-start);
-	font: bold 65%/1.5 sans-serif;
-	left: .6em;
-	min-width: 1em;
-	padding: 0 .5em;
-	position: absolute;
-	text-align: center;
-	text-shadow: none;
-	top: .4em;
-	vertical-align: .3em;
-}
-
-.line-highlight[data-end]:after {
-	bottom: .4em;
-	content: attr(data-end);
-	top: auto;
 }


### PR DESCRIPTION
Prompted by https://github.com/PrismJS/prism-themes/pull/141. Also removes redeclared properties, those that are the same as those in the plugins' default stylesheets.