### PR TITLE
Tests: Added `TestCaseFile` class and generalized `runTestCase`

### DIFF
--- a/tests/helper/test-case.js
+++ b/tests/helper/test-case.js
@@ -1,5 +1,3 @@
-//@ts-check
-
 'use strict';
 
 const fs = require('fs');

--- a/tests/helper/test-case.js
+++ b/tests/helper/test-case.js
@@ -183,7 +183,12 @@ class TokenizeJSONRunner {
 	 */
 	isEqual(actual, expected) {
 		const simplifiedActual = TokenStreamTransformer.simplify(actual);
-		const simplifiedExpected = JSON.parse(expected);
+		let simplifiedExpected;
+		try {
+			simplifiedExpected = JSON.parse(expected);
+		} catch (error) {
+			return false;
+		}
 
 		return JSON.stringify(simplifiedActual) === JSON.stringify(simplifiedExpected);
 	}
@@ -196,7 +201,6 @@ class TokenizeJSONRunner {
 	assertEqual(actual, expected, message) {
 		const simplifiedActual = TokenStreamTransformer.simplify(actual);
 		const simplifiedExpected = JSON.parse(expected);
-
 
 		const actualString = JSON.stringify(simplifiedActual);
 		const expectedString = JSON.stringify(simplifiedExpected);

--- a/tests/helper/test-case.js
+++ b/tests/helper/test-case.js
@@ -108,7 +108,7 @@ class TestCaseFile {
 	 * @returns {TestCaseFile}
 	 */
 	static parse(content) {
-		const eol = (/\r\n?|\n/.exec(content) || ['\n'])[0];
+		const eol = (/\r\n|\n/.exec(content) || ['\n'])[0];
 
 		// normalize line ends to CRLF
 		content = content.replace(/\r\n?|\n/g, '\r\n');
@@ -119,7 +119,7 @@ class TestCaseFile {
 		const description = parts[2] || '';
 
 		const file = new TestCaseFile(code.trim(), expected.trim(), description.trim());
-		file.eol = eol;
+		file.eol = /** @type {"\r\n" | "\n"} */ (eol);
 
 		const codeStartSpaces = /^\s*/.exec(code)[0];
 		const expectedStartSpaces = /^\s*/.exec(expected)[0];

--- a/tests/helper/test-case.js
+++ b/tests/helper/test-case.js
@@ -167,7 +167,7 @@ module.exports = {
 	 * @param {"none" | "insert" | "update"} updateMode
 	 */
 	runTestCase(languageIdentifier, filePath, updateMode) {
-		const testCase = TestCaseFile.parse(filePath);
+		const testCase = TestCaseFile.readFromFile(filePath);
 		const usedLanguages = this.parseLanguageNames(languageIdentifier);
 
 		const Prism = PrismLoader.createInstance(usedLanguages.languages);

--- a/tests/pattern-tests.js
+++ b/tests/pattern-tests.js
@@ -31,7 +31,7 @@ for (const languageIdentifier in testSuite) {
 
 	for (const file of testSuite[languageIdentifier]) {
 		if (path.extname(file) === '.test') {
-			snippets.push(TestCase.TestCaseFile.parse(file).code);
+			snippets.push(TestCase.TestCaseFile.readFromFile(file).code);
 		} else {
 			snippets.push(...Object.keys(require(file)));
 		}

--- a/tests/pattern-tests.js
+++ b/tests/pattern-tests.js
@@ -31,7 +31,7 @@ for (const languageIdentifier in testSuite) {
 
 	for (const file of testSuite[languageIdentifier]) {
 		if (path.extname(file) === '.test') {
-			snippets.push(TestCase.parseTestCaseFile(file).code);
+			snippets.push(TestCase.TestCaseFile.parse(file).code);
 		} else {
 			snippets.push(...Object.keys(require(file)));
 		}


### PR DESCRIPTION
This adds 2 things:

1. A `TestCaseClass` class.
2. A `TokenizeJSONRunner` class.

I moved all the logic for parsing and printing `.test` files into the `TestCaseClass`. This neatly separates the `.test` file format from the code running tests.

I generalized the `runTestCase` function by adding a new `runTestCaseWithRunner` function. The new function will also take a runner. Runners are a new concept here. A runner is responsible for tokenizing/highlighting code and comparing it to the expected value.

This generalization is overkill as is right now but necessary for adding HTML `.test` files.