### PR TITLE
Redesign header templates (#3577)

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -155,7 +155,6 @@ footer:before {
 	}
 
 	header h1 {
-		float: left;
 		margin-right: 30px;
 		color: #7fab14;
 		text-align: center;
@@ -187,8 +186,8 @@ footer:before {
 
 	header .intro p {
 		margin: 0;
-		font: 150%/1.4 Questrial, sans-serif;
-		font-size: 150%;
+		font: Questrial, sans-serif;
+		font-size: 140%;
 	}
 
 	#features {
@@ -225,11 +224,6 @@ footer:before {
 					margin-bottom: .1em;
 					font-size: 160%;
 				}
-
-	header .download-button {
-		float: right;
-		margin: 0 0 .5em .5em;
-	}
 
 	#theme {
 		position: relative;
@@ -364,6 +358,12 @@ footer:before {
 			#theme > label:nth-of-type(4n+1) {
 				margin-left: 4em;
 			}
+			.download-button {
+				font-size: 130%;
+			}
+			header .intro p {
+				font-size: 120%;
+			}
 		}
 
 
@@ -371,6 +371,7 @@ footer {
 	margin-top: 2em;
 	background-position: bottom;
 	color: white;
+	filter: saturate(70%);
 }
 
 	footer:before {
@@ -389,32 +390,34 @@ footer {
 
 .download-button {
 	display: block;
-	padding: .2em .8em .1em;
+	padding: .6em 1em;
 	border: 1px solid rgba(0,0,0,0.5);
 	border-radius: 10px;
-	background: #39a1cf;
-	box-shadow: 0 2px 10px black,
-	   inset 0 1px hsla(0,0%,100%,.3),
-	   inset 0 .4em hsla(0,0%,100%,.2),
-	   inset 0 10px 20px hsla(0,0%,100%,.25),
-	   inset 0 -15px 30px rgba(0,0,0,0.3);
 	color: white;
+	margin: 1.8em 25%;
+	box-shadow: 0 2px 10px black,
+		inset 0 1px hsla(0,0%,100%,.3),
+		inset 0 .4em hsla(0,0%,100%,.2),
+		inset 0 10px 20px hsla(0,0%,100%,.25),
+		inset 0 -15px 30px rgba(0,0,0,0.3);
 	text-shadow: 0 -1px 2px black;
 	text-align: center;
-	font-size: 250%;
+	font-size: 150%;
 	line-height: 1.5;
+	letter-spacing: .2em;
+	font-weight: 600;
 	text-transform: uppercase;
 	text-decoration: none;
 	hyphens: manual;
 }
 
 .download-button:hover {
-	background-color: #7fab14;
+	background-color: hsla(77, 79%, 47%, .7);
 }
 
 .download-button:active {
 	box-shadow: inset 0 2px 8px rgba(0,0,0,.8);
-}
+}	
 
 #toc {
 	position: fixed;
@@ -517,3 +520,44 @@ ul.plugin-list {
 	ul.plugin-list > li > div {
 		margin-bottom: .5em;
 	}
+
+/* Website-redisign addons */
+
+.prism-box {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	gap: .6em;
+}
+
+.prism-about {
+	background-image: linear-gradient(135deg, #fff1 20%, #fff2, #fff1 80%);
+	box-shadow: 0 0 0em .5em #0006;
+	border-radius: 10px;
+	padding: 1.1em;
+	hyphens: none;
+	text-align: center;
+	letter-spacing: .05rem;
+}
+
+.prism-about::before {
+	content: open-quote;
+	top: 0;
+	left: 0;
+}
+
+.prism-about::after {
+	content: close-quote;
+	bottom: 0;
+	right: 0;
+}
+
+.prism-about::before, .prism-about::after {
+	display: inline-block;
+	text-align: center;
+	font-weight: 700;
+	scale: 1.6;
+	margin: 0 .4em;
+	color: #cccc;
+	font-family: Arvo sans-serif;
+}

--- a/assets/templates/header-main.html
+++ b/assets/templates/header-main.html
@@ -1,11 +1,15 @@
-<h1><a href="index.html"><img src="assets/logo.svg" alt="Prism" /></a></h1>
+<div class="prism-box">
+
+	<h1><a href="index.html"><img src="assets/logo.svg" alt="Prism" /></a></h1>
+
+	<p class="prism-about" >
+		Prism is a lightweight, extensible syntax highlighter, built with modern web standards in mind.
+		It’s used in millions of websites, including some of those you visit daily
+	</p>
+
+</div>
 
 <a href="download.html" class="download-button">Download</a>
-
-<p>
-	Prism is a lightweight, extensible syntax highlighter, built with modern web standards in mind.
-	It’s used in millions of websites, including some of those you visit daily.
-</p>
 
 <!--<a href="https://twitter.com/share" class="twitter-share-button" data-via="prismjs" data-size="large" data-related="LeaVerou">Tweet</a>
 <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0];if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src="//platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script>

--- a/assets/templates/header-plugins.html
+++ b/assets/templates/header-plugins.html
@@ -1,8 +1,14 @@
-<h1><a href="index.html"><img src="assets/logo.svg" alt="Prism" /> plugins</a></h1>
+<div class="prism-box">
+
+	<h1><a href="index.html"><img src="assets/logo.svg" alt="Prism" /> plugins</a></h1>
+
+	<p class="prism-about" >
+		Prism is a lightweight, extensible syntax highlighter, built with modern web standards in mind.
+		It’s used in millions of websites, including some of those you visit daily
+	</p>
+
+</div>
 
 <a href="download.html" class="download-button">Download</a>
 
-<p>
-	Prism is a lightweight, extensible syntax highlighter, built with modern web standards in mind.
-	It’s used in millions of websites, including some of those you visit daily.
-</p>
+


### PR DESCRIPTION
(#3577) Header templates received a visual and layout change : 

1) Download button received a transparent background. Hovering over the button makes it change background to lightgreen. Also, button sizing is slightly modified.

2) Prism description text (header) is now placed inside a cite quotes. There are now more styling added, to make it look a bit prettier.

3) Instead of keeping Prism logo, description text and download button in one line, the button has been moved below. Each header element is now centered. Overall it made a header section a bit more spacious, but separated from remain content.

4) Also, added a minor change to footer styling. Background image has saturation level lowered, to make colors softer, less intensive. No other parts for footer are changed.