### PR TITLE
Website: Repositioned theme selector

### DIFF
--- a/assets/code.js
+++ b/assets/code.js
@@ -244,27 +244,4 @@ var setTheme;
 
 	$$('.plugin-list').forEach(listPlugins);
 
-	// small polyfill for Element#matches
-	if (!Element.prototype.matches) {
-		Element.prototype.matches = Element.prototype.msMatchesSelector || Element.prototype.webkitMatchesSelector;
-	}
-
-	Prism && Prism.hooks.add('complete', function (env) {
-		var element = env.element;
-
-		requestAnimationFrame(function () {
-			if (!element.matches('div.code-toolbar > pre > code')) {
-				return;
-			}
-
-			var pre = element.parentElement;
-			var wrapper = pre.parentElement;
-
-			// transfer margin of pre to wrapper
-			wrapper.style.margin = window.getComputedStyle(pre).margin;
-			pre.style.margin = '0';
-
-		});
-	});
-
 }());

--- a/assets/style.css
+++ b/assets/style.css
@@ -188,7 +188,6 @@ footer:before {
 	}
 
 	#features {
-		width: 66em;
 		margin-top: 2em;
 		font-size: 80%;
 	}
@@ -197,12 +196,16 @@ footer:before {
 			margin: 0 0 2em 0;
 			list-style: none;
 			display: inline-block;
-			width: 27em;
+			width: 49%;
+			box-sizing: border-box;
 			vertical-align: top;
 		}
 
 		#features li:nth-child(odd) {
-			margin-right: 5em;
+			padding-right: 2.5em;
+		}
+		#features li:nth-child(even) {
+			padding-left: 2.5em;
 		}
 
 			#features li:before {
@@ -229,7 +232,7 @@ footer:before {
 		position: relative;
 		z-index: 1;
 		float: right;
-		margin-right: -1em;
+		margin-right: -9em;
 		text-align: center;
 		text-transform: uppercase;
 		letter-spacing: .2em;
@@ -277,12 +280,88 @@ footer:before {
 
 		#theme > input {
 			position: absolute;
+			left: 0;
 			clip: rect(0,0,0,0);
 		}
 
 		#theme > input:checked + label {
 			background: #7fab14;
 		}
+
+		@media (max-width: 1300px) and (min-width: 951px) {
+			#theme {
+				position: relative;
+				z-index: 1;
+				float: left;
+				margin: 1em 0;
+				width: 100%;
+			}
+			#theme + * {
+				clear: both;
+			}
+
+				#theme > p {
+					display: none;
+				}
+
+				#theme > label {
+					float: left;
+					font-size: 82.6%;
+				}
+
+				#theme > label:before {
+					display: none;
+				}
+
+				#theme > label:nth-of-type(n+2) {
+					margin-top: 0;
+				}
+		}
+
+		@media (max-width: 950px) {
+			#theme {
+				position: relative;
+				z-index: 1;
+				float: left;
+				margin: 1em 0;
+			}
+			#theme + * {
+				clear: both;
+			}
+
+				#theme > p {
+					left: inherit;
+					right: -1em;
+				}
+
+				#theme > label {
+					float: left;
+				}
+
+				#theme > label:before {
+					display: none;
+				}
+
+				#theme > label:nth-of-type(n+2) {
+					margin-top: 0;
+				}
+				#theme > label:nth-of-type(n+5) {
+					margin-top: -2.5em;
+				}
+				#theme > label:nth-of-type(4n+1) {
+					margin-left: 12.5em;
+				}
+		}
+
+		@media (max-width: 800px) {
+			#theme > label:nth-of-type(4) {
+				margin-right: 4em;
+			}
+			#theme > label:nth-of-type(4n+1) {
+				margin-left: 4em;
+			}
+		}
+
 
 footer {
 	margin-top: 2em;
@@ -429,12 +508,3 @@ ul.plugin-list {
 	ul.plugin-list > li > div {
 		margin-bottom: .5em;
 	}
-
-/*
- * Fix for Toolbar's overflow issue
- */
-
-div.code-toolbar {
-	display: block;
-	overflow: auto;
-}

--- a/test.html
+++ b/test.html
@@ -8,10 +8,6 @@
 <link rel="stylesheet" href="assets/style.css" />
 <link rel="stylesheet" href="themes/prism.css" data-noprefix />
 <style>
-#theme {
-	margin-right: -9em;
-}
-
 textarea {
 	width: 100%;
 	height: 10em;


### PR DESCRIPTION
This PR repositions the theme selector so it no longer overlaps with the rest of the page.

This has two parts: 

1. The theme selector is moved more to the right on large screens:

![image](https://user-images.githubusercontent.com/20878432/136689906-14991f22-c22f-4bed-8281-81b0d5a28266.png)


2. The theme selector gets a new compact design on small screens:

![image](https://user-images.githubusercontent.com/20878432/136689934-98e71c12-bb4a-4cde-9882-892f6e2a0e17.png)

![image](https://user-images.githubusercontent.com/20878432/136689946-1a3e717f-71db-4c19-85cb-8c8cf754f2da.png)

Tested in Chrome, Firefox, and IE11.

---

This also reverts #1966 since it's no longer necessary.

This fixes #3110.