### PR TITLE
Copy-to-Clipboard: Add a text-override attribute

### DIFF
--- a/plugins/copy-to-clipboard/index.html
+++ b/plugins/copy-to-clipboard/index.html
@@ -34,6 +34,7 @@
 		<li><code class="token attr-name">data-prismjs-copy-error</code> — a message displayed after failing copying, prompting the user to press <code>Ctrl+C</code>;</li>
 		<li><code class="token attr-name">data-prismjs-copy-success</code> — a message displayed after a successful copying;</li>
 		<li><code class="token attr-name">data-prismjs-copy-timeout</code> — a timeout (in milliseconds) after copying. Once the timeout passed, the success or error message will revert back to the default message. The value should be a non-negative integer.</li>
+		<li><code class="token attr-name">data-prismjs-copy-text</code> — set a different string to be copied to the clipboard. This overrides the default behaviour of copying the shown text into the clipboard.</li>
 	</ul>
 
 	<p>The plugin traverses up the DOM tree to find each of these attributes. The search starts at every <code class="token tag">pre code</code> element and stops at the closest ancestor element that has a desired attribute or at the worst case, at the <code class="token tag">html</code> element.</p>

--- a/plugins/copy-to-clipboard/prism-copy-to-clipboard.js
+++ b/plugins/copy-to-clipboard/prism-copy-to-clipboard.js
@@ -95,7 +95,8 @@
 			'copy': 'Copy',
 			'copy-error': 'Press Ctrl+C to copy',
 			'copy-success': 'Copied!',
-			'copy-timeout': 5000
+			'copy-timeout': 5000,
+			'copy-text': null
 		};
 
 		var prefix = 'data-prismjs-';
@@ -125,10 +126,16 @@
 
 		setState('copy');
 
-		registerClipboard(linkCopy, {
-			getText: function () {
+		var getText = settings['copy-text']
+			? function () {
+				return settings['copy-text'];
+			}
+			: function () {
 				return element.textContent;
-			},
+			};
+
+		registerClipboard(linkCopy, {
+			getText: getText,
 			success: function () {
 				setState('copy-success');
 

--- a/tests/plugins/copy-to-clipboard/basic-functionality.js
+++ b/tests/plugins/copy-to-clipboard/basic-functionality.js
@@ -68,4 +68,18 @@ describe('Copy to Clipboard', function () {
 		assert.strictEqual(clipboard.text, 'baz');
 	});
 
+	it('should copy specified text independet of code block text', function () {
+		const clipboard = new DummyClipboard();
+		window.navigator.clipboard = clipboard;
+
+		document.body.innerHTML = `<pre class="language-none" data-prismjs-copy-text="bar"><code>foo</code></pre>`;
+		Prism.highlightAll();
+
+		const button = document.querySelector('button');
+		assert.notStrictEqual(button, null);
+
+		button.click();
+
+		assert.strictEqual(clipboard.text, 'bar');
+	});
 });


### PR DESCRIPTION
This PR adds a new data-attribute that allows overriding the text that is to be copied to the clipboard. This allows hiding credentials in the visible UI, but having them copied correctly.

An example of this could be a cURL command setting an API-Key as a Header, with this change the UI-visible Text could show `X-API-Key: XXXXXX` instead of the real APi-Key, but still copy the correct cURL command.