### PR TITLE
Simplified ESM build

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -15,7 +15,7 @@ module.exports = {
 		'eqeqeq': ['error', 'always', { 'null': 'ignore' }],
 
 		// imports
-		'import/extensions': ['warn', 'never'],
+		'import/extensions': ['warn', 'always'], // "always" is most compatible with default vanilla ES Modules
 		'import/order': [
 			'warn',
 			{

--- a/.mocharc.json
+++ b/.mocharc.json
@@ -1,0 +1,7 @@
+{
+	"Xrequire": "@babel/register",
+		"Xexperimental-specifier-resolution=node": "",
+	"node-option": [
+		"loader=ts-node/esm"
+	]
+}

--- a/.mocharc.yml
+++ b/.mocharc.yml
@@ -1,1 +1,0 @@
-require: '@babel/register'

--- a/benchmark/benchmark.ts
+++ b/benchmark/benchmark.ts
@@ -5,10 +5,10 @@ import fs from 'fs';
 import path from 'path';
 import { gitP } from 'simple-git';
 import { argv } from 'yargs';
-import { parseLanguageNames } from '../tests/helper/test-case';
-import { config as baseConfig } from './config';
-import type { Prism } from '../src/core';
-import type { Config, ConfigOptions } from './config';
+import { parseLanguageNames } from '../tests/helper/test-case.js';
+import { config as baseConfig } from './config.js';
+import type { Prism } from '../src/core.js';
+import type { Config, ConfigOptions } from './config.js';
 import type { Options, Stats } from 'benchmark';
 
 

--- a/package.json
+++ b/package.json
@@ -2,14 +2,15 @@
 	"name": "prismjs",
 	"version": "1.29.0",
 	"description": "Lightweight, robust, elegant syntax highlighting. A spin-off project from Dabblet.",
-	"main": "prism.js",
+  "type": "module",
+	"main": "dist/core/prism.js",
 	"style": "themes/prism.css",
 	"engines": {
 		"node": ">=14"
 	},
 	"scripts": {
 		"benchmark": "ts-node benchmark/benchmark.ts",
-		"build": "ts-node scripts/build.ts",
+		"build": "ts-node-esm scripts/build.ts && npm run tsc",
 		"prepare": "npm run build",
 		"lint": "eslint . --cache",
 		"lint:fix": "npm run lint -- --fix",
@@ -24,7 +25,8 @@
 		"test:plugins": "ts-mocha tests/plugins/**/*.ts",
 		"test:runner": "ts-mocha tests/testrunner-tests.ts",
 		"test": "npm-run-all test:*",
-		"tsc": "tsc && tsc -p tests/tsconfig.json"
+    "typecheck": "tsc --noEmit && tsc -p tests/tsconfig.json --noEmit",
+		"tsc": "tsc"
 	},
 	"repository": {
 		"type": "git",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
 	"scripts": {
 		"benchmark": "ts-node benchmark/benchmark.ts",
 		"build": "ts-node scripts/build.ts",
+		"prepare": "npm run build",
 		"lint": "eslint . --cache",
 		"lint:fix": "npm run lint -- --fix",
 		"lint:ci": "eslint . --max-warnings 0",

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -1,34 +1,36 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
-import rollupTerser from '@rollup/plugin-terser';
-import rollupTypescript from '@rollup/plugin-typescript';
+// import rollupTerser from '@rollup/plugin-terser';
+// import rollupTypescript from '@rollup/plugin-typescript';
 import CleanCSS from 'clean-css';
 import fs from 'fs';
 import { mkdir, readFile, readdir, rm, writeFile, } from 'fs/promises';
-import MagicString from 'magic-string';
+// import MagicString from 'magic-string';
 import path from 'path';
-import { rollup } from 'rollup';
+// import { rollup } from 'rollup';
+import { fileURLToPath } from 'url';
 import { webfont } from 'webfont';
-import { toArray } from '../src/shared/util';
-import { components } from './components';
-import { parallel, runTask, series } from './tasks';
-import type { ComponentProto } from '../src/types';
-import type { Plugin, SourceMapInput } from 'rollup';
+// import { toArray } from '../src/shared/util.js';
+// import { components } from './components.js';
+import { parallel, runTask, series } from './tasks.js';
+// import type { ComponentProto } from '../src/types';
+// import type { Plugin, SourceMapInput } from 'rollup';
 
 
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const SRC_DIR = path.join(__dirname, '../src/');
-const languageIds = fs.readdirSync(path.join(SRC_DIR, 'languages')).map((f) => f.slice('prism-'.length).slice(0, -'.js'.length)).sort();
+// const languageIds = fs.readdirSync(path.join(SRC_DIR, 'languages')).map((f) => f.slice('prism-'.length).slice(0, -'.js'.length)).sort();
 const pluginIds = fs.readdirSync(path.join(SRC_DIR, 'plugins')).sort();
 
-async function loadComponent(id: string) {
-	let file;
-	if (pluginIds.includes(id)) {
-		file = path.join(SRC_DIR, `plugins/${id}/prism-${id}.ts`);
-	} else {
-		file = path.join(SRC_DIR, `languages/prism-${id}.ts`);
-	}
-	const exports = (await import(file)) as { default: ComponentProto };
-	return exports.default;
-}
+// async function loadComponent(id: string) {
+// 	let file;
+// 	if (pluginIds.includes(id)) {
+// 		file = path.join(SRC_DIR, `plugins/${id}/prism-${id}.ts`);
+// 	} else {
+// 		file = path.join(SRC_DIR, `languages/prism-${id}.ts`);
+// 	}
+// 	const exports = (await import(file)) as { default: ComponentProto };
+// 	return exports.default;
+// }
 
 async function minifyCSS() {
 	const input: Record<string, string> = {};
@@ -42,7 +44,7 @@ async function minifyCSS() {
 	for (const id of pluginIds) {
 		const file = path.join(SRC_DIR, `plugins/${id}/prism-${id}.css`);
 		if (fs.existsSync(file)) {
-			input[`plugins/prism-${id}.css`] = file;
+			input[`plugins/${id}/prism-${id}.css`] = file;
 		}
 	}
 
@@ -116,119 +118,119 @@ async function treeviewIconFont() {
 	fs.writeFileSync(cssPath, css.replace(fontFaceRegex, fontFace), 'utf-8');
 }
 
-const dataToInsert = {
-	aliases_placeholder: async () => {
-		const data = await Promise.all([...languageIds, ...pluginIds].map(async (id) => {
-			const proto = await loadComponent(id);
-			return { id, alias: toArray(proto.alias) };
-		}));
-		return Object.fromEntries(data.flatMap(({ id, alias }) => alias.map((a) => [a, id])));
-	},
-	all_languages_placeholder: () => Promise.resolve(languageIds),
-	title_placeholder: async () => {
-		const rawTitles = new Map<string, string>();
-		for (const [id, entry] of Object.entries(components.languages)) {
-			if (id === 'meta') {
-				continue;
-			}
+// const dataToInsert = {
+// 	aliases_placeholder: async () => {
+// 		const data = await Promise.all([...languageIds, ...pluginIds].map(async (id) => {
+// 			const proto = await loadComponent(id);
+// 			return { id, alias: toArray(proto.alias) };
+// 		}));
+// 		return Object.fromEntries(data.flatMap(({ id, alias }) => alias.map((a) => [a, id])));
+// 	},
+// 	all_languages_placeholder: () => Promise.resolve(languageIds),
+// 	title_placeholder: async () => {
+// 		const rawTitles = new Map<string, string>();
+// 		for (const [id, entry] of Object.entries(components.languages)) {
+// 			if (id === 'meta') {
+// 				continue;
+// 			}
 
-			rawTitles.set(id, entry.title);
-			for (const [alias, title] of Object.entries(entry.aliasTitles || {})) {
-				rawTitles.set(alias, title);
-			}
-		}
+// 			rawTitles.set(id, entry.title);
+// 			for (const [alias, title] of Object.entries(entry.aliasTitles || {})) {
+// 				rawTitles.set(alias, title);
+// 			}
+// 		}
 
-		const data = (await Promise.all(languageIds.map(async (id) => {
-			const proto = await loadComponent(id);
-			const title = rawTitles.get(id);
-			if (!title) {
-				throw new Error(`No title for ${id}`);
-			}
-			return [id, ...toArray(proto.alias)].map((name) => ({ name, title: rawTitles.get(id) ?? title }));
-		}))).flat();
-		data.push({ name: 'none', title: 'Plain text' });
+// 		const data = (await Promise.all(languageIds.map(async (id) => {
+// 			const proto = await loadComponent(id);
+// 			const title = rawTitles.get(id);
+// 			if (!title) {
+// 				throw new Error(`No title for ${id}`);
+// 			}
+// 			return [id, ...toArray(proto.alias)].map((name) => ({ name, title: rawTitles.get(id) ?? title }));
+// 		}))).flat();
+// 		data.push({ name: 'none', title: 'Plain text' });
 
-		/**
-		 * Tries to guess the name of a language given its id.
-		 *
-		 * @param name The language id.
-		 */
-		function guessTitle(name: string) {
-			return (name.substring(0, 1).toUpperCase() + name.substring(1)).replace(/s(?=cript)/, 'S');
-		}
+// 		/**
+// 		 * Tries to guess the name of a language given its id.
+// 		 *
+// 		 * @param name The language id.
+// 		 */
+// 		function guessTitle(name: string) {
+// 			return (name.substring(0, 1).toUpperCase() + name.substring(1)).replace(/s(?=cript)/, 'S');
+// 		}
 
-		return Object.fromEntries(
-			data.filter(({ name, title }) => guessTitle(name) !== title).map(({ name, title }) => [name, title])
-		);
-	}
-};
+// 		return Object.fromEntries(
+// 			data.filter(({ name, title }) => guessTitle(name) !== title).map(({ name, title }) => [name, title])
+// 		);
+// 	}
+// };
 
-const dataInsertPlugin: Plugin = {
-	name: 'data-insert',
-	async renderChunk(code, chunk) {
-		const pattern = /\/\*\s*(\w+)\[\s*\*\/[\s\S]*?\/\*\s*\]\s*\*\//g;
+// const dataInsertPlugin: Plugin = {
+// 	name: 'data-insert',
+// 	async renderChunk(code, chunk) {
+// 		const pattern = /\/\*\s*(\w+)\[\s*\*\/[\s\S]*?\/\*\s*\]\s*\*\//g;
 
-		// search for placeholders
-		const contained = new Set<string>();
-		let m;
-		while ((m = pattern.exec(code))) {
-			contained.add(m[1]);
-		}
+// 		// search for placeholders
+// 		const contained = new Set<string>();
+// 		let m;
+// 		while ((m = pattern.exec(code))) {
+// 			contained.add(m[1]);
+// 		}
 
-		if (contained.size === 0) {
-			return null;
-		}
+// 		if (contained.size === 0) {
+// 			return null;
+// 		}
 
-		// fetch placeholder data
-		const dataByName: Record<string, unknown> = {};
-		for (const name of contained) {
-			if (name in dataToInsert) {
-				dataByName[name] = await dataToInsert[name as keyof typeof dataToInsert]();
-			} else {
-				throw new Error(`Unknown placeholder ${name} in ${chunk.fileName}`);
-			}
-		}
+// 		// fetch placeholder data
+// 		const dataByName: Record<string, unknown> = {};
+// 		for (const name of contained) {
+// 			if (name in dataToInsert) {
+// 				dataByName[name] = await dataToInsert[name as keyof typeof dataToInsert]();
+// 			} else {
+// 				throw new Error(`Unknown placeholder ${name} in ${chunk.fileName}`);
+// 			}
+// 		}
 
-		// replace placeholders
-		const str = new MagicString(code);
-		str.replace(pattern, (_, name: string) => {
-			return JSON.stringify(dataByName[name]);
-		});
-		return toRenderedChunk(str);
-	},
-};
+// 		// replace placeholders
+// 		const str = new MagicString(code);
+// 		str.replace(pattern, (_, name: string) => {
+// 			return JSON.stringify(dataByName[name]);
+// 		});
+// 		return toRenderedChunk(str);
+// 	},
+// };
 
-const inlineRegexSourcePlugin: Plugin = {
-	name: 'inline-regex-source',
-	renderChunk(code) {
-		const str = new MagicString(code);
-		str.replace(
-			/\/((?:[^\n\r[\\\/]|\\.|\[(?:[^\n\r\\\]]|\\.)*\])+)\/\s*\.\s*source\b/g,
-			(m, source: string) => {
-				// escape backslashes
-				source = source.replace(/\\(.)|\[(?:\\s\\S|\\S\\s)\]/g, (m, g1: string) => {
-					if (g1) {
-						// characters like /\n/ can just be kept as "\n" instead of being escaped to "\\n"
-						if (/[nrt0/]/.test(g1)) {
-							return m;
-						}
-						if ('\\' === g1) {
-							return '\\\\\\\\'; // escape using 4 backslashes
-						}
-						return '\\\\' + g1;
-					} else {
-						return '[^]';
-					}
-				});
-				// escape single quotes
-				source = source.replace(/'/g, "\\'");
-				// wrap source in single quotes
-				return "'" + source + "'";
-			}
-		);
-		return toRenderedChunk(str);
-	},
-};
+// const inlineRegexSourcePlugin: Plugin = {
+// 	name: 'inline-regex-source',
+// 	renderChunk(code) {
+// 		const str = new MagicString(code);
+// 		str.replace(
+// 			/\/((?:[^\n\r[\\\/]|\\.|\[(?:[^\n\r\\\]]|\\.)*\])+)\/\s*\.\s*source\b/g,
+// 			(m, source: string) => {
+// 				// escape backslashes
+// 				source = source.replace(/\\(.)|\[(?:\\s\\S|\\S\\s)\]/g, (m, g1: string) => {
+// 					if (g1) {
+// 						// characters like /\n/ can just be kept as "\n" instead of being escaped to "\\n"
+// 						if (/[nrt0/]/.test(g1)) {
+// 							return m;
+// 						}
+// 						if ('\\' === g1) {
+// 							return '\\\\\\\\'; // escape using 4 backslashes
+// 						}
+// 						return '\\\\' + g1;
+// 					} else {
+// 						return '[^]';
+// 					}
+// 				});
+// 				// escape single quotes
+// 				source = source.replace(/'/g, "\\'");
+// 				// wrap source in single quotes
+// 				return "'" + source + "'";
+// 			}
+// 		);
+// 		return toRenderedChunk(str);
+// 	},
+// };
 
 /**
  * This plugin wraps bare grammar objects into functions.
@@ -239,97 +241,82 @@ const inlineRegexSourcePlugin: Plugin = {
  *
  * @see https://github.com/PrismJS/prism/issues/2768
  */
-const lazyGrammarPlugin: Plugin = {
-	name: 'lazy-grammar',
-	renderChunk(code) {
-		const str = new MagicString(code);
-		str.replace(
-			/^(?<indent>[ \t]+)grammar: (\{[\s\S]*?^\k<indent>\})/m,
-			(m, _, grammar: string) => `\tgrammar: () => (${grammar})`
-		);
-		return toRenderedChunk(str);
-	},
-};
+// const lazyGrammarPlugin: Plugin = {
+// 	name: 'lazy-grammar',
+// 	renderChunk(code) {
+// 		const str = new MagicString(code);
+// 		str.replace(
+// 			/^(?<indent>[ \t]+)grammar: (\{[\s\S]*?^\k<indent>\})/m,
+// 			(m, _, grammar: string) => `\tgrammar: () => (${grammar})`
+// 		);
+// 		return toRenderedChunk(str);
+// 	},
+// };
 
-function toRenderedChunk(s: MagicString): { code: string; map: SourceMapInput } {
-	return {
-		code: s.toString(),
-		map: s.generateMap({ hires: true }) as SourceMapInput,
-	};
-}
+// function toRenderedChunk(s: MagicString): { code: string; map: SourceMapInput } {
+// 	return {
+// 		code: s.toString(),
+// 		map: s.generateMap({ hires: true }) as SourceMapInput,
+// 	};
+// }
 
-const terserPlugin = rollupTerser({
-	ecma: 2020,
-	module: true,
-	compress: {
-		passes: 4,
-		unsafe: true,
-		unsafe_arrows: true,
-		unsafe_math: true,
-		unsafe_regexp: true,
-	},
-	format: {
-		comments: false
-	},
-	keep_classnames: true
-});
+// const terserPlugin = rollupTerser({
+// 	ecma: 2020,
+// 	module: true,
+// 	compress: {
+// 		passes: 4,
+// 		unsafe: true,
+// 		unsafe_arrows: true,
+// 		unsafe_math: true,
+// 		unsafe_regexp: true,
+// 	},
+// 	format: {
+// 		comments: false
+// 	},
+// 	keep_classnames: true
+// });
 
 async function clean() {
 	const outputDir = path.join(__dirname, '../dist');
 	await rm(outputDir, { recursive: true, force: true });
 }
 
-async function buildJS() {
-	const input: Record<string, string> = {
-		'core': path.join(SRC_DIR, 'core.ts'),
-		'shared': path.join(SRC_DIR, 'shared.ts'),
-	};
-	for (const id of languageIds) {
-		input[`languages/prism-${id}`] = path.join(SRC_DIR, `languages/prism-${id}.ts`);
-	}
-	for (const id of pluginIds) {
-		input[`plugins/prism-${id}`] = path.join(SRC_DIR, `plugins/${id}/prism-${id}.ts`);
-	}
+// async function buildJS() {
+// 	const input: Record<string, string> = {
+// 		'core': path.join(SRC_DIR, 'core.ts'),
+// 		'shared': path.join(SRC_DIR, 'shared.ts'),
+// 	};
+// 	for (const id of languageIds) {
+// 		input[`languages/prism-${id}`] = path.join(SRC_DIR, `languages/prism-${id}.ts`);
+// 	}
+// 	for (const id of pluginIds) {
+// 		input[`plugins/prism-${id}`] = path.join(SRC_DIR, `plugins/${id}/prism-${id}.ts`);
+// 	}
 
-	let bundle;
-	try {
-		bundle = await rollup({
-			input,
-			plugins: [rollupTypescript({ module: 'esnext' })],
-		});
+// 	let bundle;
+// 	try {
+// 		bundle = await rollup({
+// 			input,
+// 			plugins: [rollupTypescript({ module: 'esnext' })],
+// 		});
 
-		// ESM
-		await bundle.write({
-			dir: 'dist/esm',
-			chunkFileNames: '_chunks/[name]-[hash].js',
-			validate: true,
-			sourcemap: 'hidden',
-			plugins: [
-				lazyGrammarPlugin,
-				dataInsertPlugin,
-				inlineRegexSourcePlugin,
-				terserPlugin
-			]
-		});
+// 		// ESM
+// 		await bundle.write({
+// 			dir: 'dist/',
+// 			chunkFileNames: '_chunks/[name]-[hash].js',
+// 			validate: true,
+// 			sourcemap: 'hidden',
+// 			plugins: [
+// 				lazyGrammarPlugin,
+// 				dataInsertPlugin,
+// 				inlineRegexSourcePlugin,
+// 				terserPlugin
+// 			]
+// 		});
+// 	} finally {
+// 		await bundle?.close();
+// 	}
+// }
 
-		// CommonJS
-		await bundle.write({
-			dir: 'dist/cjs',
-			chunkFileNames: '_chunks/[name]-[hash].js',
-			validate: true,
-			sourcemap: 'hidden',
-			format: 'cjs',
-			exports: 'named',
-			plugins: [
-				lazyGrammarPlugin,
-				dataInsertPlugin,
-				inlineRegexSourcePlugin,
-				terserPlugin
-			]
-		});
-	} finally {
-		await bundle?.close();
-	}
-}
-
-runTask(series(clean, parallel(buildJS, series(treeviewIconFont, minifyCSS))));
+// runTask(series(clean, parallel(buildJS, series(treeviewIconFont, minifyCSS))));
+runTask(series(clean, treeviewIconFont, minifyCSS));

--- a/scripts/create-changelog.ts
+++ b/scripts/create-changelog.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import simpleGit from 'simple-git';
-import { components } from './components';
-import { runTask } from './tasks';
+import { components } from './components.js';
+import { runTask } from './tasks.js';
 
 const git = simpleGit(__dirname);
 

--- a/scripts/linkify-changelog.ts
+++ b/scripts/linkify-changelog.ts
@@ -1,5 +1,5 @@
 import fs from 'fs/promises';
-import { runTask } from './tasks';
+import { runTask } from './tasks.js';
 
 runTask(async () => {
 	const changelog = 'CHANGELOG.md';

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -1,78 +1,7 @@
 {
   "extends": "../tsconfig.json",
   "compilerOptions": {
-    /* Visit https://aka.ms/tsconfig to read more about this file */
-
-    /* Projects */
-    // "incremental": true,                              /* Save .tsbuildinfo files to allow for incremental compilation of projects. */
-    // "composite": true,                                /* Enable constraints that allow a TypeScript project to be used with project references. */
-    // "tsBuildInfoFile": "./.tsbuildinfo",              /* Specify the path to .tsbuildinfo incremental compilation file. */
-    // "disableSourceOfProjectReferenceRedirect": true,  /* Disable preferring source files instead of declaration files when referencing composite projects. */
-    // "disableSolutionSearching": true,                 /* Opt a project out of multi-project reference checking when editing. */
-    // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
-
-    /* Language and Environment */
-    "target": "ES2020",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
-    // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
-    // "jsx": "preserve",                                /* Specify what JSX code is generated. */
-    // "experimentalDecorators": true,                   /* Enable experimental support for TC39 stage 2 draft decorators. */
-    // "emitDecoratorMetadata": true,                    /* Emit design-type metadata for decorated declarations in source files. */
-    // "jsxFactory": "",                                 /* Specify the JSX factory function used when targeting React JSX emit, e.g. 'React.createElement' or 'h'. */
-    // "jsxFragmentFactory": "",                         /* Specify the JSX Fragment reference used for fragments when targeting React JSX emit e.g. 'React.Fragment' or 'Fragment'. */
-    // "jsxImportSource": "",                            /* Specify module specifier used to import the JSX factory functions when using 'jsx: react-jsx*'. */
-    // "reactNamespace": "",                             /* Specify the object invoked for 'createElement'. This only applies when targeting 'react' JSX emit. */
-    // "noLib": true,                                    /* Disable including any library files, including the default lib.d.ts. */
-    // "useDefineForClassFields": true,                  /* Emit ECMAScript-standard-compliant class fields. */
-    // "moduleDetection": "auto",                        /* Control what method is used to detect module-format JS files. */
-
-    /* Modules */
-    "module": "CommonJS",                                /* Specify what module code is generated. */
-    // "rootDir": "./",                                  /* Specify the root folder within your source files. */
-    // "moduleResolution": "node",                       /* Specify how TypeScript looks up a file from a given module specifier. */
-    // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
-    // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
-    // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
-    // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */
-    // "types": [],                                      /* Specify type package names to be included without being referenced in a source file. */
-    // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
-    // "moduleSuffixes": [],                             /* List of file name suffixes to search when resolving a module. */
-    // "resolveJsonModule": true,                        /* Enable importing .json files. */
-    // "noResolve": true,                                /* Disallow 'import's, 'require's or '<reference>'s from expanding the number of files TypeScript should add to a project. */
-
-    /* JavaScript Support */
-    "allowJs": true,                                  /* Allow JavaScript files to be a part of your program. Use the 'checkJS' option to get errors from these files. */
-    "checkJs": true,                                  /* Enable error reporting in type-checked JavaScript files. */
-    // "maxNodeModuleJsDepth": 1,                        /* Specify the maximum folder depth used for checking JavaScript files from 'node_modules'. Only applicable with 'allowJs'. */
-
-    /* Emit */
-    // "declaration": true,                              /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
-    // "declarationMap": true,                           /* Create sourcemaps for d.ts files. */
-    // "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
-    // "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
-    // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
-    // "outDir": "./",                                   /* Specify an output folder for all emitted files. */
-    // "removeComments": true,                           /* Disable emitting comments. */
     "noEmit": true,                                   /* Disable emitting files from a compilation. */
-    // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */
-    // "importsNotUsedAsValues": "remove",               /* Specify emit/checking behavior for imports that are only used for types. */
-    // "downlevelIteration": true,                       /* Emit more compliant, but verbose and less performant JavaScript for iteration. */
-    // "sourceRoot": "",                                 /* Specify the root path for debuggers to find the reference source code. */
-    // "mapRoot": "",                                    /* Specify the location where debugger should locate map files instead of generated locations. */
-    // "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
-    // "inlineSources": true,                            /* Include source code in the sourcemaps inside the emitted JavaScript. */
-    // "emitBOM": true,                                  /* Emit a UTF-8 Byte Order Mark (BOM) in the beginning of output files. */
-    // "newLine": "crlf",                                /* Set the newline character for emitting files. */
-    // "stripInternal": true,                            /* Disable emitting declarations that have '@internal' in their JSDoc comments. */
-    // "noEmitHelpers": true,                            /* Disable generating custom helper functions like '__extends' in compiled output. */
-    // "noEmitOnError": true,                            /* Disable emitting files if any type checking errors are reported. */
-    // "preserveConstEnums": true,                       /* Disable erasing 'const enum' declarations in generated code. */
-    // "declarationDir": "./",                           /* Specify the output directory for generated declaration files. */
-    // "preserveValueImports": true,                     /* Preserve unused imported values in the JavaScript output that would otherwise be removed. */
-
-    /* Interop Constraints */
-    // "isolatedModules": true,                          /* Ensure that each file can be safely transpiled without relying on other imports. */
-    // "allowSyntheticDefaultImports": true,             /* Allow 'import x from y' when a module doesn't have a default export. */
-    "esModuleInterop": true,                             /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */
   },
   "include": ["./**/*"]
 }

--- a/src/auto-start.ts
+++ b/src/auto-start.ts
@@ -1,5 +1,5 @@
-import Prism from './global';
-import autoloader from './plugins/autoloader/prism-autoloader';
+import Prism from './global.js';
+import autoloader from './plugins/autoloader/prism-autoloader.js';
 
 Prism.components.add(autoloader);
 

--- a/src/core/hooks.ts
+++ b/src/core/hooks.ts
@@ -1,6 +1,6 @@
 import type { Grammar, TokenName } from '../types';
-import type { HookState } from './hook-state';
-import type { TokenStream } from './token';
+import type { HookState } from './hook-state.js';
+import type { TokenStream } from './token.js';
 
 export class Hooks {
 	// eslint-disable-next-line func-call-spacing

--- a/src/core/prism.ts
+++ b/src/core/prism.ts
@@ -1,16 +1,16 @@
-import { getLanguage, setLanguage } from '../shared/dom-util';
-import { rest, tokenize } from '../shared/symbols';
-import { htmlEncode } from '../shared/util';
-import { HookState } from './hook-state';
-import { Hooks } from './hooks';
-import { LinkedList } from './linked-list';
-import { Registry } from './registry';
-import { Token } from './token';
+import { getLanguage, setLanguage } from '../shared/dom-util.js';
+import { rest, tokenize } from '../shared/symbols.js';
+import { htmlEncode } from '../shared/util.js';
+import { HookState } from './hook-state.js';
+import { Hooks } from './hooks.js';
+import { LinkedList } from './linked-list.js';
+import { Registry } from './registry.js';
+import { Token } from './token.js';
 import type { KnownPlugins } from '../known-plugins';
 import type { Grammar, GrammarToken, GrammarTokens } from '../types';
-import type { HookEnvMap } from './hooks';
-import type { LinkedListHeadNode, LinkedListMiddleNode, LinkedListTailNode } from './linked-list';
-import type { TokenStream } from './token';
+import type { HookEnvMap } from './hooks.js';
+import type { LinkedListHeadNode, LinkedListMiddleNode, LinkedListTailNode } from './linked-list.js';
+import type { TokenStream } from './token.js';
 
 /**
  * Prism: Lightweight, robust, elegant syntax highlighting

--- a/src/core/registry.ts
+++ b/src/core/registry.ts
@@ -1,7 +1,7 @@
-import { extend } from '../shared/language-util';
-import { forEach, kebabToCamelCase } from '../shared/util';
+import { extend } from '../shared/language-util.js';
+import { forEach, kebabToCamelCase } from '../shared/util.js';
 import type { ComponentProto, Grammar } from '../types';
-import type { Prism } from './prism';
+import type { Prism } from './prism.js';
 
 interface Entry {
 	proto: ComponentProto;

--- a/src/global.ts
+++ b/src/global.ts
@@ -1,4 +1,4 @@
-import { Prism } from './core/prism';
+import { Prism } from './core/prism.js';
 
 const globalSymbol = Symbol.for('Prism global');
 

--- a/src/known-plugins.d.ts
+++ b/src/known-plugins.d.ts
@@ -1,13 +1,13 @@
-import type { Autoloader } from './plugins/autoloader/prism-autoloader';
-import type { CustomClass } from './plugins/custom-class/prism-custom-class';
-import type { FileHighlight } from './plugins/file-highlight/prism-file-highlight';
-import type { FilterHighlightAll } from './plugins/filter-highlight-all/prism-filter-highlight-all';
-import type { JsonpHighlight } from './plugins/jsonp-highlight/prism-jsonp-highlight';
-import type { LineHighlight } from './plugins/line-highlight/prism-line-highlight';
-import type { LineNumbers } from './plugins/line-numbers/prism-line-numbers';
-import type { NormalizeWhitespace } from './plugins/normalize-whitespace/prism-normalize-whitespace';
-import type { PreviewerCollection } from './plugins/previewers/prism-previewers';
-import type { Toolbar } from './plugins/toolbar/prism-toolbar';
+import type { Autoloader } from './plugins/autoloader/prism-autoloader.js';
+import type { CustomClass } from './plugins/custom-class/prism-custom-class.js';
+import type { FileHighlight } from './plugins/file-highlight/prism-file-highlight.js';
+import type { FilterHighlightAll } from './plugins/filter-highlight-all/prism-filter-highlight-all.js';
+import type { JsonpHighlight } from './plugins/jsonp-highlight/prism-jsonp-highlight.js';
+import type { LineHighlight } from './plugins/line-highlight/prism-line-highlight.js';
+import type { LineNumbers } from './plugins/line-numbers/prism-line-numbers.js';
+import type { NormalizeWhitespace } from './plugins/normalize-whitespace/prism-normalize-whitespace.js';
+import type { PreviewerCollection } from './plugins/previewers/prism-previewers.js';
+import type { Toolbar } from './plugins/toolbar/prism-toolbar.js';
 
 declare interface KnownPlugins {
 	autoloader: Autoloader;

--- a/src/languages/prism-actionscript.ts
+++ b/src/languages/prism-actionscript.ts
@@ -1,5 +1,5 @@
-import { insertBefore } from '../shared/language-util';
-import javascript from './prism-javascript';
+import { insertBefore } from '../shared/language-util.js';
+import javascript from './prism-javascript.js';
 import type { GrammarToken, LanguageProto } from '../types';
 
 export default {

--- a/src/languages/prism-apex.ts
+++ b/src/languages/prism-apex.ts
@@ -1,5 +1,5 @@
-import clike from './prism-clike';
-import sql from './prism-sql';
+import clike from './prism-clike.js';
+import sql from './prism-sql.js';
 import type { LanguageProto } from '../types';
 
 export default {

--- a/src/languages/prism-arduino.ts
+++ b/src/languages/prism-arduino.ts
@@ -1,4 +1,4 @@
-import cpp from './prism-cpp';
+import cpp from './prism-cpp.js';
 import type { LanguageProto } from '../types';
 
 export default {

--- a/src/languages/prism-asciidoc.ts
+++ b/src/languages/prism-asciidoc.ts
@@ -1,4 +1,4 @@
-import { rest } from '../shared/symbols';
+import { rest } from '../shared/symbols.js';
 import type { Grammar, GrammarToken, LanguageProto } from '../types';
 
 export default {

--- a/src/languages/prism-aspnet.ts
+++ b/src/languages/prism-aspnet.ts
@@ -1,7 +1,7 @@
-import { insertBefore } from '../shared/language-util';
-import { rest } from '../shared/symbols';
-import csharp from './prism-csharp';
-import markup from './prism-markup';
+import { insertBefore } from '../shared/language-util.js';
+import { rest } from '../shared/symbols.js';
+import csharp from './prism-csharp.js';
+import markup from './prism-markup.js';
 import type { Grammar, GrammarToken, LanguageProto } from '../types';
 
 export default {

--- a/src/languages/prism-birb.ts
+++ b/src/languages/prism-birb.ts
@@ -1,5 +1,5 @@
-import { insertBefore } from '../shared/language-util';
-import clike from './prism-clike';
+import { insertBefore } from '../shared/language-util.js';
+import clike from './prism-clike.js';
 import type { LanguageProto } from '../types';
 
 export default {

--- a/src/languages/prism-bison.ts
+++ b/src/languages/prism-bison.ts
@@ -1,6 +1,6 @@
-import { insertBefore } from '../shared/language-util';
-import { rest } from '../shared/symbols';
-import c from './prism-c';
+import { insertBefore } from '../shared/language-util.js';
+import { rest } from '../shared/symbols.js';
+import c from './prism-c.js';
 import type { LanguageProto } from '../types';
 
 export default {

--- a/src/languages/prism-c.ts
+++ b/src/languages/prism-c.ts
@@ -1,5 +1,5 @@
-import { insertBefore } from '../shared/language-util';
-import clike from './prism-clike';
+import { insertBefore } from '../shared/language-util.js';
+import clike from './prism-clike.js';
 import type { GrammarToken, LanguageProto } from '../types';
 
 export default {

--- a/src/languages/prism-cfscript.ts
+++ b/src/languages/prism-cfscript.ts
@@ -1,5 +1,5 @@
-import { insertBefore } from '../shared/language-util';
-import clike from './prism-clike';
+import { insertBefore } from '../shared/language-util.js';
+import clike from './prism-clike.js';
 import type { LanguageProto } from '../types';
 
 export default {

--- a/src/languages/prism-chaiscript.ts
+++ b/src/languages/prism-chaiscript.ts
@@ -1,7 +1,7 @@
-import { insertBefore } from '../shared/language-util';
-import { toArray } from '../shared/util';
-import clike from './prism-clike';
-import cpp from './prism-cpp';
+import { insertBefore } from '../shared/language-util.js';
+import { toArray } from '../shared/util.js';
+import clike from './prism-clike.js';
+import cpp from './prism-cpp.js';
 import type { LanguageProto } from '../types';
 
 export default {

--- a/src/languages/prism-cilkc.ts
+++ b/src/languages/prism-cilkc.ts
@@ -1,5 +1,5 @@
-import { insertBefore } from '../shared/language-util';
-import c from './prism-c';
+import { insertBefore } from '../shared/language-util.js';
+import c from './prism-c.js';
 import type { LanguageProto } from '../types';
 
 export default {

--- a/src/languages/prism-cilkcpp.ts
+++ b/src/languages/prism-cilkcpp.ts
@@ -1,5 +1,5 @@
-import { insertBefore } from '../shared/language-util';
-import cpp from './prism-cpp';
+import { insertBefore } from '../shared/language-util.js';
+import cpp from './prism-cpp.js';
 import type { LanguageProto } from '../types';
 
 export default {

--- a/src/languages/prism-coffeescript.ts
+++ b/src/languages/prism-coffeescript.ts
@@ -1,5 +1,5 @@
-import { insertBefore } from '../shared/language-util';
-import javascript from './prism-javascript';
+import { insertBefore } from '../shared/language-util.js';
+import javascript from './prism-javascript.js';
 import type { LanguageProto } from '../types';
 
 export default {

--- a/src/languages/prism-cpp.ts
+++ b/src/languages/prism-cpp.ts
@@ -1,5 +1,5 @@
-import { insertBefore } from '../shared/language-util';
-import c from './prism-c';
+import { insertBefore } from '../shared/language-util.js';
+import c from './prism-c.js';
 import type { LanguageProto } from '../types';
 
 export default {

--- a/src/languages/prism-crystal.ts
+++ b/src/languages/prism-crystal.ts
@@ -1,6 +1,6 @@
-import { insertBefore } from '../shared/language-util';
-import { toArray } from '../shared/util';
-import ruby from './prism-ruby';
+import { insertBefore } from '../shared/language-util.js';
+import { toArray } from '../shared/util.js';
+import ruby from './prism-ruby.js';
 import type { LanguageProto } from '../types';
 
 export default {

--- a/src/languages/prism-csharp.ts
+++ b/src/languages/prism-csharp.ts
@@ -1,5 +1,5 @@
-import { insertBefore } from '../shared/language-util';
-import clike from './prism-clike';
+import { insertBefore } from '../shared/language-util.js';
+import clike from './prism-clike.js';
 import type { LanguageProto } from '../types';
 
 /**

--- a/src/languages/prism-cshtml.ts
+++ b/src/languages/prism-cshtml.ts
@@ -1,6 +1,6 @@
-import { insertBefore } from '../shared/language-util';
-import csharp from './prism-csharp';
-import markup from './prism-markup';
+import { insertBefore } from '../shared/language-util.js';
+import csharp from './prism-csharp.js';
+import markup from './prism-markup.js';
 import type { Grammar, GrammarToken, LanguageProto } from '../types';
 
 export default {

--- a/src/languages/prism-css-extras.ts
+++ b/src/languages/prism-css-extras.ts
@@ -1,4 +1,4 @@
-import cssSelector from './prism-css-selector';
+import cssSelector from './prism-css-selector.js';
 import type { LanguageProto } from '../types';
 
 export default {

--- a/src/languages/prism-css.ts
+++ b/src/languages/prism-css.ts
@@ -1,5 +1,5 @@
-import { insertBefore } from '../shared/language-util';
-import { rest } from '../shared/symbols';
+import { insertBefore } from '../shared/language-util.js';
+import { rest } from '../shared/symbols.js';
 import type { LanguageProto } from '../types';
 
 export default {

--- a/src/languages/prism-d.ts
+++ b/src/languages/prism-d.ts
@@ -1,5 +1,5 @@
-import { insertBefore } from '../shared/language-util';
-import clike from './prism-clike';
+import { insertBefore } from '../shared/language-util.js';
+import clike from './prism-clike.js';
 import type { LanguageProto } from '../types';
 
 export default {

--- a/src/languages/prism-dart.ts
+++ b/src/languages/prism-dart.ts
@@ -1,5 +1,5 @@
-import { insertBefore } from '../shared/language-util';
-import clike from './prism-clike';
+import { insertBefore } from '../shared/language-util.js';
+import clike from './prism-clike.js';
 import type { LanguageProto } from '../types';
 
 export default {

--- a/src/languages/prism-django.ts
+++ b/src/languages/prism-django.ts
@@ -1,6 +1,6 @@
-import { embeddedIn } from '../shared/languages/templating';
-import { tokenize } from '../shared/symbols';
-import markup from './prism-markup';
+import { embeddedIn } from '../shared/languages/templating.js';
+import { tokenize } from '../shared/symbols.js';
+import markup from './prism-markup.js';
 import type { LanguageProto } from '../types';
 
 // Django/Jinja2 syntax definition for Prism.js <http://prismjs.com> syntax highlighter.

--- a/src/languages/prism-ejs.ts
+++ b/src/languages/prism-ejs.ts
@@ -1,7 +1,7 @@
-import { embeddedIn } from '../shared/languages/templating';
-import { tokenize } from '../shared/symbols';
-import javascript from './prism-javascript';
-import markup from './prism-markup';
+import { embeddedIn } from '../shared/languages/templating.js';
+import { tokenize } from '../shared/symbols.js';
+import javascript from './prism-javascript.js';
+import markup from './prism-markup.js';
 import type { LanguageProto } from '../types';
 
 export default {

--- a/src/languages/prism-elixir.ts
+++ b/src/languages/prism-elixir.ts
@@ -1,4 +1,4 @@
-import { rest } from '../shared/symbols';
+import { rest } from '../shared/symbols.js';
 import type { LanguageProto } from '../types';
 
 export default {

--- a/src/languages/prism-erb.ts
+++ b/src/languages/prism-erb.ts
@@ -1,7 +1,7 @@
-import { embeddedIn } from '../shared/languages/templating';
-import { tokenize } from '../shared/symbols';
-import markup from './prism-markup';
-import ruby from './prism-ruby';
+import { embeddedIn } from '../shared/languages/templating.js';
+import { tokenize } from '../shared/symbols.js';
+import markup from './prism-markup.js';
+import ruby from './prism-ruby.js';
 import type { LanguageProto } from '../types';
 
 export default {

--- a/src/languages/prism-etlua.ts
+++ b/src/languages/prism-etlua.ts
@@ -1,7 +1,7 @@
-import { embeddedIn } from '../shared/languages/templating';
-import { tokenize } from '../shared/symbols';
-import lua from './prism-lua';
-import markup from './prism-markup';
+import { embeddedIn } from '../shared/languages/templating.js';
+import { tokenize } from '../shared/symbols.js';
+import lua from './prism-lua.js';
+import markup from './prism-markup.js';
 import type { LanguageProto } from '../types';
 
 export default {

--- a/src/languages/prism-factor.ts
+++ b/src/languages/prism-factor.ts
@@ -1,4 +1,4 @@
-import { regexEscape } from '../shared/util';
+import { regexEscape } from '../shared/util.js';
 import type { LanguageProto } from '../types';
 
 export default {

--- a/src/languages/prism-firestore-security-rules.ts
+++ b/src/languages/prism-firestore-security-rules.ts
@@ -1,5 +1,5 @@
-import { insertBefore } from '../shared/language-util';
-import clike from './prism-clike';
+import { insertBefore } from '../shared/language-util.js';
+import clike from './prism-clike.js';
 import type { LanguageProto } from '../types';
 
 export default {

--- a/src/languages/prism-flow.ts
+++ b/src/languages/prism-flow.ts
@@ -1,6 +1,6 @@
-import { insertBefore } from '../shared/language-util';
-import { toArray } from '../shared/util';
-import javascript from './prism-javascript';
+import { insertBefore } from '../shared/language-util.js';
+import { toArray } from '../shared/util.js';
+import javascript from './prism-javascript.js';
 import type { GrammarToken, LanguageProto } from '../types';
 
 export default {

--- a/src/languages/prism-fsharp.ts
+++ b/src/languages/prism-fsharp.ts
@@ -1,5 +1,5 @@
-import { insertBefore } from '../shared/language-util';
-import clike from './prism-clike';
+import { insertBefore } from '../shared/language-util.js';
+import clike from './prism-clike.js';
 import type { LanguageProto } from '../types';
 
 export default {

--- a/src/languages/prism-ftl.ts
+++ b/src/languages/prism-ftl.ts
@@ -1,6 +1,6 @@
-import { embeddedIn } from '../shared/languages/templating';
-import { rest, tokenize } from '../shared/symbols';
-import markup from './prism-markup';
+import { embeddedIn } from '../shared/languages/templating.js';
+import { rest, tokenize } from '../shared/symbols.js';
+import markup from './prism-markup.js';
 import type { Grammar, LanguageProto } from '../types';
 
 export default {

--- a/src/languages/prism-glsl.ts
+++ b/src/languages/prism-glsl.ts
@@ -1,4 +1,4 @@
-import c from './prism-c';
+import c from './prism-c.js';
 import type { LanguageProto } from '../types';
 
 export default {

--- a/src/languages/prism-gml.ts
+++ b/src/languages/prism-gml.ts
@@ -1,4 +1,4 @@
-import clike from './prism-clike';
+import clike from './prism-clike.js';
 import type { LanguageProto } from '../types';
 
 export default {

--- a/src/languages/prism-go.ts
+++ b/src/languages/prism-go.ts
@@ -1,5 +1,5 @@
-import { insertBefore } from '../shared/language-util';
-import clike from './prism-clike';
+import { insertBefore } from '../shared/language-util.js';
+import clike from './prism-clike.js';
 import type { LanguageProto } from '../types';
 
 export default {

--- a/src/languages/prism-gradle.ts
+++ b/src/languages/prism-gradle.ts
@@ -1,5 +1,5 @@
-import { insertBefore } from '../shared/language-util';
-import clike from './prism-clike';
+import { insertBefore } from '../shared/language-util.js';
+import clike from './prism-clike.js';
 import type { LanguageProto } from '../types';
 
 export default {

--- a/src/languages/prism-graphql.ts
+++ b/src/languages/prism-graphql.ts
@@ -1,6 +1,6 @@
-import { withoutTokenize } from '../shared/language-util';
-import { tokenize } from '../shared/symbols';
-import type { Token } from '../core';
+import { withoutTokenize } from '../shared/language-util.js';
+import { tokenize } from '../shared/symbols.js';
+import type { Token } from '../core.js';
 import type { LanguageProto } from '../types';
 
 export default {

--- a/src/languages/prism-groovy.ts
+++ b/src/languages/prism-groovy.ts
@@ -1,5 +1,5 @@
-import { insertBefore } from '../shared/language-util';
-import clike from './prism-clike';
+import { insertBefore } from '../shared/language-util.js';
+import clike from './prism-clike.js';
 import type { LanguageProto } from '../types';
 
 export default {

--- a/src/languages/prism-haml.ts
+++ b/src/languages/prism-haml.ts
@@ -1,5 +1,5 @@
-import { insertBefore } from '../shared/language-util';
-import ruby from './prism-ruby';
+import { insertBefore } from '../shared/language-util.js';
+import ruby from './prism-ruby.js';
 import type { Grammar, LanguageProto } from '../types';
 
 export default {

--- a/src/languages/prism-handlebars.ts
+++ b/src/languages/prism-handlebars.ts
@@ -1,6 +1,6 @@
-import { embeddedIn } from '../shared/languages/templating';
-import { tokenize } from '../shared/symbols';
-import markup from './prism-markup';
+import { embeddedIn } from '../shared/languages/templating.js';
+import { tokenize } from '../shared/symbols.js';
+import markup from './prism-markup.js';
 import type { LanguageProto } from '../types';
 
 export default {

--- a/src/languages/prism-haxe.ts
+++ b/src/languages/prism-haxe.ts
@@ -1,5 +1,5 @@
-import { insertBefore } from '../shared/language-util';
-import clike from './prism-clike';
+import { insertBefore } from '../shared/language-util.js';
+import clike from './prism-clike.js';
 import type { LanguageProto } from '../types';
 
 export default {

--- a/src/languages/prism-hlsl.ts
+++ b/src/languages/prism-hlsl.ts
@@ -1,5 +1,5 @@
-import { toArray } from '../shared/util';
-import c from './prism-c';
+import { toArray } from '../shared/util.js';
+import c from './prism-c.js';
 import type { LanguageProto } from '../types';
 
 export default {

--- a/src/languages/prism-http.ts
+++ b/src/languages/prism-http.ts
@@ -1,4 +1,4 @@
-import { insertBefore } from '../shared/language-util';
+import { insertBefore } from '../shared/language-util.js';
 import type { Grammar, LanguageProto } from '../types';
 
 export default {

--- a/src/languages/prism-icu-message-format.ts
+++ b/src/languages/prism-icu-message-format.ts
@@ -1,4 +1,4 @@
-import { rest } from '../shared/symbols';
+import { rest } from '../shared/symbols.js';
 import type { LanguageProto } from '../types';
 
 export default {

--- a/src/languages/prism-idris.ts
+++ b/src/languages/prism-idris.ts
@@ -1,5 +1,5 @@
-import { insertBefore } from '../shared/language-util';
-import haskell from './prism-haskell';
+import { insertBefore } from '../shared/language-util.js';
+import haskell from './prism-haskell.js';
 import type { LanguageProto } from '../types';
 
 export default {

--- a/src/languages/prism-inform7.ts
+++ b/src/languages/prism-inform7.ts
@@ -1,4 +1,4 @@
-import { rest } from '../shared/symbols';
+import { rest } from '../shared/symbols.js';
 import type { Grammar, LanguageProto } from '../types';
 
 export default {

--- a/src/languages/prism-java.ts
+++ b/src/languages/prism-java.ts
@@ -1,6 +1,6 @@
-import { insertBefore } from '../shared/language-util';
-import { toArray } from '../shared/util';
-import clike from './prism-clike';
+import { insertBefore } from '../shared/language-util.js';
+import { toArray } from '../shared/util.js';
+import clike from './prism-clike.js';
 import type { LanguageProto } from '../types';
 
 export default {

--- a/src/languages/prism-javadoc.ts
+++ b/src/languages/prism-javadoc.ts
@@ -1,7 +1,7 @@
-import { insertBefore } from '../shared/language-util';
-import java from './prism-java';
-import javadoclike from './prism-javadoclike';
-import markup from './prism-markup';
+import { insertBefore } from '../shared/language-util.js';
+import java from './prism-java.js';
+import javadoclike from './prism-javadoclike.js';
+import markup from './prism-markup.js';
 import type { LanguageProto } from '../types';
 
 export default {

--- a/src/languages/prism-javascript.ts
+++ b/src/languages/prism-javascript.ts
@@ -1,8 +1,8 @@
-import { insertBefore } from '../shared/language-util';
-import { JS_TEMPLATE, JS_TEMPLATE_INTERPOLATION } from '../shared/languages/patterns';
-import { rest } from '../shared/symbols';
-import { toArray } from '../shared/util';
-import clike from './prism-clike';
+import { insertBefore } from '../shared/language-util.js';
+import { JS_TEMPLATE, JS_TEMPLATE_INTERPOLATION } from '../shared/languages/patterns.js';
+import { rest } from '../shared/symbols.js';
+import { toArray } from '../shared/util.js';
+import clike from './prism-clike.js';
 import type { LanguageProto } from '../types';
 
 export default {

--- a/src/languages/prism-jolie.ts
+++ b/src/languages/prism-jolie.ts
@@ -1,5 +1,5 @@
-import { insertBefore } from '../shared/language-util';
-import clike from './prism-clike';
+import { insertBefore } from '../shared/language-util.js';
+import clike from './prism-clike.js';
 import type { LanguageProto } from '../types';
 
 export default {

--- a/src/languages/prism-js-templates.ts
+++ b/src/languages/prism-js-templates.ts
@@ -1,6 +1,6 @@
-import { JS_TEMPLATE, JS_TEMPLATE_INTERPOLATION } from '../shared/languages/patterns';
-import { embeddedIn } from '../shared/languages/templating';
-import { rest, tokenize } from '../shared/symbols';
+import { JS_TEMPLATE, JS_TEMPLATE_INTERPOLATION } from '../shared/languages/patterns.js';
+import { embeddedIn } from '../shared/languages/templating.js';
+import { rest, tokenize } from '../shared/symbols.js';
 import type { GrammarToken, LanguageProto } from '../types';
 
 /**

--- a/src/languages/prism-jsdoc.ts
+++ b/src/languages/prism-jsdoc.ts
@@ -1,7 +1,7 @@
-import { insertBefore } from '../shared/language-util';
-import javadoclike from './prism-javadoclike';
-import javascript from './prism-javascript';
-import typescript from './prism-typescript';
+import { insertBefore } from '../shared/language-util.js';
+import javadoclike from './prism-javadoclike.js';
+import javascript from './prism-javascript.js';
+import typescript from './prism-typescript.js';
 import type { LanguageProto } from '../types';
 
 export default {

--- a/src/languages/prism-json5.ts
+++ b/src/languages/prism-json5.ts
@@ -1,4 +1,4 @@
-import json from './prism-json';
+import json from './prism-json.js';
 import type { LanguageProto } from '../types';
 
 export default {

--- a/src/languages/prism-jsonp.ts
+++ b/src/languages/prism-jsonp.ts
@@ -1,5 +1,5 @@
-import { insertBefore } from '../shared/language-util';
-import json from './prism-json';
+import { insertBefore } from '../shared/language-util.js';
+import json from './prism-json.js';
 import type { LanguageProto } from '../types';
 
 export default {

--- a/src/languages/prism-jsx.ts
+++ b/src/languages/prism-jsx.ts
@@ -1,9 +1,9 @@
-import { Token, getTextContent } from '../core/token';
-import { insertBefore, withoutTokenize } from '../shared/language-util';
-import { rest, tokenize } from '../shared/symbols';
-import javascript from './prism-javascript';
-import markup from './prism-markup';
-import type { TokenStream } from '../core/token';
+import { Token, getTextContent } from '../core/token.js';
+import { insertBefore, withoutTokenize } from '../shared/language-util.js';
+import { rest, tokenize } from '../shared/symbols.js';
+import javascript from './prism-javascript.js';
+import markup from './prism-markup.js';
+import type { TokenStream } from '../core/token.js';
 import type { Grammar, GrammarToken, LanguageProto } from '../types';
 
 function stringifyToken(token: string | Token | TokenStream | undefined): string {

--- a/src/languages/prism-kotlin.ts
+++ b/src/languages/prism-kotlin.ts
@@ -1,5 +1,5 @@
-import { insertBefore } from '../shared/language-util';
-import clike from './prism-clike';
+import { insertBefore } from '../shared/language-util.js';
+import clike from './prism-clike.js';
 import type { LanguageProto } from '../types';
 
 export default {

--- a/src/languages/prism-latte.ts
+++ b/src/languages/prism-latte.ts
@@ -1,8 +1,8 @@
-import { insertBefore } from '../shared/language-util';
-import { embeddedIn } from '../shared/languages/templating';
-import { tokenize } from '../shared/symbols';
-import markup from './prism-markup';
-import php from './prism-php';
+import { insertBefore } from '../shared/language-util.js';
+import { embeddedIn } from '../shared/languages/templating.js';
+import { tokenize } from '../shared/symbols.js';
+import markup from './prism-markup.js';
+import php from './prism-php.js';
 import type { Grammar, GrammarToken, LanguageProto } from '../types';
 
 export default {

--- a/src/languages/prism-less.ts
+++ b/src/languages/prism-less.ts
@@ -1,5 +1,5 @@
-import { insertBefore } from '../shared/language-util';
-import css from './prism-css';
+import { insertBefore } from '../shared/language-util.js';
+import css from './prism-css.js';
 import type { LanguageProto } from '../types';
 
 export default {

--- a/src/languages/prism-lilypond.ts
+++ b/src/languages/prism-lilypond.ts
@@ -1,5 +1,5 @@
-import { rest } from '../shared/symbols';
-import scheme from './prism-scheme';
+import { rest } from '../shared/symbols.js';
+import scheme from './prism-scheme.js';
 import type { LanguageProto } from '../types';
 
 export default {

--- a/src/languages/prism-liquid.ts
+++ b/src/languages/prism-liquid.ts
@@ -1,6 +1,6 @@
-import { embeddedIn } from '../shared/languages/templating';
-import { tokenize } from '../shared/symbols';
-import markup from './prism-markup';
+import { embeddedIn } from '../shared/languages/templating.js';
+import { tokenize } from '../shared/symbols.js';
+import markup from './prism-markup.js';
 import type { LanguageProto } from '../types';
 
 export default {

--- a/src/languages/prism-lisp.ts
+++ b/src/languages/prism-lisp.ts
@@ -1,4 +1,4 @@
-import { rest } from '../shared/symbols';
+import { rest } from '../shared/symbols.js';
 import type { LanguageProto } from '../types';
 
 export default {

--- a/src/languages/prism-livescript.ts
+++ b/src/languages/prism-livescript.ts
@@ -1,4 +1,4 @@
-import { rest } from '../shared/symbols';
+import { rest } from '../shared/symbols.js';
 import type { LanguageProto } from '../types';
 
 export default {

--- a/src/languages/prism-markdown.ts
+++ b/src/languages/prism-markdown.ts
@@ -1,7 +1,7 @@
-import { getTextContent } from '../core/token';
-import { insertBefore, withoutTokenize } from '../shared/language-util';
-import { tokenize } from '../shared/symbols';
-import markup from './prism-markup';
+import { getTextContent } from '../core/token.js';
+import { insertBefore, withoutTokenize } from '../shared/language-util.js';
+import { tokenize } from '../shared/symbols.js';
+import markup from './prism-markup.js';
 import type { Grammar, GrammarToken, LanguageProto } from '../types';
 
 export default {

--- a/src/languages/prism-markup.ts
+++ b/src/languages/prism-markup.ts
@@ -1,5 +1,5 @@
-import { insertBefore } from '../shared/language-util';
-import xml from './prism-xml';
+import { insertBefore } from '../shared/language-util.js';
+import xml from './prism-xml.js';
 import type { Grammar, GrammarToken, LanguageProto } from '../types';
 
 /**

--- a/src/languages/prism-mongodb.ts
+++ b/src/languages/prism-mongodb.ts
@@ -1,5 +1,5 @@
-import { insertBefore } from '../shared/language-util';
-import javascript from './prism-javascript';
+import { insertBefore } from '../shared/language-util.js';
+import javascript from './prism-javascript.js';
 import type { GrammarToken, LanguageProto } from '../types';
 
 export default {

--- a/src/languages/prism-n4js.ts
+++ b/src/languages/prism-n4js.ts
@@ -1,5 +1,5 @@
-import { insertBefore } from '../shared/language-util';
-import javascript from './prism-javascript';
+import { insertBefore } from '../shared/language-util.js';
+import javascript from './prism-javascript.js';
 import type { LanguageProto } from '../types';
 
 export default {

--- a/src/languages/prism-naniscript.ts
+++ b/src/languages/prism-naniscript.ts
@@ -1,6 +1,6 @@
-import { getTextContent } from '../core/token';
-import { withoutTokenize } from '../shared/language-util';
-import { tokenize } from '../shared/symbols';
+import { getTextContent } from '../core/token.js';
+import { withoutTokenize } from '../shared/language-util.js';
+import { tokenize } from '../shared/symbols.js';
 import type { LanguageProto } from '../types';
 
 function isBracketsBalanced(input: string): boolean {

--- a/src/languages/prism-objectivec.ts
+++ b/src/languages/prism-objectivec.ts
@@ -1,4 +1,4 @@
-import c from './prism-c';
+import c from './prism-c.js';
 import type { LanguageProto } from '../types';
 
 export default {

--- a/src/languages/prism-opencl.ts
+++ b/src/languages/prism-opencl.ts
@@ -1,5 +1,5 @@
-import { insertBefore } from '../shared/language-util';
-import c from './prism-c';
+import { insertBefore } from '../shared/language-util.js';
+import c from './prism-c.js';
 import type { LanguageProto } from '../types';
 
 export default {

--- a/src/languages/prism-parser.ts
+++ b/src/languages/prism-parser.ts
@@ -1,5 +1,5 @@
-import { insertBefore } from '../shared/language-util';
-import markup from './prism-markup';
+import { insertBefore } from '../shared/language-util.js';
+import markup from './prism-markup.js';
 import type { Grammar, GrammarToken, LanguageProto } from '../types';
 
 export default {

--- a/src/languages/prism-php.ts
+++ b/src/languages/prism-php.ts
@@ -1,7 +1,7 @@
-import { insertBefore } from '../shared/language-util';
-import { embeddedIn } from '../shared/languages/templating';
-import { tokenize } from '../shared/symbols';
-import markup from './prism-markup';
+import { insertBefore } from '../shared/language-util.js';
+import { embeddedIn } from '../shared/languages/templating.js';
+import { tokenize } from '../shared/symbols.js';
+import markup from './prism-markup.js';
 import type { LanguageProto } from '../types';
 
 export default {

--- a/src/languages/prism-phpdoc.ts
+++ b/src/languages/prism-phpdoc.ts
@@ -1,5 +1,5 @@
-import { insertBefore } from '../shared/language-util';
-import javadoclike from './prism-javadoclike';
+import { insertBefore } from '../shared/language-util.js';
+import javadoclike from './prism-javadoclike.js';
 import type { LanguageProto } from '../types';
 
 export default {

--- a/src/languages/prism-plsql.ts
+++ b/src/languages/prism-plsql.ts
@@ -1,5 +1,5 @@
-import { insertBefore } from '../shared/language-util';
-import sql from './prism-sql';
+import { insertBefore } from '../shared/language-util.js';
+import sql from './prism-sql.js';
 import type { LanguageProto } from '../types';
 
 export default {

--- a/src/languages/prism-processing.ts
+++ b/src/languages/prism-processing.ts
@@ -1,5 +1,5 @@
-import { insertBefore } from '../shared/language-util';
-import clike from './prism-clike';
+import { insertBefore } from '../shared/language-util.js';
+import clike from './prism-clike.js';
 import type { LanguageProto } from '../types';
 
 export default {

--- a/src/languages/prism-protobuf.ts
+++ b/src/languages/prism-protobuf.ts
@@ -1,5 +1,5 @@
-import { insertBefore } from '../shared/language-util';
-import clike from './prism-clike';
+import { insertBefore } from '../shared/language-util.js';
+import clike from './prism-clike.js';
 import type { LanguageProto } from '../types';
 
 export default {

--- a/src/languages/prism-pug.ts
+++ b/src/languages/prism-pug.ts
@@ -1,7 +1,7 @@
-import { insertBefore } from '../shared/language-util';
-import { rest } from '../shared/symbols';
-import javascript from './prism-javascript';
-import markup from './prism-markup';
+import { insertBefore } from '../shared/language-util.js';
+import { rest } from '../shared/symbols.js';
+import javascript from './prism-javascript.js';
+import markup from './prism-markup.js';
 import type { GrammarTokens, LanguageProto } from '../types';
 
 export default {

--- a/src/languages/prism-puppet.ts
+++ b/src/languages/prism-puppet.ts
@@ -1,4 +1,4 @@
-import { rest } from '../shared/symbols';
+import { rest } from '../shared/symbols.js';
 import type { LanguageProto } from '../types';
 
 export default {

--- a/src/languages/prism-pure.ts
+++ b/src/languages/prism-pure.ts
@@ -1,5 +1,5 @@
-import { insertBefore } from '../shared/language-util';
-import { rest } from '../shared/symbols';
+import { insertBefore } from '../shared/language-util.js';
+import { rest } from '../shared/symbols.js';
 import type { LanguageProto } from '../types';
 
 export default {

--- a/src/languages/prism-purebasic.ts
+++ b/src/languages/prism-purebasic.ts
@@ -1,5 +1,5 @@
-import { insertBefore } from '../shared/language-util';
-import clike from './prism-clike';
+import { insertBefore } from '../shared/language-util.js';
+import clike from './prism-clike.js';
 import type { LanguageProto } from '../types';
 
 export default {

--- a/src/languages/prism-purescript.ts
+++ b/src/languages/prism-purescript.ts
@@ -1,4 +1,4 @@
-import haskell, { asciiOperator, infixOperator } from './prism-haskell';
+import haskell, { asciiOperator, infixOperator } from './prism-haskell.js';
 import type { LanguageProto } from '../types';
 
 export default {

--- a/src/languages/prism-python.ts
+++ b/src/languages/prism-python.ts
@@ -1,4 +1,4 @@
-import { rest } from '../shared/symbols';
+import { rest } from '../shared/symbols.js';
 import type { LanguageProto } from '../types';
 
 export default {

--- a/src/languages/prism-qml.ts
+++ b/src/languages/prism-qml.ts
@@ -1,4 +1,4 @@
-import javascript from './prism-javascript';
+import javascript from './prism-javascript.js';
 import type { LanguageProto } from '../types';
 
 export default {

--- a/src/languages/prism-qore.ts
+++ b/src/languages/prism-qore.ts
@@ -1,4 +1,4 @@
-import clike from './prism-clike';
+import clike from './prism-clike.js';
 import type { LanguageProto } from '../types';
 
 export default {

--- a/src/languages/prism-qsharp.ts
+++ b/src/languages/prism-qsharp.ts
@@ -1,5 +1,5 @@
-import { insertBefore } from '../shared/language-util';
-import clike from './prism-clike';
+import { insertBefore } from '../shared/language-util.js';
+import clike from './prism-clike.js';
 import type { LanguageProto } from '../types';
 
 export default {

--- a/src/languages/prism-racket.ts
+++ b/src/languages/prism-racket.ts
@@ -1,5 +1,5 @@
-import { insertBefore } from '../shared/language-util';
-import scheme from './prism-scheme';
+import { insertBefore } from '../shared/language-util.js';
+import scheme from './prism-scheme.js';
 import type { LanguageProto } from '../types';
 
 export default {

--- a/src/languages/prism-reason.ts
+++ b/src/languages/prism-reason.ts
@@ -1,5 +1,5 @@
-import { insertBefore } from '../shared/language-util';
-import clike from './prism-clike';
+import { insertBefore } from '../shared/language-util.js';
+import clike from './prism-clike.js';
 import type { LanguageProto } from '../types';
 
 export default {

--- a/src/languages/prism-rescript.ts
+++ b/src/languages/prism-rescript.ts
@@ -1,5 +1,5 @@
-import { insertBefore } from '../shared/language-util';
-import { rest } from '../shared/symbols';
+import { insertBefore } from '../shared/language-util.js';
+import { rest } from '../shared/symbols.js';
 import type { LanguageProto } from '../types';
 
 export default {

--- a/src/languages/prism-ruby.ts
+++ b/src/languages/prism-ruby.ts
@@ -1,5 +1,5 @@
-import { insertBefore } from '../shared/language-util';
-import clike from './prism-clike';
+import { insertBefore } from '../shared/language-util.js';
+import clike from './prism-clike.js';
 import type { LanguageProto } from '../types';
 
 export default {

--- a/src/languages/prism-rust.ts
+++ b/src/languages/prism-rust.ts
@@ -1,4 +1,4 @@
-import { rest } from '../shared/symbols';
+import { rest } from '../shared/symbols.js';
 import type { LanguageProto } from '../types';
 
 export default {

--- a/src/languages/prism-sas.ts
+++ b/src/languages/prism-sas.ts
@@ -1,4 +1,4 @@
-import { rest } from '../shared/symbols';
+import { rest } from '../shared/symbols.js';
 import type { LanguageProto } from '../types';
 
 export default {

--- a/src/languages/prism-sass.ts
+++ b/src/languages/prism-sass.ts
@@ -1,5 +1,5 @@
-import { insertBefore } from '../shared/language-util';
-import css from './prism-css';
+import { insertBefore } from '../shared/language-util.js';
+import css from './prism-css.js';
 import type { LanguageProto } from '../types';
 
 export default {

--- a/src/languages/prism-scala.ts
+++ b/src/languages/prism-scala.ts
@@ -1,5 +1,5 @@
-import { insertBefore } from '../shared/language-util';
-import java from './prism-java';
+import { insertBefore } from '../shared/language-util.js';
+import java from './prism-java.js';
 import type { LanguageProto } from '../types';
 
 export default {

--- a/src/languages/prism-scss.ts
+++ b/src/languages/prism-scss.ts
@@ -1,6 +1,6 @@
-import { insertBefore } from '../shared/language-util';
-import { rest } from '../shared/symbols';
-import css from './prism-css';
+import { insertBefore } from '../shared/language-util.js';
+import { rest } from '../shared/symbols.js';
+import css from './prism-css.js';
 import type { LanguageProto } from '../types';
 
 export default {

--- a/src/languages/prism-shell-session.ts
+++ b/src/languages/prism-shell-session.ts
@@ -1,4 +1,4 @@
-import bash from './prism-bash';
+import bash from './prism-bash.js';
 import type { LanguageProto } from '../types';
 
 export default {

--- a/src/languages/prism-smarty.ts
+++ b/src/languages/prism-smarty.ts
@@ -1,6 +1,6 @@
-import { embeddedIn } from '../shared/languages/templating';
-import { tokenize } from '../shared/symbols';
-import markup from './prism-markup';
+import { embeddedIn } from '../shared/languages/templating.js';
+import { tokenize } from '../shared/symbols.js';
+import markup from './prism-markup.js';
 import type { GrammarToken, LanguageProto } from '../types';
 
 export default {

--- a/src/languages/prism-solidity.ts
+++ b/src/languages/prism-solidity.ts
@@ -1,5 +1,5 @@
-import { insertBefore } from '../shared/language-util';
-import clike from './prism-clike';
+import { insertBefore } from '../shared/language-util.js';
+import clike from './prism-clike.js';
 import type { LanguageProto } from '../types';
 
 export default {

--- a/src/languages/prism-soy.ts
+++ b/src/languages/prism-soy.ts
@@ -1,6 +1,6 @@
-import { embeddedIn } from '../shared/languages/templating';
-import { tokenize } from '../shared/symbols';
-import markup from './prism-markup';
+import { embeddedIn } from '../shared/languages/templating.js';
+import { tokenize } from '../shared/symbols.js';
+import markup from './prism-markup.js';
 import type { LanguageProto } from '../types';
 
 export default {

--- a/src/languages/prism-sparql.ts
+++ b/src/languages/prism-sparql.ts
@@ -1,5 +1,5 @@
-import { insertBefore } from '../shared/language-util';
-import turtle from './prism-turtle';
+import { insertBefore } from '../shared/language-util.js';
+import turtle from './prism-turtle.js';
 import type { LanguageProto } from '../types';
 
 export default {

--- a/src/languages/prism-sqf.ts
+++ b/src/languages/prism-sqf.ts
@@ -1,5 +1,5 @@
-import { insertBefore } from '../shared/language-util';
-import clike from './prism-clike';
+import { insertBefore } from '../shared/language-util.js';
+import clike from './prism-clike.js';
 import type { LanguageProto } from '../types';
 
 export default {

--- a/src/languages/prism-squirrel.ts
+++ b/src/languages/prism-squirrel.ts
@@ -1,6 +1,6 @@
-import { insertBefore } from '../shared/language-util';
-import { toArray } from '../shared/util';
-import clike from './prism-clike';
+import { insertBefore } from '../shared/language-util.js';
+import { toArray } from '../shared/util.js';
+import clike from './prism-clike.js';
 import type { LanguageProto } from '../types';
 
 export default {

--- a/src/languages/prism-stata.ts
+++ b/src/languages/prism-stata.ts
@@ -1,6 +1,6 @@
-import java from './prism-java';
-import mata from './prism-mata';
-import python from './prism-python';
+import java from './prism-java.js';
+import mata from './prism-mata.js';
+import python from './prism-python.js';
 import type { LanguageProto } from '../types';
 
 export default {

--- a/src/languages/prism-stylus.ts
+++ b/src/languages/prism-stylus.ts
@@ -1,4 +1,4 @@
-import { rest } from '../shared/symbols';
+import { rest } from '../shared/symbols.js';
 import type { Grammar, LanguageProto } from '../types';
 
 export default {

--- a/src/languages/prism-t4-cs.ts
+++ b/src/languages/prism-t4-cs.ts
@@ -1,5 +1,5 @@
-import { createT4 } from '../shared/languages/t4-templating';
-import csharp from './prism-csharp';
+import { createT4 } from '../shared/languages/t4-templating.js';
+import csharp from './prism-csharp.js';
 import type { LanguageProto } from '../types';
 
 export default {

--- a/src/languages/prism-t4-vb.ts
+++ b/src/languages/prism-t4-vb.ts
@@ -1,5 +1,5 @@
-import { createT4 } from '../shared/languages/t4-templating';
-import vbnet from './prism-vbnet';
+import { createT4 } from '../shared/languages/t4-templating.js';
+import vbnet from './prism-vbnet.js';
 import type { LanguageProto } from '../types';
 
 export default {

--- a/src/languages/prism-tap.ts
+++ b/src/languages/prism-tap.ts
@@ -1,4 +1,4 @@
-import yaml from './prism-yaml';
+import yaml from './prism-yaml.js';
 import type { LanguageProto } from '../types';
 
 // https://en.wikipedia.org/wiki/Test_Anything_Protocol

--- a/src/languages/prism-textile.ts
+++ b/src/languages/prism-textile.ts
@@ -1,4 +1,4 @@
-import markup from './prism-markup';
+import markup from './prism-markup.js';
 import type { GrammarToken, LanguageProto } from '../types';
 
 export default {

--- a/src/languages/prism-treeview.ts
+++ b/src/languages/prism-treeview.ts
@@ -1,6 +1,6 @@
-import { getTextContent } from '../core/token';
-import { withoutTokenize } from '../shared/language-util';
-import { tokenize } from '../shared/symbols';
+import { getTextContent } from '../core/token.js';
+import { withoutTokenize } from '../shared/language-util.js';
+import { tokenize } from '../shared/symbols.js';
 import type { LanguageProto } from '../types';
 
 export default {

--- a/src/languages/prism-tsx.ts
+++ b/src/languages/prism-tsx.ts
@@ -1,5 +1,5 @@
-import jsx from './prism-jsx';
-import typescript from './prism-typescript';
+import jsx from './prism-jsx.js';
+import typescript from './prism-typescript.js';
 import type { GrammarToken, LanguageProto } from '../types';
 
 export default {

--- a/src/languages/prism-tt2.ts
+++ b/src/languages/prism-tt2.ts
@@ -1,8 +1,8 @@
-import { insertBefore } from '../shared/language-util';
-import { embeddedIn } from '../shared/languages/templating';
-import { tokenize } from '../shared/symbols';
-import clike from './prism-clike';
-import markup from './prism-markup';
+import { insertBefore } from '../shared/language-util.js';
+import { embeddedIn } from '../shared/languages/templating.js';
+import { tokenize } from '../shared/symbols.js';
+import clike from './prism-clike.js';
+import markup from './prism-markup.js';
 import type { LanguageProto } from '../types';
 
 export default {

--- a/src/languages/prism-twig.ts
+++ b/src/languages/prism-twig.ts
@@ -1,6 +1,6 @@
-import { embeddedIn } from '../shared/languages/templating';
-import { tokenize } from '../shared/symbols';
-import markup from './prism-markup';
+import { embeddedIn } from '../shared/languages/templating.js';
+import { tokenize } from '../shared/symbols.js';
+import markup from './prism-markup.js';
 import type { LanguageProto } from '../types';
 
 export default {

--- a/src/languages/prism-typescript.ts
+++ b/src/languages/prism-typescript.ts
@@ -1,6 +1,6 @@
-import { insertBefore } from '../shared/language-util';
-import { toArray } from '../shared/util';
-import javascript from './prism-javascript';
+import { insertBefore } from '../shared/language-util.js';
+import { toArray } from '../shared/util.js';
+import javascript from './prism-javascript.js';
 import type { Grammar, LanguageProto } from '../types';
 
 export default {

--- a/src/languages/prism-v.ts
+++ b/src/languages/prism-v.ts
@@ -1,5 +1,5 @@
-import { insertBefore } from '../shared/language-util';
-import clike from './prism-clike';
+import { insertBefore } from '../shared/language-util.js';
+import clike from './prism-clike.js';
 import type { LanguageProto } from '../types';
 
 export default {

--- a/src/languages/prism-vala.ts
+++ b/src/languages/prism-vala.ts
@@ -1,6 +1,6 @@
-import { insertBefore } from '../shared/language-util';
-import { rest } from '../shared/symbols';
-import clike from './prism-clike';
+import { insertBefore } from '../shared/language-util.js';
+import { rest } from '../shared/symbols.js';
+import clike from './prism-clike.js';
 import type { LanguageProto } from '../types';
 
 export default {

--- a/src/languages/prism-vbnet.ts
+++ b/src/languages/prism-vbnet.ts
@@ -1,5 +1,5 @@
-import { insertBefore } from '../shared/language-util';
-import basic from './prism-basic';
+import { insertBefore } from '../shared/language-util.js';
+import basic from './prism-basic.js';
 import type { LanguageProto } from '../types';
 
 export default {

--- a/src/languages/prism-velocity.ts
+++ b/src/languages/prism-velocity.ts
@@ -1,6 +1,6 @@
-import { insertBefore } from '../shared/language-util';
-import { rest } from '../shared/symbols';
-import markup from './prism-markup';
+import { insertBefore } from '../shared/language-util.js';
+import { rest } from '../shared/symbols.js';
+import markup from './prism-markup.js';
 import type { Grammar, GrammarToken, LanguageProto } from '../types';
 
 export default {

--- a/src/languages/prism-wiki.ts
+++ b/src/languages/prism-wiki.ts
@@ -1,6 +1,6 @@
-import { insertBefore } from '../shared/language-util';
-import { rest } from '../shared/symbols';
-import markup from './prism-markup';
+import { insertBefore } from '../shared/language-util.js';
+import { rest } from '../shared/symbols.js';
+import markup from './prism-markup.js';
 import type { GrammarToken, LanguageProto } from '../types';
 
 export default {

--- a/src/languages/prism-xeora.ts
+++ b/src/languages/prism-xeora.ts
@@ -1,4 +1,4 @@
-import markup from './prism-markup';
+import markup from './prism-markup.js';
 import type { LanguageProto } from '../types';
 
 export default {

--- a/src/languages/prism-xml-doc.ts
+++ b/src/languages/prism-xml-doc.ts
@@ -1,4 +1,4 @@
-import markup from './prism-markup';
+import markup from './prism-markup.js';
 import type { LanguageProto } from '../types';
 
 export default {

--- a/src/languages/prism-xml.ts
+++ b/src/languages/prism-xml.ts
@@ -1,4 +1,4 @@
-import { MARKUP_TAG } from '../shared/languages/patterns';
+import { MARKUP_TAG } from '../shared/languages/patterns.js';
 import type { LanguageProto } from '../types';
 
 export default {

--- a/src/languages/prism-xquery.ts
+++ b/src/languages/prism-xquery.ts
@@ -1,8 +1,8 @@
-import { Token, getTextContent } from '../core/token';
-import { withoutTokenize } from '../shared/language-util';
-import { tokenize } from '../shared/symbols';
-import markup from './prism-markup';
-import type { TokenStream } from '../core/token';
+import { Token, getTextContent } from '../core/token.js';
+import { withoutTokenize } from '../shared/language-util.js';
+import { tokenize } from '../shared/symbols.js';
+import markup from './prism-markup.js';
+import type { TokenStream } from '../core/token.js';
 import type { Grammar, GrammarToken, LanguageProto } from '../types';
 
 function walkTokens(tokens: TokenStream) {

--- a/src/load-languages.ts
+++ b/src/load-languages.ts
@@ -1,7 +1,7 @@
-import { resolveAlias } from './shared/meta/alias-data';
-import { knownLanguages } from './shared/meta/all-languages-data';
-import { toArray } from './shared/util';
-import type { Prism } from './core';
+import { resolveAlias } from './shared/meta/alias-data.js';
+import { knownLanguages } from './shared/meta/all-languages-data.js';
+import { toArray } from './shared/util.js';
+import type { Prism } from './core.js';
 import type { ComponentProto } from './types';
 
 function pathJoin(dir: string, file: string) {

--- a/src/plugins/autolinker/prism-autolinker.ts
+++ b/src/plugins/autolinker/prism-autolinker.ts
@@ -1,5 +1,5 @@
-import { addHooks } from '../../shared/hooks-util';
-import { tokenizeStrings } from '../../shared/tokenize-strings';
+import { addHooks } from '../../shared/hooks-util.js';
+import { tokenizeStrings } from '../../shared/tokenize-strings.js';
 import type { PluginProto } from '../../types';
 
 export default {

--- a/src/plugins/autoloader/prism-autoloader.ts
+++ b/src/plugins/autoloader/prism-autoloader.ts
@@ -1,7 +1,7 @@
-import { getParentPre } from '../../shared/dom-util';
-import { resolveAlias } from '../../shared/meta/alias-data';
-import { toArray } from '../../shared/util';
-import type { Prism } from '../../core';
+import { getParentPre } from '../../shared/dom-util.js';
+import { resolveAlias } from '../../shared/meta/alias-data.js';
+import { toArray } from '../../shared/util.js';
+import type { Prism } from '../../core.js';
 import type { ComponentProto, PluginProto } from '../../types';
 
 function getDefaultSrcPath() {

--- a/src/plugins/command-line/prism-command-line.ts
+++ b/src/plugins/command-line/prism-command-line.ts
@@ -1,7 +1,7 @@
-import { getParentPre } from '../../shared/dom-util';
-import { addHooks } from '../../shared/hooks-util';
-import { htmlEncode } from '../../shared/util';
-import type { StateKey } from '../../core/hook-state';
+import { getParentPre } from '../../shared/dom-util.js';
+import { addHooks } from '../../shared/hooks-util.js';
+import { htmlEncode } from '../../shared/util.js';
+import type { StateKey } from '../../core/hook-state.js';
 import type { PluginProto } from '../../types';
 
 const CLASS_PATTERN = /(?:^|\s)command-line(?:\s|$)/;

--- a/src/plugins/copy-to-clipboard/prism-copy-to-clipboard.ts
+++ b/src/plugins/copy-to-clipboard/prism-copy-to-clipboard.ts
@@ -1,4 +1,4 @@
-import toolbar from '../toolbar/prism-toolbar';
+import toolbar from '../toolbar/prism-toolbar.js';
 import type { PluginProto } from '../../types';
 
 interface CopyInfo {

--- a/src/plugins/data-uri-highlight/prism-data-uri-highlight.ts
+++ b/src/plugins/data-uri-highlight/prism-data-uri-highlight.ts
@@ -1,4 +1,4 @@
-import { tokenizeStrings } from '../../shared/tokenize-strings';
+import { tokenizeStrings } from '../../shared/tokenize-strings.js';
 import type { PluginProto } from '../../types';
 
 export default {

--- a/src/plugins/diff-highlight/prism-diff-highlight.ts
+++ b/src/plugins/diff-highlight/prism-diff-highlight.ts
@@ -1,8 +1,8 @@
-import { Token, getTextContent } from '../../core/token';
-import diff, { PREFIXES } from '../../languages/prism-diff';
-import { addHooks } from '../../shared/hooks-util';
-import type { BeforeSanityCheckEnv, BeforeTokenizeEnv } from '../../core/hooks';
-import type { TokenStream } from '../../core/token';
+import { Token, getTextContent } from '../../core/token.js';
+import diff, { PREFIXES } from '../../languages/prism-diff.js';
+import { addHooks } from '../../shared/hooks-util.js';
+import type { BeforeSanityCheckEnv, BeforeTokenizeEnv } from '../../core/hooks.js';
+import type { TokenStream } from '../../core/token.js';
 import type { PluginProto } from '../../types';
 
 export default {

--- a/src/plugins/download-button/prism-download-button.ts
+++ b/src/plugins/download-button/prism-download-button.ts
@@ -1,5 +1,5 @@
-import { getParentPre } from '../../shared/dom-util';
-import toolbar from '../toolbar/prism-toolbar';
+import { getParentPre } from '../../shared/dom-util.js';
+import toolbar from '../toolbar/prism-toolbar.js';
 import type { PluginProto } from '../../types';
 
 export default {

--- a/src/plugins/file-highlight/prism-file-highlight.ts
+++ b/src/plugins/file-highlight/prism-file-highlight.ts
@@ -1,6 +1,6 @@
-import { setLanguage } from '../../shared/dom-util';
-import { addHooks } from '../../shared/hooks-util';
-import type { Prism } from '../../core';
+import { setLanguage } from '../../shared/dom-util.js';
+import { addHooks } from '../../shared/hooks-util.js';
+import type { Prism } from '../../core.js';
 import type { PluginProto } from '../../types';
 
 const FAILURE_MESSAGE = (status: number, message: string) => {

--- a/src/plugins/filter-highlight-all/prism-filter-highlight-all.ts
+++ b/src/plugins/filter-highlight-all/prism-filter-highlight-all.ts
@@ -1,4 +1,4 @@
-import { getLanguage } from '../../shared/dom-util';
+import { getLanguage } from '../../shared/dom-util.js';
 import type { PluginProto } from '../../types';
 
 type Condition = (value: { element: Element; language: string }) => boolean;

--- a/src/plugins/inline-color/prism-inline-color.ts
+++ b/src/plugins/inline-color/prism-inline-color.ts
@@ -1,5 +1,5 @@
-import cssExtras from '../../languages/prism-css-extras';
-import { MARKUP_TAG } from '../../shared/languages/patterns';
+import cssExtras from '../../languages/prism-css-extras.js';
+import { MARKUP_TAG } from '../../shared/languages/patterns.js';
 import type { PluginProto } from '../../types';
 
 const HTML_TAG = RegExp(MARKUP_TAG, 'g');

--- a/src/plugins/jsonp-highlight/prism-jsonp-highlight.ts
+++ b/src/plugins/jsonp-highlight/prism-jsonp-highlight.ts
@@ -1,5 +1,5 @@
-import { addHooks } from '../../shared/hooks-util';
-import type { Prism } from '../../core';
+import { addHooks } from '../../shared/hooks-util.js';
+import type { Prism } from '../../core.js';
 import type { PluginProto } from '../../types';
 
 function getGlobal(): Record<string, unknown> {

--- a/src/plugins/keep-markup/prism-keep-markup.ts
+++ b/src/plugins/keep-markup/prism-keep-markup.ts
@@ -1,6 +1,6 @@
-import { isActive } from '../../shared/dom-util';
-import { addHooks } from '../../shared/hooks-util';
-import type { StateKey } from '../../core/hook-state';
+import { isActive } from '../../shared/dom-util.js';
+import { addHooks } from '../../shared/hooks-util.js';
+import type { StateKey } from '../../core/hook-state.js';
 import type { PluginProto } from '../../types';
 
 function isElement(child: ChildNode): child is Element {

--- a/src/plugins/line-highlight/prism-line-highlight.ts
+++ b/src/plugins/line-highlight/prism-line-highlight.ts
@@ -1,7 +1,7 @@
-import { isActive } from '../../shared/dom-util';
-import { combineCallbacks } from '../../shared/hooks-util';
-import { lazy, noop } from '../../shared/util';
-import type { Prism } from '../../core';
+import { isActive } from '../../shared/dom-util.js';
+import { combineCallbacks } from '../../shared/hooks-util.js';
+import { lazy, noop } from '../../shared/util.js';
+import type { Prism } from '../../core.js';
 import type { PluginProto } from '../../types';
 
 const LINE_NUMBERS_CLASS = 'line-numbers';

--- a/src/plugins/line-numbers/prism-line-numbers.ts
+++ b/src/plugins/line-numbers/prism-line-numbers.ts
@@ -1,6 +1,6 @@
-import { getParentPre, isActive } from '../../shared/dom-util';
-import { combineCallbacks } from '../../shared/hooks-util';
-import { isNonNull, noop } from '../../shared/util';
+import { getParentPre, isActive } from '../../shared/dom-util.js';
+import { combineCallbacks } from '../../shared/hooks-util.js';
+import { isNonNull, noop } from '../../shared/util.js';
 import type { PluginProto } from '../../types';
 
 /**

--- a/src/plugins/match-braces/prism-match-braces.ts
+++ b/src/plugins/match-braces/prism-match-braces.ts
@@ -1,4 +1,4 @@
-import { getParentPre, isActive } from '../../shared/dom-util';
+import { getParentPre, isActive } from '../../shared/dom-util.js';
 import type { PluginProto } from '../../types';
 
 export default {

--- a/src/plugins/normalize-whitespace/prism-normalize-whitespace.ts
+++ b/src/plugins/normalize-whitespace/prism-normalize-whitespace.ts
@@ -1,4 +1,4 @@
-import { getParentPre, isActive } from '../../shared/dom-util';
+import { getParentPre, isActive } from '../../shared/dom-util.js';
 import type { PluginProto } from '../../types';
 
 function tabLength(str: string) {

--- a/src/plugins/previewers/prism-previewers.ts
+++ b/src/plugins/previewers/prism-previewers.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
-import cssExtras from '../../languages/prism-css-extras';
-import { forEach } from '../../shared/util';
+import cssExtras from '../../languages/prism-css-extras.js';
+import { forEach } from '../../shared/util.js';
 import type { PluginProto } from '../../types';
 
 /**

--- a/src/plugins/show-invisibles/prism-show-invisibles.ts
+++ b/src/plugins/show-invisibles/prism-show-invisibles.ts
@@ -1,4 +1,4 @@
-import { tokenizeStrings } from '../../shared/tokenize-strings';
+import { tokenizeStrings } from '../../shared/tokenize-strings.js';
 import type { PluginProto } from '../../types';
 
 export default {

--- a/src/plugins/show-language/prism-show-language.ts
+++ b/src/plugins/show-language/prism-show-language.ts
@@ -1,6 +1,6 @@
-import { getParentPre } from '../../shared/dom-util';
-import { getTitle } from '../../shared/meta/title-data';
-import toolbar from '../toolbar/prism-toolbar';
+import { getParentPre } from '../../shared/dom-util.js';
+import { getTitle } from '../../shared/meta/title-data.js';
+import toolbar from '../toolbar/prism-toolbar.js';
 import type { PluginProto } from '../../types';
 
 export default {

--- a/src/plugins/toolbar/prism-toolbar.ts
+++ b/src/plugins/toolbar/prism-toolbar.ts
@@ -1,6 +1,6 @@
-import { getParentPre } from '../../shared/dom-util';
-import { noop } from '../../shared/util';
-import type { CompleteEnv, HookCallback } from '../../core/hooks';
+import { getParentPre } from '../../shared/dom-util.js';
+import { noop } from '../../shared/util.js';
+import type { CompleteEnv, HookCallback } from '../../core/hooks.js';
 import type { PluginProto } from '../../types';
 
 /**

--- a/src/plugins/treeview-icons/prism-treeview-icons.ts
+++ b/src/plugins/treeview-icons/prism-treeview-icons.ts
@@ -1,4 +1,4 @@
-import treeview from '../../languages/prism-treeview';
+import treeview from '../../languages/prism-treeview.js';
 import type { PluginProto } from '../../types';
 
 export default {

--- a/src/plugins/unescaped-markup/prism-unescaped-markup.ts
+++ b/src/plugins/unescaped-markup/prism-unescaped-markup.ts
@@ -1,4 +1,4 @@
-import { addHooks } from '../../shared/hooks-util';
+import { addHooks } from '../../shared/hooks-util.js';
 import type { PluginProto } from '../../types';
 
 export default {

--- a/src/plugins/wpd/prism-wpd.ts
+++ b/src/plugins/wpd/prism-wpd.ts
@@ -1,4 +1,4 @@
-import cssSelector from '../../languages/prism-css-selector';
+import cssSelector from '../../languages/prism-css-selector.js';
 import type { PluginProto } from '../../types';
 
 const htmlTags = new Set<string>([

--- a/src/shared/hooks-util.ts
+++ b/src/shared/hooks-util.ts
@@ -1,4 +1,4 @@
-import type { HookCallback, HookEnvMap, Hooks } from '../core/hooks';
+import type { HookCallback, HookEnvMap, Hooks } from '../core/hooks.js';
 
 /**
  * Returns a single function that calls all the given functions.

--- a/src/shared/language-util.ts
+++ b/src/shared/language-util.ts
@@ -1,4 +1,4 @@
-import { rest, tokenize } from './symbols';
+import { rest, tokenize } from './symbols.js';
 import type { Grammar, GrammarToken, GrammarTokens } from '../types';
 
 // TODO: Update documentation

--- a/src/shared/languages/templating.ts
+++ b/src/shared/languages/templating.ts
@@ -1,10 +1,10 @@
-import { getTextContent } from '../../core/token';
-import { withoutTokenize } from '../language-util';
-import type { Prism } from '../../core';
-import type { Registry } from '../../core/registry';
-import type { Token, TokenStream } from '../../core/token';
+import { getTextContent } from '../../core/token.js';
+import { withoutTokenize } from '../language-util.js';
+import type { Prism } from '../../core.js';
+import type { Registry } from '../../core/registry.js';
+import type { Token, TokenStream } from '../../core/token.js';
 import type { Grammar } from '../../types';
-import type { tokenize } from '../symbols';
+import type { tokenize } from '../symbols.js';
 
 
 const placeholderPattern = /___PH\d+___/;

--- a/src/shared/tokenize-strings.ts
+++ b/src/shared/tokenize-strings.ts
@@ -1,4 +1,4 @@
-import type { TokenStream } from '../core/token';
+import type { TokenStream } from '../core/token.js';
 
 /**
  * Given a token stream and a tokenization function, this will tokenize all

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,7 +1,7 @@
-import type { Prism } from './core/prism';
-import type { TokenStream } from './core/token';
+import type { Prism } from './core/prism.js';
+import type { TokenStream } from './core/token.js';
 import type { KnownPlugins } from './known-plugins';
-import type { rest, tokenize } from './shared/symbols';
+import type { rest, tokenize } from './shared/symbols.js';
 
 export interface GrammarOptions {
 	readonly getLanguage: (id: string) => Grammar;

--- a/tests/components-test.ts
+++ b/tests/components-test.ts
@@ -1,9 +1,11 @@
 import { assert } from 'chai';
 import { readFileSync } from 'fs';
 import path from 'path';
-import { forEach, noop, toArray } from '../src/shared/util';
-import { getComponent, getComponentIds, getLanguageIds } from './helper/prism-loader';
+import { fileURLToPath } from 'url';
+import { forEach, noop, toArray } from '../src/shared/util.js';
+import { getComponent, getComponentIds, getLanguageIds } from './helper/prism-loader.js';
 
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 describe('Components', () => {
 	it('- should not have redundant optional dependencies', async function () {

--- a/tests/core/greedy.ts
+++ b/tests/core/greedy.ts
@@ -1,6 +1,6 @@
 import { assert } from 'chai';
-import { Prism } from '../../src/core/prism';
-import { simplify } from '../helper/token-stream-transformer';
+import { Prism } from '../../src/core/prism.js';
+import { simplify } from '../helper/token-stream-transformer.js';
 import type { Grammar } from '../../src/types';
 
 function testTokens({ grammar, code, expected }: { grammar: Grammar, code: string, expected: unknown }) {

--- a/tests/core/registry.ts
+++ b/tests/core/registry.ts
@@ -1,5 +1,5 @@
 import { assert } from 'chai';
-import { Prism } from '../../src/core/prism';
+import { Prism } from '../../src/core/prism.js';
 
 describe('Registry', () => {
 	it('should resolve aliases', () => {

--- a/tests/coverage.ts
+++ b/tests/coverage.ts
@@ -1,8 +1,8 @@
 import { assert } from 'chai';
-import * as PrismLoader from './helper/prism-loader';
-import { runTestCase } from './helper/test-case';
-import { loadAllTests } from './helper/test-discovery';
-import { BFS, BFSPathToPrismTokenPath, isRegExp } from './helper/util';
+import * as PrismLoader from './helper/prism-loader.js';
+import { runTestCase } from './helper/test-case.js';
+import { loadAllTests } from './helper/test-discovery.js';
+import { BFS, BFSPathToPrismTokenPath, isRegExp } from './helper/util.js';
 
 describe('Pattern test coverage', () => {
 	interface PatternData {

--- a/tests/examples-test.ts
+++ b/tests/examples-test.ts
@@ -2,7 +2,10 @@ import { assert } from 'chai';
 import { readFileSync, readdirSync } from 'fs';
 import { Parser } from 'htmlparser2';
 import path from 'path';
-import { getLanguageIds } from './helper/prism-loader';
+import { fileURLToPath } from 'url';
+import { getLanguageIds } from './helper/prism-loader.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const EXAMPLES_DIR = path.join(__dirname, '/../website/examples');
 

--- a/tests/helper/args.ts
+++ b/tests/helper/args.ts
@@ -1,4 +1,6 @@
-import { argv } from 'yargs';
+import yargs from 'yargs';
+
+const { argv } = yargs;
 
 const args = argv as {
 	language?: string | string[];

--- a/tests/helper/prism-dom-util.ts
+++ b/tests/helper/prism-dom-util.ts
@@ -1,8 +1,8 @@
-import { createPrismDOM } from './prism-loader';
-import { assertEqual, useSnapshot } from './snapshot';
-import { formatHtml } from './util';
+import { createPrismDOM } from './prism-loader.js';
+import { assertEqual, useSnapshot } from './snapshot.js';
+import { formatHtml } from './util.js';
 import type { KebabToCamelCase } from '../../src/types';
-import type { PrismDOM, PrismWindow } from './prism-loader';
+import type { PrismDOM, PrismWindow } from './prism-loader.js';
 
 interface AssertOptions {
 	language?: string;

--- a/tests/helper/prism-loader.ts
+++ b/tests/helper/prism-loader.ts
@@ -1,11 +1,13 @@
 import { readdirSync } from 'fs';
 import { JSDOM } from 'jsdom';
 import path from 'path';
-import { Prism } from '../../src/core/prism';
-import { isNonNull, lazy, noop, toArray } from '../../src/shared/util';
+import { fileURLToPath } from 'url';
+import { Prism } from '../../src/core/prism.js';
+import { isNonNull, lazy, noop, toArray } from '../../src/shared/util.js';
 import type { ComponentProto, LanguageProto, PluginProto } from '../../src/types';
 import type { DOMWindow } from 'jsdom';
 
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const SRC_DIR = path.join(__dirname, '../../src');
 
 export const getLanguageIds = lazy(() => {

--- a/tests/helper/test-case.ts
+++ b/tests/helper/test-case.ts
@@ -1,10 +1,10 @@
 import { assert } from 'chai';
 import fs from 'fs';
-import { createInstance } from './prism-loader';
-import * as TokenStreamTransformer from './token-stream-transformer';
-import { formatHtml, getLeadingSpaces } from './util';
-import type { Prism } from '../../src/core';
-import type { TokenStream } from '../../src/core/token';
+import { createInstance } from './prism-loader.js';
+import * as TokenStreamTransformer from './token-stream-transformer.js';
+import { formatHtml, getLeadingSpaces } from './util.js';
+import type { Prism } from '../../src/core.js';
+import type { TokenStream } from '../../src/core/token.js';
 
 const defaultCreateInstance = createInstance;
 

--- a/tests/helper/test-discovery.ts
+++ b/tests/helper/test-discovery.ts
@@ -1,6 +1,8 @@
 import fs from 'fs';
 import path from 'path';
+import { fileURLToPath } from 'url';
 
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const LANGUAGES_DIR = path.join(__dirname, '..', 'languages');
 
 /**

--- a/tests/helper/token-stream-transformer.ts
+++ b/tests/helper/token-stream-transformer.ts
@@ -1,4 +1,4 @@
-import { getLeadingSpaces, getTrailingSpaces } from './util';
+import { getLeadingSpaces, getTrailingSpaces } from './util.js';
 
 interface TokenStreamItem {
 	type: string;

--- a/tests/identifier-test.ts
+++ b/tests/identifier-test.ts
@@ -1,9 +1,9 @@
 import { assert } from 'chai';
-import { toArray } from '../src/shared/util';
-import { createInstance, getComponent, getLanguageIds } from './helper/prism-loader';
-import { prettyprint } from './helper/token-stream-transformer';
-import type { Prism, Token } from '../src/core';
-import type { TokenStream } from '../src/core/token';
+import { toArray } from '../src/shared/util.js';
+import { createInstance, getComponent, getLanguageIds } from './helper/prism-loader.js';
+import { prettyprint } from './helper/token-stream-transformer.js';
+import type { Prism, Token } from '../src/core.js';
+import type { TokenStream } from '../src/core/token.js';
 
 
 // This is where you can exclude a language from the identifier test.

--- a/tests/languages/antlr4/action_feature.test
+++ b/tests/languages/antlr4/action_feature.test
@@ -3,7 +3,7 @@ options { superClass = LexerAdaptor; }
 @lexer::header {
   import { Token } from 'antlr4ts/Token';
   import { CommonToken } from 'antlr4ts/CommonToken';
-  import { Python3Parser } from './Python3Parser';
+  import { Python3Parser } from './Python3Parser.js';
 }
 
 END : 'end' {System.out.println("found an end");} ;

--- a/tests/pattern-tests.ts
+++ b/tests/pattern-tests.ts
@@ -3,15 +3,15 @@ import { JS, NFA, Transformers, Words, combineTransformers, getIntersectionWordS
 import * as RAA from 'regexp-ast-analysis';
 import { visitRegExpAST } from 'regexpp';
 import * as scslre from 'scslre';
-import { lazy, toArray } from '../src/shared/util';
-import * as args from './helper/args';
-import { createInstance, getComponent, getLanguageIds } from './helper/prism-loader';
-import { TestCaseFile, parseLanguageNames } from './helper/test-case';
-import { loadAllTests } from './helper/test-discovery';
-import { BFS, BFSPathToPrismTokenPath, isRegExp, parseRegex } from './helper/util';
-import type { Prism } from '../src/core';
+import { lazy, toArray } from '../src/shared/util.js';
+import * as args from './helper/args.js';
+import { createInstance, getComponent, getLanguageIds } from './helper/prism-loader.js';
+import { TestCaseFile, parseLanguageNames } from './helper/test-case.js';
+import { loadAllTests } from './helper/test-discovery.js';
+import { BFS, BFSPathToPrismTokenPath, isRegExp, parseRegex } from './helper/util.js';
+import type { Prism } from '../src/core.js';
 import type { Grammar, GrammarToken } from '../src/types';
-import type { LiteralAST, PathItem } from './helper/util';
+import type { LiteralAST, PathItem } from './helper/util.js';
 import type { CapturingGroup, Element, Group, LookaroundAssertion, Node, Pattern } from 'regexpp/ast';
 
 /**

--- a/tests/plugins/autolinker/basic-functionality.ts
+++ b/tests/plugins/autolinker/basic-functionality.ts
@@ -1,4 +1,4 @@
-import { createTestSuite } from '../../helper/prism-dom-util';
+import { createTestSuite } from '../../helper/prism-dom-util.js';
 
 describe('Autolinker', () => {
 	const { it } = createTestSuite({

--- a/tests/plugins/copy-to-clipboard/basic-functionality.ts
+++ b/tests/plugins/copy-to-clipboard/basic-functionality.ts
@@ -1,5 +1,5 @@
 import { assert } from 'chai';
-import { createTestSuite } from '../../helper/prism-dom-util';
+import { createTestSuite } from '../../helper/prism-dom-util.js';
 
 
 class DummyClipboard {

--- a/tests/plugins/custom-class/basic-functionality.ts
+++ b/tests/plugins/custom-class/basic-functionality.ts
@@ -1,4 +1,4 @@
-import { createTestSuite } from '../../helper/prism-dom-util';
+import { createTestSuite } from '../../helper/prism-dom-util.js';
 
 
 describe('Custom class', () => {

--- a/tests/plugins/data-uri-highlight/basic-functionality.ts
+++ b/tests/plugins/data-uri-highlight/basic-functionality.ts
@@ -1,4 +1,4 @@
-import { createTestSuite } from '../../helper/prism-dom-util';
+import { createTestSuite } from '../../helper/prism-dom-util.js';
 
 
 describe('Data-URI Highlight', () => {

--- a/tests/plugins/diff-highlight/basic-functionality.ts
+++ b/tests/plugins/diff-highlight/basic-functionality.ts
@@ -1,4 +1,4 @@
-import { createTestSuite } from '../../helper/prism-dom-util';
+import { createTestSuite } from '../../helper/prism-dom-util.js';
 
 const jsCode = `
 @@ -4,6 +4,5 @@

--- a/tests/plugins/highlight-keywords/basic-functionality.ts
+++ b/tests/plugins/highlight-keywords/basic-functionality.ts
@@ -1,4 +1,4 @@
-import { createTestSuite } from '../../helper/prism-dom-util';
+import { createTestSuite } from '../../helper/prism-dom-util.js';
 
 
 describe('Highlight Keywords', () => {

--- a/tests/plugins/keep-markup/test.ts
+++ b/tests/plugins/keep-markup/test.ts
@@ -1,6 +1,6 @@
 import { assert } from 'chai';
-import { createTestSuite } from '../../helper/prism-dom-util';
-import type { PrismDOM } from '../../helper/prism-loader';
+import { createTestSuite } from '../../helper/prism-dom-util.js';
+import type { PrismDOM } from '../../helper/prism-loader.js';
 
 
 describe('Keep Markup', () => {

--- a/tests/plugins/line-highlight/basic-functionality.ts
+++ b/tests/plugins/line-highlight/basic-functionality.ts
@@ -1,4 +1,4 @@
-import { createTestSuite } from '../../helper/prism-dom-util';
+import { createTestSuite } from '../../helper/prism-dom-util.js';
 
 // just a few lines of JS code, so we have something to highlight
 const exampleCode = String.raw`// foo

--- a/tests/plugins/show-invisibles/basic-functionality.ts
+++ b/tests/plugins/show-invisibles/basic-functionality.ts
@@ -1,4 +1,4 @@
-import { createTestSuite } from '../../helper/prism-dom-util';
+import { createTestSuite } from '../../helper/prism-dom-util.js';
 
 
 describe('Show Invisibles', () => {

--- a/tests/plugins/show-language/basic-functionality.ts
+++ b/tests/plugins/show-language/basic-functionality.ts
@@ -1,7 +1,7 @@
 import { assert } from 'chai';
-import { knownTitles } from '../../../src/shared/meta/title-data';
-import { createTestSuite } from '../../helper/prism-dom-util';
-import type { PrismDOM } from '../../helper/prism-loader';
+import { knownTitles } from '../../../src/shared/meta/title-data.js';
+import { createTestSuite } from '../../helper/prism-dom-util.js';
+import type { PrismDOM } from '../../helper/prism-loader.js';
 
 
 describe('Show language', () => {

--- a/tests/plugins/unescaped-markup/basic-functionality.ts
+++ b/tests/plugins/unescaped-markup/basic-functionality.ts
@@ -1,6 +1,6 @@
 import { assert } from 'chai';
-import { createTestSuite } from '../../helper/prism-dom-util';
-import type { PrismDOM } from '../../helper/prism-loader';
+import { createTestSuite } from '../../helper/prism-dom-util.js';
+import type { PrismDOM } from '../../helper/prism-loader.js';
 
 
 describe('Show language', () => {

--- a/tests/plugins/wpd/basic-functionality.ts
+++ b/tests/plugins/wpd/basic-functionality.ts
@@ -1,4 +1,4 @@
-import { createTestSuite } from '../../helper/prism-dom-util';
+import { createTestSuite } from '../../helper/prism-dom-util.js';
 
 
 describe('WPD', () => {

--- a/tests/run.ts
+++ b/tests/run.ts
@@ -1,7 +1,7 @@
 import path from 'path';
-import { language, update } from './helper/args';
-import * as TestCase from './helper/test-case';
-import * as TestDiscovery from './helper/test-discovery';
+import { language, update } from './helper/args.js';
+import * as TestCase from './helper/test-case.js';
+import * as TestDiscovery from './helper/test-discovery.js';
 
 const testSuite =
 	language

--- a/tests/testrunner-tests.ts
+++ b/tests/testrunner-tests.ts
@@ -1,6 +1,6 @@
 import { assert } from 'chai';
-import { parseLanguageNames } from './helper/test-case';
-import { simplify } from './helper/token-stream-transformer';
+import { parseLanguageNames } from './helper/test-case.js';
+import { simplify } from './helper/token-stream-transformer.js';
 
 
 describe('The token stream transformer', () => {

--- a/tests/tsconfig.json
+++ b/tests/tsconfig.json
@@ -1,77 +1,8 @@
 {
   "extends": "../tsconfig.json",
   "compilerOptions": {
-    /* Visit https://aka.ms/tsconfig to read more about this file */
-
-    /* Projects */
-    // "incremental": true,                              /* Save .tsbuildinfo files to allow for incremental compilation of projects. */
-    // "composite": true,                                /* Enable constraints that allow a TypeScript project to be used with project references. */
-    // "tsBuildInfoFile": "./.tsbuildinfo",              /* Specify the path to .tsbuildinfo incremental compilation file. */
-    // "disableSourceOfProjectReferenceRedirect": true,  /* Disable preferring source files instead of declaration files when referencing composite projects. */
-    // "disableSolutionSearching": true,                 /* Opt a project out of multi-project reference checking when editing. */
-    // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
-
-    /* Language and Environment */
-    "target": "ES2020",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
-    // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
-    // "jsx": "preserve",                                /* Specify what JSX code is generated. */
-    // "experimentalDecorators": true,                   /* Enable experimental support for TC39 stage 2 draft decorators. */
-    // "emitDecoratorMetadata": true,                    /* Emit design-type metadata for decorated declarations in source files. */
-    // "jsxFactory": "",                                 /* Specify the JSX factory function used when targeting React JSX emit, e.g. 'React.createElement' or 'h'. */
-    // "jsxFragmentFactory": "",                         /* Specify the JSX Fragment reference used for fragments when targeting React JSX emit e.g. 'React.Fragment' or 'Fragment'. */
-    // "jsxImportSource": "",                            /* Specify module specifier used to import the JSX factory functions when using 'jsx: react-jsx*'. */
-    // "reactNamespace": "",                             /* Specify the object invoked for 'createElement'. This only applies when targeting 'react' JSX emit. */
-    // "noLib": true,                                    /* Disable including any library files, including the default lib.d.ts. */
-    // "useDefineForClassFields": true,                  /* Emit ECMAScript-standard-compliant class fields. */
-    // "moduleDetection": "auto",                        /* Control what method is used to detect module-format JS files. */
-
-    /* Modules */
-    "module": "commonjs",                                /* Specify what module code is generated. */
-    // "rootDir": "./",                                  /* Specify the root folder within your source files. */
-    // "moduleResolution": "node",                       /* Specify how TypeScript looks up a file from a given module specifier. */
-    // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
-    // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
-    // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
-    // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */
-    // "types": [],                                      /* Specify type package names to be included without being referenced in a source file. */
-    // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
-    // "moduleSuffixes": [],                             /* List of file name suffixes to search when resolving a module. */
-    // "resolveJsonModule": true,                        /* Enable importing .json files. */
-    // "noResolve": true,                                /* Disallow 'import's, 'require's or '<reference>'s from expanding the number of files TypeScript should add to a project. */
-
-    /* JavaScript Support */
-    "allowJs": true,                                  /* Allow JavaScript files to be a part of your program. Use the 'checkJS' option to get errors from these files. */
-    "checkJs": true,                                  /* Enable error reporting in type-checked JavaScript files. */
-    // "maxNodeModuleJsDepth": 1,                        /* Specify the maximum folder depth used for checking JavaScript files from 'node_modules'. Only applicable with 'allowJs'. */
-
-    /* Emit */
-    // "declaration": true,                              /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
-    // "declarationMap": true,                           /* Create sourcemaps for d.ts files. */
-    // "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
-    // "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
-    // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
-    // "outDir": "./",                                   /* Specify an output folder for all emitted files. */
-    // "removeComments": true,                           /* Disable emitting comments. */
+	"verbatimModuleSyntax": false, // TODO true
     "noEmit": true,                                   /* Disable emitting files from a compilation. */
-    // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */
-    // "importsNotUsedAsValues": "remove",               /* Specify emit/checking behavior for imports that are only used for types. */
-    // "downlevelIteration": true,                       /* Emit more compliant, but verbose and less performant JavaScript for iteration. */
-    // "sourceRoot": "",                                 /* Specify the root path for debuggers to find the reference source code. */
-    // "mapRoot": "",                                    /* Specify the location where debugger should locate map files instead of generated locations. */
-    // "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
-    // "inlineSources": true,                            /* Include source code in the sourcemaps inside the emitted JavaScript. */
-    // "emitBOM": true,                                  /* Emit a UTF-8 Byte Order Mark (BOM) in the beginning of output files. */
-    // "newLine": "crlf",                                /* Set the newline character for emitting files. */
-    // "stripInternal": true,                            /* Disable emitting declarations that have '@internal' in their JSDoc comments. */
-    // "noEmitHelpers": true,                            /* Disable generating custom helper functions like '__extends' in compiled output. */
-    // "noEmitOnError": true,                            /* Disable emitting files if any type checking errors are reported. */
-    // "preserveConstEnums": true,                       /* Disable erasing 'const enum' declarations in generated code. */
-    // "declarationDir": "./",                           /* Specify the output directory for generated declaration files. */
-    // "preserveValueImports": true,                     /* Preserve unused imported values in the JavaScript output that would otherwise be removed. */
-
-    /* Interop Constraints */
-    // "isolatedModules": true,                          /* Ensure that each file can be safely transpiled without relying on other imports. */
-    // "allowSyntheticDefaultImports": true,             /* Allow 'import x from y' when a module doesn't have a default export. */
     "esModuleInterop": true,                             /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */
   },
   "include": ["./**/*"]

--- a/tests/tsconfig.json
+++ b/tests/tsconfig.json
@@ -1,9 +1,7 @@
 {
   "extends": "../tsconfig.json",
   "compilerOptions": {
-	"verbatimModuleSyntax": false, // TODO true
     "noEmit": true,                                   /* Disable emitting files from a compilation. */
-    "esModuleInterop": true,                             /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */
   },
   "include": ["./**/*"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
     // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
 
     /* Language and Environment */
-    "target": "es2020",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
+    "target": "es2021",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
     // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
     // "jsx": "preserve",                                /* Specify what JSX code is generated. */
     // "experimentalDecorators": true,                   /* Enable experimental support for TC39 stage 2 draft decorators. */
@@ -25,35 +25,31 @@
     // "moduleDetection": "auto",                        /* Control what method is used to detect module-format JS files. */
 
     /* Modules */
-    "module": "commonjs",                                /* Specify what module code is generated. */
+    "module": "ESNext",                                  /* Specify what module code is generated. */
     // "rootDir": "./",                                  /* Specify the root folder within your source files. */
-    // "moduleResolution": "node",                       /* Specify how TypeScript looks up a file from a given module specifier. */
+    "moduleResolution": "node",                          /* Specify how TypeScript looks up a file from a given module specifier. */
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
     // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
     // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */
     // "types": [],                                      /* Specify type package names to be included without being referenced in a source file. */
-    // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
+    "allowUmdGlobalAccess": false,                        /* Allow accessing UMD globals from modules. */
     // "moduleSuffixes": [],                             /* List of file name suffixes to search when resolving a module. */
     // "resolveJsonModule": true,                        /* Enable importing .json files. */
     // "noResolve": true,                                /* Disallow 'import's, 'require's or '<reference>'s from expanding the number of files TypeScript should add to a project. */
 
-    /* JavaScript Support */
-    "allowJs": true,                                  /* Allow JavaScript files to be a part of your program. Use the 'checkJS' option to get errors from these files. */
-    "checkJs": true,                                  /* Enable error reporting in type-checked JavaScript files. */
-    // "maxNodeModuleJsDepth": 1,                        /* Specify the maximum folder depth used for checking JavaScript files from 'node_modules'. Only applicable with 'allowJs'. */
-
     /* Emit */
-    // "declaration": true,                              /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
-    // "declarationMap": true,                           /* Create sourcemaps for d.ts files. */
+    "declaration": true,                                 /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
+    "declarationMap": true,                              /* Create sourcemaps for d.ts files. */
     // "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
-    // "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
+    "sourceMap": true,                                   /* Create source map files for emitted JavaScript files. */
     // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
-    // "outDir": "./",                                   /* Specify an output folder for all emitted files. */
+    "outDir": "dist",                                    /* Specify an output folder for all emitted files. */
     // "removeComments": true,                           /* Disable emitting comments. */
-    "noEmit": true,                                   /* Disable emitting files from a compilation. */
+    // "noEmit": true,                                   /* Disable emitting files from a compilation. */
     // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */
-    // "importsNotUsedAsValues": "remove",               /* Specify emit/checking behavior for imports that are only used for types. */
+    // "importsNotUsedAsValues": "error",                /* Specify emit/checking behavior for imports that are only used for types. */
+	"verbatimModuleSyntax": true,
     // "downlevelIteration": true,                       /* Emit more compliant, but verbose and less performant JavaScript for iteration. */
     // "sourceRoot": "",                                 /* Specify the root path for debuggers to find the reference source code. */
     // "mapRoot": "",                                    /* Specify the location where debugger should locate map files instead of generated locations. */
@@ -70,7 +66,7 @@
 
     /* Interop Constraints */
     // "isolatedModules": true,                          /* Ensure that each file can be safely transpiled without relying on other imports. */
-    // "allowSyntheticDefaultImports": true,             /* Allow 'import x from y' when a module doesn't have a default export. */
+    "allowSyntheticDefaultImports": true,                /* Allow 'import x from y' when a module doesn't have a default export. */
     "esModuleInterop": true,                             /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */
     // "preserveSymlinks": true,                         /* Disable resolving symlinks to their realpath. This correlates to the same flag in node. */
     "forceConsistentCasingInFileNames": true,            /* Ensure that casing is correct in imports. */


### PR DESCRIPTION
Issue:

- https://github.com/PrismJS/prism/issues/3702 (read this first)

Continues from PR

- https://github.com/PrismJS/prism/pull/3699

To test this in an existing app, install Prism v2 like so:

```sh
npm install prismjs@github:trusktr/prism#simple-esm
```

To try an existing Prism v2 example along with a Node ESM test try this repo:

https://github.com/trusktr/prism-v2-test

```sh
npm install # this installs Prism from git, from this branch
npm test # this verifies that importing Prism in Node ESM works (we should perhaps move that test into this repo)
```

The gold standard today is that if a project is both as close to vanilla ESM as possible and importable in Node ESM, it is likely to work with today's build tools.

In particular, this change tries to stay as close to vanilla ESM as possible, by avoiding the use of package.json `exports` field (browsers do not read package.json, let along an exports field).

The example app above shows importing Prism without any configuration or build. In the worst case, if they wish to avoid putting `./node_modules` directly in their import statement, they can create a `<script type=importmap>` element to map `prismjs` to the `node_modules` location.

All Mocha unit tests pass except two of them. I also removed the components.json build, which I think needs to be restored for when new languages are added (? I'm not sure yet), but now we'll ensure that we restore what is needed on this simplified foundation.

---

The mantras here are:

- simple ES Module output that requires the least amount of tooling or configuration to import in vanilla ES Modules (namely, in a browser where this is most likely to be imported, where browser ESM is a subset of Node ESM).
- we start with most vanilla ESM setup before starting to add any build steps, so that we're staying on the most compatible ESM path.

This is as simple as it can possibly get for browser ES Modules (apart from us also including a sample `importmap` that they can paste into their HTML, which we can do.

This is still WIP, we need to look at the components.json build requirement.

---

- [ ] ensure the `components.json` build is handled if needed
- [ ] fix last type definition issues (described in https://github.com/PrismJS/prism/issues/3702#issuecomment-1622713226)

---

Comments in the diff have some more details.