### PR TITLE
Fix the `type-check` action

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55,7 +55,7 @@
 				"scslre": "^0.1.6",
 				"simple-git": "^3.3.0",
 				"tsx": "^4.19.3",
-				"typescript": "^5.0.4",
+				"typescript": "^5.8.3",
 				"webfont": "^11.2.26",
 				"yargs": "^17.7.2"
 			},
@@ -4365,9 +4365,9 @@
 			}
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.5.137",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.137.tgz",
-			"integrity": "sha512-/QSJaU2JyIuTbbABAo/crOs+SuAZLS+fVVS10PVrIT9hrRkmZl8Hb0xPSkKRUUWHQtYzXHpQUW3Dy5hwMzGZkA==",
+			"version": "1.5.138",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.138.tgz",
+			"integrity": "sha512-FWlQc52z1dXqm+9cCJ2uyFgJkESd+16j6dBEjsgDNuHjBpuIzL8/lRc0uvh1k8RNI6waGo6tcy2DvwkTBJOLDg==",
 			"dev": true,
 			"license": "ISC"
 		},

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
 		"scslre": "^0.1.6",
 		"simple-git": "^3.3.0",
 		"tsx": "^4.19.3",
-		"typescript": "^5.0.4",
+		"typescript": "^5.8.3",
 		"webfont": "^11.2.26",
 		"yargs": "^17.7.2"
 	},

--- a/src/languages/prism-cshtml.ts
+++ b/src/languages/prism-cshtml.ts
@@ -94,33 +94,33 @@ export default {
 			(/[^<]/.source +
 				'|' +
 				// all tags that are not the start tag
-				// eslint-disable-next-line regexp/strict
-				/<\/?(?!\1\b)/.source +
+				// @ts-expect-error TS(2532): Ignore the non-existent capturing group error.
+				/<\/?(?!\1\b)/.source + // eslint-disable-line regexp/strict
 				tagContent +
 				'|' +
 				// nested start tag
 				nested(
-					// eslint-disable-next-line regexp/strict
-					/<\1/.source +
+					// @ts-expect-error TS(2532): Ignore the non-existent capturing group error.
+					/<\1/.source + // eslint-disable-line regexp/strict
 						tagAttrs +
 						/\s*>/.source +
 						'(?:' +
 						(/[^<]/.source +
 							'|' +
 							// all tags that are not the start tag
-							// eslint-disable-next-line regexp/strict
-							/<\/?(?!\1\b)/.source +
+							// @ts-expect-error TS(2532): Ignore the non-existent capturing group error.
+							/<\/?(?!\1\b)/.source + // eslint-disable-line regexp/strict
 							tagContent +
 							'|' +
 							'<self>') +
 						')*' +
-						// eslint-disable-next-line regexp/strict
-						/<\/\1\s*>/.source,
+						// @ts-expect-error TS(2532): Ignore the non-existent capturing group error.
+						/<\/\1\s*>/.source, // eslint-disable-line regexp/strict
 					2
 				)) +
 			')*' +
-			// eslint-disable-next-line regexp/strict
-			/<\/\1\s*>/.source +
+			// @ts-expect-error TS(2532): Ignore the non-existent capturing group error.
+			/<\/\1\s*>/.source + // eslint-disable-line regexp/strict
 			'|' +
 			/</.source +
 			tagContent +

--- a/src/languages/prism-cue.ts
+++ b/src/languages/prism-cue.ts
@@ -5,20 +5,20 @@ export default {
 	grammar () {
 		// https://cuelang.org/docs/references/spec/
 
-		// eslint-disable-next-line regexp/strict
-		const stringEscape = /\\(?:(?!\2)|\2(?:[^()\r\n]|\([^()]*\)))/.source;
+		// @ts-expect-error TS(2532): Ignore the non-existent capturing group error.
+		const stringEscape = /\\(?:(?!\2)|\2(?:[^()\r\n]|\([^()]*\)))/.source; // eslint-disable-line regexp/strict
 		const stringTypes =
-			// eslint-disable-next-line regexp/strict
-			/"""(?:[^\\"]|"(?!""\2)|<esc>)*"""/.source +
+			// @ts-expect-error TS(2532): Ignore the non-existent capturing group error.
+			/"""(?:[^\\"]|"(?!""\2)|<esc>)*"""/.source + // eslint-disable-line regexp/strict
 			'|' +
-			// eslint-disable-next-line regexp/strict
-			/'''(?:[^\\']|'(?!''\2)|<esc>)*'''/.source +
+			// @ts-expect-error TS(2532): Ignore the non-existent capturing group error.
+			/'''(?:[^\\']|'(?!''\2)|<esc>)*'''/.source + // eslint-disable-line regexp/strict
 			'|' +
-			// eslint-disable-next-line regexp/strict
-			/"(?:[^\\\r\n"]|"(?!\2)|<esc>)*"/.source +
+			// @ts-expect-error TS(2532): Ignore the non-existent capturing group error.
+			/"(?:[^\\\r\n"]|"(?!\2)|<esc>)*"/.source + // eslint-disable-line regexp/strict
 			'|' +
-			// eslint-disable-next-line regexp/strict
-			/'(?:[^\\\r\n']|'(?!\2)|<esc>)*'/.source;
+			// @ts-expect-error TS(2532): Ignore the non-existent capturing group error.
+			/'(?:[^\\\r\n']|'(?!\2)|<esc>)*'/.source; // eslint-disable-line regexp/strict
 		const stringLiteral = '(?:' + stringTypes.replace(/<esc>/g, stringEscape) + ')';
 
 		return {
@@ -27,8 +27,8 @@ export default {
 				greedy: true,
 			},
 			'string-literal': {
-				// eslint-disable-next-line regexp/strict
-				pattern: RegExp(/(^|[^#"'\\])(#*)/.source + stringLiteral + /(?!["'])\2/.source),
+				// @ts-expect-error TS(2532): Ignore the non-existent capturing group error.
+				pattern: RegExp(/(^|[^#"'\\])(#*)/.source + stringLiteral + /(?!["'])\2/.source), // eslint-disable-line regexp/strict
 				lookbehind: true,
 				greedy: true,
 				inside: {

--- a/src/languages/prism-d.ts
+++ b/src/languages/prism-d.ts
@@ -48,11 +48,11 @@ export default {
 							/\bq"((?!\d)\w+)$[\s\S]*?^\1"/.source,
 
 							// q"//", q"||", etc.
-							// eslint-disable-next-line regexp/strict
-							/\bq"(.)[\s\S]*?\2"/.source,
+							// @ts-expect-error TS(2532): Ignore the non-existent capturing group error.
+							/\bq"(.)[\s\S]*?\2"/.source, // eslint-disable-line regexp/strict
 
-							// eslint-disable-next-line regexp/strict
-							/(["`])(?:\\[\s\S]|(?!\3)[^\\])*\3[cwd]?/.source,
+							// @ts-expect-error TS(2532): Ignore the non-existent capturing group error.
+							/(["`])(?:\\[\s\S]|(?!\3)[^\\])*\3[cwd]?/.source, // eslint-disable-line regexp/strict
 						].join('|'),
 						'm'
 					),

--- a/src/languages/prism-markdown.ts
+++ b/src/languages/prism-markdown.ts
@@ -267,8 +267,8 @@ export default {
 			'strike': {
 				// ~~strike through~~
 				// ~strike~
-				// eslint-disable-next-line regexp/strict
-				pattern: createInline(/(~~?)(?:(?!~)<inner>)+\2/.source),
+				// @ts-expect-error TS(2532): Ignore the non-existent capturing group error.
+				pattern: createInline(/(~~?)(?:(?!~)<inner>)+\2/.source), // eslint-disable-line regexp/strict
 				lookbehind: true,
 				greedy: true,
 				inside: {

--- a/src/languages/prism-perl.ts
+++ b/src/languages/prism-perl.ts
@@ -32,8 +32,8 @@ export default {
 								/([^a-zA-Z0-9\s{(\[<])(?:(?!\1)[^\\]|\\[\s\S])*\1/.source,
 
 								// q a...a
-								// eslint-disable-next-line regexp/strict
-								/([a-zA-Z0-9])(?:(?!\2)[^\\]|\\[\s\S])*\2/.source,
+								// @ts-expect-error TS(2532): Ignore the non-existent capturing group error.
+								/([a-zA-Z0-9])(?:(?!\2)[^\\]|\\[\s\S])*\2/.source, // eslint-disable-line regexp/strict
 
 								// q(...)
 								// q{...}
@@ -69,8 +69,8 @@ export default {
 								/([^a-zA-Z0-9\s{(\[<])(?:(?!\1)[^\\]|\\[\s\S])*\1/.source,
 
 								// m a...a
-								// eslint-disable-next-line regexp/strict
-								/([a-zA-Z0-9])(?:(?!\2)[^\\]|\\[\s\S])*\2/.source,
+								// @ts-expect-error TS(2532): Ignore the non-existent capturing group error.
+								/([a-zA-Z0-9])(?:(?!\2)[^\\]|\\[\s\S])*\2/.source, // eslint-disable-line regexp/strict
 
 								// m(...)
 								// m{...}
@@ -91,13 +91,13 @@ export default {
 							'(?:' +
 							[
 								// s/.../.../
-								// eslint-disable-next-line regexp/strict
-								/([^a-zA-Z0-9\s{(\[<])(?:(?!\2)[^\\]|\\[\s\S])*\2(?:(?!\2)[^\\]|\\[\s\S])*\2/
+								// @ts-expect-error TS(2532): Ignore the non-existent capturing group error.
+								/([^a-zA-Z0-9\s{([<])(?:(?!\2)[^\\]|\\[\s\S])*\2(?:(?!\2)[^\\]|\\[\s\S])*\2/ // eslint-disable-line regexp/strict
 									.source,
 
 								// s a...a...a
-								// eslint-disable-next-line regexp/strict
-								/([a-zA-Z0-9])(?:(?!\3)[^\\]|\\[\s\S])*\3(?:(?!\3)[^\\]|\\[\s\S])*\3/
+								// @ts-expect-error TS(2532): Ignore the non-existent capturing group error.
+								/([a-zA-Z0-9])(?:(?!\3)[^\\]|\\[\s\S])*\3(?:(?!\3)[^\\]|\\[\s\S])*\3/ // eslint-disable-line regexp/strict
 									.source,
 
 								// s(...)(...)


### PR DESCRIPTION
We ignore the non-existent capturing group TS error (by expecting it) where it’s irrelevant and preserve the existing `eslint-disable` rules. There was no way to stack the existing ESLint rule with the new one (they should be applied to the same line), so I placed the ESLint rule on the same line it disables.

I also bumped up the TS version. Because why not? It's a good chance to make the code base up-to-date step-by-step. 🙃