### PR TITLE
Added list of maintainers

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,11 @@
+## Maintainers (alphabetical by user name)
+
+- [@Golmote](https://github.com/Golmote)
+- [@JaKXz](https://github.com/JaKXz) Jason Kurian
+- [@LeaVerou](https://github.com/LeaVerou) Lea Verou (original author)
+- [@mAAdhaTTah](https://github.com/mAAdhaTTah) James DiGioia <jamesorodig@gmail.com>
+- [@RunDevelopment](https://github.com/RunDevelopment) Michael Schmidt <msrd0000@gmail.com>
+
+## Former Maintainers
+
+- [@zeitgeist87](https://github.com/zeitgeist87) Andreas Rohner


### PR DESCRIPTION
This PR adds a list of all current and former members of the PrismJS org and their involvement in this project. This list is mainly useful for people that need to contact us privately, e.g. for security reasons (see #3070).

However, this does create **some privacy concerns for you guys**. Your membership in the PrismJS org will be made public. I also included the full name from your GitHub account and email addresses for some. If you do not wish for this information to be recorded here, please leave a comment.

---

Regarding the titles/categories: they don't really mean anything.

I only added those titles, so members that aren't as actively involved anymore don't get spam from people contacting the maintainers via email or pinging them on GitHub. These titles basically function as mailing lists for outsiders. They are just a way for people outside the PrismJS org to figure out, "who do I contact when I have/found a problem that needs to be discussed privately?"

If you want a different title, please say so.

---

Some comments to individuals:

- @Golmote If you want to be credited with your full name, please tell me or add it yourself. (If you don't want your name to be known/listed here, that's fine too. Just let me know if you do want it to be added.)
- @LeaVerou I took your email from your website. You did not list this email on your GH profile, so please tell me if you do not want to your email to be listed here or wish to use a different address.