### PR TITLE
add alias for gherkin language to components.json

### DIFF
--- a/components.json
+++ b/components.json
@@ -534,6 +534,7 @@
 		},
 		"gherkin": {
 			"title": "Gherkin",
+			"alias": "feature",
 			"owner": "hason"
 		},
 		"git": {


### PR DESCRIPTION
the alias `feature` is commonly used in code editors . so I added it to align prism with general code editors