### PR TITLE
Website: Updated plugin header template

### DIFF
--- a/assets/templates/header-main.html
+++ b/assets/templates/header-main.html
@@ -4,7 +4,7 @@
 
 <p>
 	Prism is a lightweight, extensible syntax highlighter, built with modern web standards in mind.
- 	It’s used in millions of websites, including some of those you visit daily.
+	It’s used in millions of websites, including some of those you visit daily.
 </p>
 
 <!--<a href="https://twitter.com/share" class="twitter-share-button" data-via="prismjs" data-size="large" data-related="LeaVerou">Tweet</a>

--- a/assets/templates/header-plugins.html
+++ b/assets/templates/header-plugins.html
@@ -4,5 +4,5 @@
 
 <p>
 	Prism is a lightweight, extensible syntax highlighter, built with modern web standards in mind.
- 	It’s used in thousands of websites, including some of those you visit daily.
+	It’s used in millions of websites, including some of those you visit daily.
 </p>


### PR DESCRIPTION
I noticed that 9f82de508dab4944e0b11524fe95f07beaa5b83f only changed `header-main.html` but not `header-plugin.html` which contains the same text.

I also removed the single space before the tabs.

![image](https://user-images.githubusercontent.com/20878432/136655315-68c9670d-3c4c-4bc1-8167-f7cee0caf77c.png)
