### PR TITLE
feat: add Dart 3.0.0 keywords

### DIFF
--- a/components/prism-dart.js
+++ b/components/prism-dart.js
@@ -1,7 +1,7 @@
 (function (Prism) {
 	var keywords = [
 		/\b(?:async|sync|yield)\*/,
-		/\b(?:abstract|assert|async|await|break|case|catch|class|const|continue|covariant|default|deferred|do|dynamic|else|enum|export|extends|extension|external|factory|final|finally|for|get|hide|if|implements|import|in|interface|library|mixin|new|null|on|operator|part|rethrow|return|set|show|static|super|switch|sync|this|throw|try|typedef|var|void|while|with|yield)\b/
+		/\b(?:abstract|assert|async|await|base|break|case|catch|class|const|continue|covariant|default|deferred|do|dynamic|else|enum|export|extends|extension|external|factory|final|finally|for|get|hide|if|implements|import|in|interface|library|mixin|new|null|on|operator|part|rethrow|return|sealed|set|show|static|super|switch|sync|this|throw|try|typedef|var|void|when|while|with|yield)\b/
 	];
 
 	// Handles named imports, such as http.Client


### PR DESCRIPTION
support for `base`, `sealed`, and `when` introduced in Dart 3.0.0