### PR TITLE
properties: Use `key`, `value` for token names, `attr-...` as aliases

### DIFF
--- a/components/prism-properties.js
+++ b/components/prism-properties.js
@@ -1,9 +1,13 @@
 Prism.languages.properties = {
 	'comment': /^[ \t]*[#!].*$/m,
-	'attr-value': {
+	'value': {
 		pattern: /(^[ \t]*(?:\\(?:\r\n|[\s\S])|[^\\\s:=])+(?: *[=:] *(?! )| ))(?:\\(?:\r\n|[\s\S])|[^\\\r\n])+/m,
-		lookbehind: true
+		lookbehind: true,
+		alias: 'attr-value'
 	},
-	'attr-name': /^[ \t]*(?:\\(?:\r\n|[\s\S])|[^\\\s:=])+(?= *[=:]| )/m,
+	'key': {
+		pattern: /^[ \t]*(?:\\(?:\r\n|[\s\S])|[^\\\s:=])+(?= *[=:]| )/m,
+		alias: 'attr-name'
+	},
 	'punctuation': /[=:]/
 };

--- a/components/prism-properties.min.js
+++ b/components/prism-properties.min.js
@@ -1,1 +1,1 @@
-Prism.languages.properties={comment:/^[ \t]*[#!].*$/m,"attr-value":{pattern:/(^[ \t]*(?:\\(?:\r\n|[\s\S])|[^\\\s:=])+(?: *[=:] *(?! )| ))(?:\\(?:\r\n|[\s\S])|[^\\\r\n])+/m,lookbehind:!0},"attr-name":/^[ \t]*(?:\\(?:\r\n|[\s\S])|[^\\\s:=])+(?= *[=:]| )/m,punctuation:/[=:]/};
+Prism.languages.properties={comment:/^[ \t]*[#!].*$/m,value:{pattern:/(^[ \t]*(?:\\(?:\r\n|[\s\S])|[^\\\s:=])+(?: *[=:] *(?! )| ))(?:\\(?:\r\n|[\s\S])|[^\\\r\n])+/m,lookbehind:!0,alias:"attr-value"},key:{pattern:/^[ \t]*(?:\\(?:\r\n|[\s\S])|[^\\\s:=])+(?= *[=:]| )/m,alias:"attr-name"},punctuation:/[=:]/};

--- a/tests/languages/properties/key_value_feature.test
+++ b/tests/languages/properties/key_value_feature.test
@@ -11,24 +11,24 @@ baz
 ----------------------------------------------------
 
 [
-	["attr-name", "foo"],
-	["attr-value", "bar"],
-	["attr-name", "foo\\:\\=\\ bar"],
-	["attr-value", "bar\\:\\= \\\r\nbaz"],
+	["key", "foo"],
+	["value", "bar"],
+	["key", "foo\\:\\=\\ bar"],
+	["value", "bar\\:\\= \\\r\nbaz"],
 
-	["attr-name", "foo"],
+	["key", "foo"],
 	["punctuation", "="],
-	["attr-value", "bar"],
-	["attr-name", "foo\\:\\=\\ bar"],
+	["value", "bar"],
+	["key", "foo\\:\\=\\ bar"],
 	["punctuation", "="],
-	["attr-value", "bar\\:\\= \\\r\nbaz"],
+	["value", "bar\\:\\= \\\r\nbaz"],
 
-	["attr-name", "foo"],
+	["key", "foo"],
 	["punctuation", ":"],
-	["attr-value", "bar"],
-	["attr-name", "foo\\:\\=\\ bar"],
+	["value", "bar"],
+	["key", "foo\\:\\=\\ bar"],
 	["punctuation", ":"],
-	["attr-value", "bar\\:\\= \\\r\nbaz"]
+	["value", "bar\\:\\= \\\r\nbaz"]
 ]
 
 ----------------------------------------------------


### PR DESCRIPTION
This PR replaces `attr-name` and `attr-value` with `key` and `value`, and uses `attr-...` as aliases instead.

Overall, this brings properties in line with similar languages (INI, editorconfig, systemd...).