### PR TITLE
Package improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,9 @@
 			"types": "./types/languages/*.d.ts",
 			"import": "./dist/languages/*.js",
 			"require": "./dist/cjs/languages/*.js"
-		}
+		},
+		"./themes/*": "./dist/themes/*.css",
+		"./components.json": "./dist/components.json"
 	},
 	"style": "themes/prism.css",
 	"engines": {

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -319,6 +319,12 @@ async function clean() {
 	]);
 }
 
+async function copyComponentsJson () {
+	const from = path.join(SRC_DIR, 'components.json');
+	const to = path.join(__dirname, '../dist/components.json');
+	await copyFile(from, to);
+}
+
 async function buildTypes() {
 	await mkdir('./types');
 
@@ -403,4 +409,4 @@ async function buildJS() {
 	}
 }
 
-runTask(series(clean, parallel(buildTypes, buildJS, series(treeviewIconFont, minifyCSS))));
+runTask(series(clean, parallel(buildTypes, buildJS, series(treeviewIconFont, minifyCSS)), copyComponentsJson));


### PR DESCRIPTION
- Add missing exports for themes and `components.json`
- Add another build step that copies `components.json` to the `dist` folder (resolved in https://github.com/PrismJS/website/pull/26#issuecomment-2823931235)