### PR TITLE
Got rid of `simple-git` warning

### DIFF
--- a/benchmark/benchmark.js
+++ b/benchmark/benchmark.js
@@ -6,7 +6,7 @@ const crypto = require('crypto');
 const { argv } = require('yargs');
 const fetch = require('node-fetch').default;
 const Benchmark = require('benchmark');
-const simpleGit = require('simple-git/promise');
+const simpleGit = require('simple-git');
 const { parseLanguageNames } = require('../tests/helper/test-case');
 
 
@@ -401,7 +401,7 @@ async function getCandidates(config) {
 	const remoteBaseDir = path.join(__dirname, 'remotes');
 	await fs.promises.mkdir(remoteBaseDir, { recursive: true });
 
-	const baseGit = simpleGit(remoteBaseDir);
+	const baseGit = simpleGit.gitP(remoteBaseDir);
 
 	for (const remote of config.remotes) {
 		const user = /[^/]+(?=\/prism.git)/.exec(remote.repo);
@@ -413,9 +413,9 @@ async function getCandidates(config) {
 		if (!fs.existsSync(remoteDir)) {
 			console.log(`Cloning ${remote.repo}`);
 			await baseGit.clone(remote.repo, remoteName);
-			remoteGit = simpleGit(remoteDir);
+			remoteGit = simpleGit.gitP(remoteDir);
 		} else {
-			remoteGit = simpleGit(remoteDir);
+			remoteGit = simpleGit.gitP(remoteDir);
 			await remoteGit.fetch('origin', branch); // get latest version of branch
 		}
 		await remoteGit.checkout(branch); // switch to branch

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -1,7 +1,7 @@
 const { markdown } = require('danger');
 const fs = require('fs').promises;
 const gzipSize = require('gzip-size');
-const git = require('simple-git/promise')(__dirname).silent(true);
+const git = require('simple-git').gitP(__dirname);
 
 /**
  * Returns the contents of a text file in the base of the PR.

--- a/gulpfile.js/changelog.js
+++ b/gulpfile.js/changelog.js
@@ -4,7 +4,7 @@ const { src, dest } = require('gulp');
 
 const replace = require('gulp-replace');
 const pump = require('pump');
-const git = require('simple-git/promise')(__dirname);
+const git = require('simple-git').gitP(__dirname);
 
 const { changelog } = require('./paths');
 


### PR DESCRIPTION
We recently upgrade to simple-git v3.x because of a CVE. See #3402. Ever since that fateful day, our logs have been spammed with this warning:

```
=============================================
simple-git has supported promises / async await since version 2.6.0.
 Importing from 'simple-git/promise' has been deprecated and will be
 removed by July 2022.

To upgrade, change all 'simple-git/promise' imports to just 'simple-git'
=============================================
```

So I finally got around to fixing that. 

Since the `simple-git` types have some sort of problem with CommonJS imports, we can't use `simpleGit(basePath)` without TS screaming at us. I used `simpleGit.gitP(basePath)` instead. What is [`gitP`](https://github.com/steveukx/git-js/blob/9bf9baa54b9389e797992d717afdfc05dceaa524/simple-git/typings/index.d.ts#L8)? I don't know. It doesn't seem to be documented, but it 1) works, 2) fixes the type error, and 3) doesn't produce any warnings.

I also removed the `.silent(true)` in `dangerfile.js` because it was deprecated. Not sure what it did.