### PR TITLE
Update `eslint-plugin-regexp@1.2.0`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2371,16 +2371,17 @@
       }
     },
     "eslint-plugin-regexp": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-regexp/-/eslint-plugin-regexp-1.0.0.tgz",
-      "integrity": "sha512-TwNkkDS+Q5+gEaUTgEYEJzP5P8Y6c/UGxJkUsg6oc/DBWGT/5VJqCw0xhx/hhFT/HgfdABngTWKBBwtqTbjGuQ==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-regexp/-/eslint-plugin-regexp-1.2.0.tgz",
+      "integrity": "sha512-yHn5D8jTmT1gmPA4Dj2ut0aGg03CkgvpKu3kG/CEQ1OcUmkoykZsiXCysaENpq/BXs60WEpz+tN2n/h4lp+Q0Q==",
       "dev": true,
       "requires": {
         "comment-parser": "^1.1.2",
         "eslint-utils": "^3.0.0",
+        "grapheme-splitter": "^1.0.4",
         "jsdoctypeparser": "^9.0.0",
         "refa": "^0.9.0",
-        "regexp-ast-analysis": "^0.2.4",
+        "regexp-ast-analysis": "^0.3.0",
         "regexpp": "^3.2.0",
         "scslre": "^0.1.6"
       },
@@ -2392,6 +2393,16 @@
           "dev": true,
           "requires": {
             "eslint-visitor-keys": "^2.0.0"
+          }
+        },
+        "regexp-ast-analysis": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/regexp-ast-analysis/-/regexp-ast-analysis-0.3.0.tgz",
+          "integrity": "sha512-11PlbBSUxwWpdj6BdZUKfhDdV9g+cveqHB+BqBQDBD7ZermDBVgtyowUaXTvT0dO3tZYo2bDIr/GoED6X1aYSA==",
+          "dev": true,
+          "requires": {
+            "refa": "^0.9.0",
+            "regexpp": "^3.2.0"
           }
         }
       }
@@ -3236,6 +3247,12 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
       "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
+      "dev": true
+    },
+    "grapheme-splitter": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
+      "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
       "dev": true
     },
     "growl": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "docdash": "^1.2.0",
     "eslint": "^7.22.0",
     "eslint-plugin-jsdoc": "^32.3.0",
-    "eslint-plugin-regexp": "^1.0.0",
+    "eslint-plugin-regexp": "^1.2.0",
     "gulp": "^4.0.2",
     "gulp-concat": "^2.3.4",
     "gulp-header": "^2.0.7",


### PR DESCRIPTION
There have been a bunch of improvements since v1.0.0. 

Especially important are the improvements to `sort-alternatives`. I was finally able to iron out its last flaws (until new ones are found). The rule can now finally be used in Prism.