### PR TITLE
Add prepare script, making it easy to install Prism from outside of NPM.

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
 	"scripts": {
 		"benchmark": "ts-node benchmark/benchmark.ts",
 		"build": "ts-node scripts/build.ts",
+		"prepare": "npm run build",
 		"lint": "eslint . --cache",
 		"lint:fix": "npm run lint -- --fix",
 		"lint:ci": "eslint . --max-warnings 0",


### PR DESCRIPTION
The `prepare` script is the NPM-standard way in which outside-of-NPM packages can be build, for example with installed from a git location.

After merging this into the main branch (currently `master`), people will be able to do this:

```sh
npm install prismjs@github:PrismJS/prism
```

If they want to try it right now before v2 is merged (if this is merged into v2), they can do this:

```sh
npm install prismjs@github:PrismJS/prism#v2
```

Without this, such installations are not possible.

What NPM does during the `install` process is

- it clones the specified repo,
- checks out the specified git ref (f.e. the `v2` in `#v2`),
- installs dependencies including dev dependencies,
- runs the `prepare` script if any (the `prepare` script will *always* have dev dependencies available to it),
- and finally packages the result in the same way as `npm pack` such that build outputs are included in the final package that gets installed into the user's node_modules

This would be a way for people to easily test v2 right now and provide feedback.