### PR TITLE
Restyle test.html show-tokens with hover class names and fatter borders.

### DIFF
--- a/test.html
+++ b/test.html
@@ -67,11 +67,30 @@ pre.show-tokens {
 }
 
 .show-tokens .token {
-	border: 1px solid;
-	padding: 6px 1px;
+	border: 2px solid;
+	padding: 4px 5px;
+	display: inline-block;
+	position: relative;
+}
+.show-tokens .token:has(> .token):hover {
+	border-color: cornflowerblue;
+}
+.show-tokens .token:has(> .token):hover::before {
+	content: attr(class);
+	position: absolute;
+	font-size: 60%;
+	left: 0;
+	top: -15px;
+}
+.show-tokens .token:not(:has(> .token)):hover::before {
+	content: attr(class);
+	position: absolute;
+	font-size: 60%;
+	left: 0;
+	bottom: -15px;
 }
 .show-tokens .token > .token {
-	padding: 4px 1px;
+	padding: 3px 1px;
 }
 .show-tokens .token > .token > .token {
 	padding: 2px 1px;


### PR DESCRIPTION
This change _improves_ the "Show tokens" styling of `test.html`. It increases border sizes but most importantly show the token class names on hover which makes testing and debugging grammars a bit easier (to not use the browser dev tools).

Tooltips: (on the bottom) for the current token, (on top) for tokens that contain tokens

Example:
![grafik](https://github.com/user-attachments/assets/52132b43-b074-4e29-92f3-ecbc393181ab)
compared to
![grafik](https://github.com/user-attachments/assets/6d6954d5-bfc4-49b8-8643-a61c6eecf70e)

The generic `token` class can't easily be stripped using CSS, `content: attr(class);`, unfortunately.
