### PR TITLE
Update to `eslint-plugin-regexp` v1.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
 				"docdash": "^1.2.0",
 				"eslint": "^7.22.0",
 				"eslint-plugin-jsdoc": "^32.3.0",
-				"eslint-plugin-regexp": "^1.4.0",
+				"eslint-plugin-regexp": "^1.6.0",
 				"gulp": "^4.0.2",
 				"gulp-clean-css": "^4.3.0",
 				"gulp-concat": "^2.3.4",
@@ -2813,9 +2813,9 @@
 			}
 		},
 		"node_modules/eslint-plugin-regexp": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-regexp/-/eslint-plugin-regexp-1.4.0.tgz",
-			"integrity": "sha512-H+APSyKFrhPOaVAdsLa3qLPD6SgkzNPypxM+lnx5fwbUY9Pcw5XV3bJkxt7JIjdsL1B5NMdQXOhN3N8LtyVa5A==",
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-regexp/-/eslint-plugin-regexp-1.6.0.tgz",
+			"integrity": "sha512-xkaQOzyY4PUukRd8b6zTq+QTtg0dePlCP2dZiM+XGSmvlpDeYiPJHfRDpAfS/sP9YtK6q7DGes1smCyPTD3Lkg==",
 			"dev": true,
 			"dependencies": {
 				"comment-parser": "^1.1.2",
@@ -13477,9 +13477,9 @@
 			}
 		},
 		"eslint-plugin-regexp": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-regexp/-/eslint-plugin-regexp-1.4.0.tgz",
-			"integrity": "sha512-H+APSyKFrhPOaVAdsLa3qLPD6SgkzNPypxM+lnx5fwbUY9Pcw5XV3bJkxt7JIjdsL1B5NMdQXOhN3N8LtyVa5A==",
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-regexp/-/eslint-plugin-regexp-1.6.0.tgz",
+			"integrity": "sha512-xkaQOzyY4PUukRd8b6zTq+QTtg0dePlCP2dZiM+XGSmvlpDeYiPJHfRDpAfS/sP9YtK6q7DGes1smCyPTD3Lkg==",
 			"dev": true,
 			"requires": {
 				"comment-parser": "^1.1.2",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
 		"docdash": "^1.2.0",
 		"eslint": "^7.22.0",
 		"eslint-plugin-jsdoc": "^32.3.0",
-		"eslint-plugin-regexp": "^1.4.0",
+		"eslint-plugin-regexp": "^1.6.0",
 		"gulp": "^4.0.2",
 		"gulp-clean-css": "^4.3.0",
 		"gulp-concat": "^2.3.4",


### PR DESCRIPTION
This updates the regexp ESLint plugin. 

The new releases include a few improvements, such as improved detection of redundant alternatives. This is what caught #3395.