### PR TITLE
Scala: Underscore in numeric literal since Scala 2.13.0

### DIFF
--- a/components/prism-scala.js
+++ b/components/prism-scala.js
@@ -9,7 +9,7 @@ Prism.languages.scala = Prism.languages.extend('java', {
 		greedy: true
 	},
 	'keyword': /<-|=>|\b(?:abstract|case|catch|class|def|derives|do|else|enum|extends|extension|final|finally|for|forSome|given|if|implicit|import|infix|inline|lazy|match|new|null|object|opaque|open|override|package|private|protected|return|sealed|self|super|this|throw|trait|transparent|try|type|using|val|var|while|with|yield)\b/,
-	'number': /\b0x(?:[\da-f]*\.)?[\da-f]+|(?:\b\d+(?:\.\d*)?|\B\.\d+)(?:e\d+)?[dfl]?/i,
+	'number': /\b0x(?:[\da-f_]*\.)?[\da-f_]+|(?:\b[\d_]+(?:\.[\d_]*)?|\B\.[\d_]+)(?:e[\d_]+)?[dfl]?/i,
 	'builtin': /\b(?:Any|AnyRef|AnyVal|Boolean|Byte|Char|Double|Float|Int|Long|Nothing|Short|String|Unit)\b/,
 	'symbol': /'[^\d\s\\]\w*/
 });

--- a/examples/prism-scala.html
+++ b/examples/prism-scala.html
@@ -13,11 +13,13 @@ string"""</code></pre>
 <pre><code>0
 21
 0xFFFFFFFF
+0xFF_FF__FF_FF
 -42L
 0.0
 1e30f
 3.14159f
 1.0e-100
+1_1.0_1e-3_0
 .1
 </code></pre>
 


### PR DESCRIPTION
Scala 2.13.0 (2019 Jul) supported `_` as separator in numeric literals.


> https://github.com/scala/scala/releases/v2.13.0
> Underscores in numeric literals
> .    Underscores can now be used as a spacer. (https://github.com/scala/scala/pull/6989)
> .   Example: 1_000_000

The updated regex matches invalid literal, such as `0x1_2.13` or `1234_`, but I assumes that simpler regex is more readable and maintainable.
