### PR TITLE
Ensured okaidia theme has constrast ratio of 4.5:1 for all tokens

### DIFF
--- a/themes/prism-okaidia.css
+++ b/themes/prism-okaidia.css
@@ -36,13 +36,13 @@ pre[class*="language-"] {
 	border-radius: 0.3em;
 }
 
-:not(pre) > code[class*="language-"],
+:not(pre)>code[class*="language-"],
 pre[class*="language-"] {
-	background: #272822;
+	background: #1B1C18;
 }
 
 /* Inline code */
-:not(pre) > code[class*="language-"] {
+:not(pre)>code[class*="language-"] {
 	padding: .1em;
 	border-radius: .3em;
 	white-space: normal;
@@ -114,6 +114,7 @@ pre[class*="language-"] {
 .token.bold {
 	font-weight: bold;
 }
+
 .token.italic {
 	font-style: italic;
 }


### PR DESCRIPTION
I understand there is a code freeze except for security fixes, but this PR is not code related and is strictly restricted to changing the color contrast in a theme.

I darkened the background just enough to ensure all token achieve a color contrast of at least 4.5:1 in order to meet WCAG 2.1 requirements.