### PR TITLE
ESLint: Allow `Map` and `Set` in ES5 code

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -131,7 +131,10 @@ module.exports = {
 				worker: true
 			},
 			globals: {
-				'Prism': true
+				'Prism': true,
+				// Allow Set and Map. They are partially supported by IE11
+				'Set': true,
+				'Map': true
 			},
 			rules: {
 				'no-var': 'off'


### PR DESCRIPTION
See [this reply](https://github.com/PrismJS/prism/pull/3326#discussion_r803569302) for context.

Briefly, IE11 partially supports `Set` and `Map`, so we should be allowed to use them throughout our code base. However, ESLint is configured to only allow ES5 code, so it rejects `Set` and `Map` as undefined variables. This PR adds an exception to our ESLint config to declare `Set` and `Map` as defined.