### PR TITLE
Fix Kotlin multiline comment in string bug #3722

### DIFF
--- a/components/prism-kotlin.js
+++ b/components/prism-kotlin.js
@@ -45,7 +45,8 @@
 						inside: interpolationInside
 					},
 					'string': /[\s\S]+/
-				}
+				},
+				greedy: true
 			},
 			{
 				pattern: /"(?:[^"\\\r\n$]|\\.|\$(?:(?!\{)|\{[^{}]*\}))*"/,
@@ -57,7 +58,8 @@
 						inside: interpolationInside
 					},
 					'string': /[\s\S]+/
-				}
+				},
+				greedy: true
 			}
 		],
 		'char': {


### PR DESCRIPTION
Added greedy matching for string literals in Kotlin, in response to #3722 