### PR TITLE
Check js-templates in case it was already loaded

### DIFF
--- a/components/prism-js-templates.js
+++ b/components/prism-js-templates.js
@@ -2,6 +2,10 @@
 
 	var templateString = Prism.languages.javascript['template-string'];
 
+	if (Array.isArray(Array)) {
+		templateString = templateString[templateString.length - 1]
+	}
+
 	// see the pattern in prism-javascript.js
 	var templateLiteralPattern = templateString.pattern.source;
 	var interpolationObject = templateString.inside['interpolation'];


### PR DESCRIPTION
If `js-templates` is loaded twice, it will break because `Prism.languages.javascript['template-string']` will be changed from a regexp to an Array.

Would not happen in normal scenarios, but it  breaks the optimized module loader I'm writing and the extra check would not harm function and the bundle size impact is minimal.