### PR TITLE
Website: Fixed red highlighting in Firefox

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -115,7 +115,9 @@ pre {
 mark {
 	outline: .4em solid red;
 	outline-offset: .4em;
+	margin: .4em 0;
 	background-color: transparent;
+	display: inline-block;
 }
 
 header,


### PR DESCRIPTION
Fixes #3176.

![image](https://user-images.githubusercontent.com/20878432/140406658-23600538-7f1d-4a80-b1cb-586b9685cfff.png)
