### PR TITLE
Add upcomming Behind (⍛) dyadic operator.

### DIFF
--- a/components/prism-apl.js
+++ b/components/prism-apl.js
@@ -17,7 +17,7 @@ Prism.languages.apl = {
 		alias: 'operator'
 	},
 	'dyadic-operator': {
-		pattern: /[.⍣⍠⍤∘⌸@⌺⍥]/,
+		pattern: /[.⍣⍠⍤∘⍛⌸@⌺⍥]/,
 		alias: 'operator'
 	},
 	'assignment': {


### PR DESCRIPTION
Dyalog v20 is adding the dyadic operator Behind. Pre-emptively add it to this project.