### PR TITLE
Website: Adjusted TOC's line height for better readability

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -364,6 +364,12 @@ footer {
 
 	#toc li {
 		list-style: none;
+		line-height: 1.2;
+		padding: .2em 0;
+	}
+
+	#toc li a {
+		padding: .2em 0;
 	}
 
 #logo:before {


### PR DESCRIPTION
This adjusts the TOC's line height for better readability on smaller screens:

Before:
![image](https://user-images.githubusercontent.com/20878432/136656102-6a535e94-c69a-4997-8ab7-a7e7eec22c92.png)

After:
![image](https://user-images.githubusercontent.com/20878432/136656097-64c5505c-9f8c-4e04-add5-839d6e9840ab.png)
