### PR TITLE
Drop support for NodeJS 10.x in development

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x, 16.x]
+        node-version: [12.x, 14.x, 16.x]
 
     steps:
       - uses: actions/checkout@v2
@@ -30,7 +30,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x, 16.x]
+        node-version: [12.x, 14.x, 16.x]
 
     steps:
       - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Thank you so much for contributing!!
 
 Prism will run on [almost any browser](https://prismjs.com/#features-full) and Node.js version but you need the following software to contribute:
 
-- Node.js >= 10.x
+- Node.js >= 12.x
 - npm >= 6.x
 
 ## Translations

--- a/docs/index.html
+++ b/docs/index.html
@@ -76,7 +76,7 @@
 <h3>Software requirements</h3>
 <p>Prism will run on <a href="https://prismjs.com/#features-full">almost any browser</a> and Node.js version but you need the following software to contribute:</p>
 <ul>
-<li>Node.js &gt;= 10.x</li>
+<li>Node.js &gt;= 12.x</li>
 <li>npm &gt;= 6.x</li>
 </ul>
 <h2>Translations</h2>


### PR DESCRIPTION
NodeJS 10.x lost support on [30 Apr 2021](https://endoflife.date/nodejs).

This PR removes NodeJS 10.x from your CI and changes the development requirements in the readme.