### PR TITLE
[WIP] advanced nesting inside liquid

### DIFF
--- a/components.json
+++ b/components.json
@@ -781,7 +781,7 @@
 		},
 		"liquid": {
 			"title": "Liquid",
-			"require": "markup-templating",
+			"require": ["markup-templating", "javascript"],
 			"owner": "cinhtau"
 		},
 		"lisp": {

--- a/components/prism-liquid.js
+++ b/components/prism-liquid.js
@@ -1,7 +1,26 @@
-Prism.languages.liquid = {
+Prism.languages.liquid = {};
+Object.assign(Prism.languages.liquid, {
 	'comment': {
 		pattern: /(^\{%\s*comment\s*%\})[\s\S]+(?=\{%\s*endcomment\s*%\}$)/,
 		lookbehind: true
+	},
+	'script': {
+		pattern: /<script>[\s\S]*<\/script>|\{% javascript %\}[\s\S]*\{% endjavascript %\}/,
+		greedy: true,
+		inside: {
+			'tag': /<script>|<\/script>|\{% javascript %\}|\{% endjavascript %\}/,
+			'javascript': {
+				alias: ['js', 'javascript', 'language-javascript'],
+				pattern: /\S+(?:\s+\S+)*/,
+				inside: {
+					'liquid': {
+						pattern: /\{%.*%\}|\{\{.*\}\}/,
+						inside: Prism.languages.liquid,
+					},
+					rest: Prism.languages.javascript,
+				}
+			},
+		}
 	},
 	'delimiter': {
 		pattern: /^\{(?:\{\{|[%\{])-?|-?(?:\}\}|[%\}])\}$/,
@@ -38,10 +57,10 @@ Prism.languages.liquid = {
 		pattern: /\bempty\b/,
 		alias: 'keyword'
 	},
-};
+});
 
 Prism.hooks.add('before-tokenize', function (env) {
-	var liquidPattern = /\{%\s*comment\s*%\}[\s\S]*?\{%\s*endcomment\s*%\}|\{(?:%[\s\S]*?%|\{\{[\s\S]*?\}\}|\{[\s\S]*?\})\}/g;
+	var liquidPattern = /\{% javascript %\}[\s\S]*\{% endjavascript %\}|<script>[\s\S]*<\/script>|\{%\s*comment\s*%\}[\s\S]*?\{%\s*endcomment\s*%\}|\{(?:%[\s\S]*?%|\{\{[\s\S]*?\}\}|\{[\s\S]*?\})\}/g;
 	var insideRaw = false;
 
 	Prism.languages['markup-templating'].buildPlaceholders(env, 'liquid', liquidPattern, function (match) {

--- a/tests/languages/liquid/nested_feature.test
+++ b/tests/languages/liquid/nested_feature.test
@@ -1,0 +1,151 @@
+<script>
+  // The drop is highlighted because liquid will render inside the comment.
+  // As such, it isn't a "real" comment w.r.t. liquid.
+  // comment {{ product.value }}
+  function main(arg1) {
+    if (condition) {
+      {% if condition %}
+        const foo = {{ variable | filter: arg1 | json }}
+      {% endif %}
+    }
+  }
+</script>
+
+{% javascript %}
+  // The drop is highlighted because liquid will render inside the comment.
+  // As such, it isn't a "real" comment w.r.t. liquid.
+  // comment {{ product.value }}
+  function main(arg1) {
+    if (condition) {
+      {% if condition %}
+        const foo = {{ variable | filter: arg1 | json }}
+      {% endif %}
+    }
+  }
+{% endjavascript %}
+
+----------------------------------------------------
+
+[
+	["liquid", [
+		["script", [
+			["tag", "<script>"],
+
+			["javascript", [
+				["comment", "// The drop is highlighted because liquid will render inside the comment."],
+
+				["comment", "// As such, it isn't a \"real\" comment w.r.t. liquid."],
+
+				["comment", "// comment {{ product.value }}"],
+
+				["keyword", "function"],
+				["function", "main"],
+				["punctuation", "("],
+				["parameter", ["arg1"]],
+				["punctuation", ")"],
+				["punctuation", "{"],
+
+				["keyword", "if"],
+				["punctuation", "("],
+				"condition",
+				["punctuation", ")"],
+				["punctuation", "{"],
+
+				["liquid", [
+					["delimiter", "{%"],
+					["keyword", "if"],
+					" condition ",
+					["delimiter", "%}"]
+				]],
+
+				["keyword", "const"],
+				" foo ",
+				["operator", "="],
+				["liquid", [
+					["delimiter", "{{"],
+					" variable ",
+					["operator", "|"],
+					["object", "filter"],
+					["operator", ":"],
+					" arg1 ",
+					["operator", "|"],
+					["function", "json"],
+					["delimiter", "}}"]
+				]],
+
+				["liquid", [
+					["delimiter", "{%"],
+					["keyword", "endif"],
+					["delimiter", "%}"]
+				]],
+
+				["punctuation", "}"],
+
+				["punctuation", "}"]
+			]],
+
+			["tag", "</script>"]
+		]]
+	]],
+
+	["liquid", [
+		["script", [
+			["tag", "{% javascript %}"],
+
+			["javascript", [
+				["comment", "// The drop is highlighted because liquid will render inside the comment."],
+
+				["comment", "// As such, it isn't a \"real\" comment w.r.t. liquid."],
+
+				["comment", "// comment {{ product.value }}"],
+
+				["keyword", "function"],
+				["function", "main"],
+				["punctuation", "("],
+				["parameter", ["arg1"]],
+				["punctuation", ")"],
+				["punctuation", "{"],
+
+				["keyword", "if"],
+				["punctuation", "("],
+				"condition",
+				["punctuation", ")"],
+				["punctuation", "{"],
+
+				["liquid", [
+					["delimiter", "{%"],
+					["keyword", "if"],
+					" condition ",
+					["delimiter", "%}"]
+				]],
+
+				["keyword", "const"],
+				" foo ",
+				["operator", "="],
+				["liquid", [
+					["delimiter", "{{"],
+					" variable ",
+					["operator", "|"],
+					["object", "filter"],
+					["operator", ":"],
+					" arg1 ",
+					["operator", "|"],
+					["function", "json"],
+					["delimiter", "}}"]
+				]],
+
+				["liquid", [
+					["delimiter", "{%"],
+					["keyword", "endif"],
+					["delimiter", "%}"]
+				]],
+
+				["punctuation", "}"],
+
+				["punctuation", "}"]
+			]],
+
+			["tag", "{% endjavascript %}"]
+		]]
+	]]
+]


### PR DESCRIPTION
@RunDevelopment may I get your feedback on this approach to get other languages tokenized inside liquid? I have a feeling there's a better way but I can't remember where to look to find a better example of what we're trying to achieve here 😅 

I wanted to share this with you before I continue down this path of trying to get nested `json` to work with the `schema` keyword, e.g.

```liquid
{% schema %}
  {
    "json is highlighted properly": [
      "world. cool huh?",
      true,
    ],
    "nested": {
      "object": "properties"
    },
    "invalid": type
    "missing": "comma"
  }
{% endschema %}
```

Thanks!