### PR TITLE
Ditch `eslint-plugin-prettier` and use `eslint-config-prettier`

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -3,10 +3,10 @@ import js from '@eslint/js';
 import tsEslintPlugin from '@typescript-eslint/eslint-plugin';
 import tsEslintParser from '@typescript-eslint/parser';
 import { defineConfig } from 'eslint/config';
+import eslintConfigPrettier from 'eslint-config-prettier/flat';
 import eslintCommentsPlugin from 'eslint-plugin-eslint-comments';
 import importPlugin from 'eslint-plugin-import';
 import jsdocPlugin from 'eslint-plugin-jsdoc';
-import prettierPlugin from 'eslint-plugin-prettier';
 import regexpPlugin from 'eslint-plugin-regexp';
 import globals from 'globals';
 
@@ -25,15 +25,12 @@ const config = [
 			import: importPlugin,
 			jsdoc: jsdocPlugin,
 			regexp: regexpPlugin,
-			prettier: prettierPlugin,
 		},
 		languageOptions: {
 			ecmaVersion: 'latest',
 			sourceType: 'module',
 		},
 		rules: {
-			...prettierPlugin.configs.recommended.rules,
-
 			'no-use-before-define': ['warn', { 'functions': false, 'classes': false }],
 			'eqeqeq': ['warn', 'always', { 'null': 'ignore' }],
 
@@ -262,6 +259,7 @@ const config = [
 			},
 		},
 	},
+	eslintConfigPrettier,
 ];
 
 export default defineConfig(replaceErrorsWithWarnings(config));

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,6 @@
 				"eslint-plugin-eslint-comments": "^3.2.0",
 				"eslint-plugin-import": "^2.31.0",
 				"eslint-plugin-jsdoc": "^50.6.9",
-				"eslint-plugin-prettier": "^5.2.6",
 				"eslint-plugin-regexp": "^2.7.0",
 				"globals": "^16.0.0",
 				"gzip-size": "^7.0.0",
@@ -2181,19 +2180,6 @@
 			"license": "MIT",
 			"dependencies": {
 				"@octokit/openapi-types": "^24.2.0"
-			}
-		},
-		"node_modules/@pkgr/core": {
-			"version": "0.2.4",
-			"resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.2.4.tgz",
-			"integrity": "sha512-ROFF39F6ZrnzSUEmQQZUar0Jt4xVoP9WnDRdWwF4NNcXs3xBTLgBUDoOwW141y1jP+S8nahIbdxbFC7IShw9Iw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": "^12.20.0 || ^14.18.0 || >=16.0.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/pkgr"
 			}
 		},
 		"node_modules/@prettier/sync": {
@@ -4917,37 +4903,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/eslint-plugin-prettier": {
-			"version": "5.2.6",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.2.6.tgz",
-			"integrity": "sha512-mUcf7QG2Tjk7H055Jk0lGBjbgDnfrvqjhXh9t2xLMSCjZVcw9Rb1V6sVNXO0th3jgeO7zllWPTNRil3JW94TnQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"prettier-linter-helpers": "^1.0.0",
-				"synckit": "^0.11.0"
-			},
-			"engines": {
-				"node": "^14.18.0 || >=16.0.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/eslint-plugin-prettier"
-			},
-			"peerDependencies": {
-				"@types/eslint": ">=8.0.0",
-				"eslint": ">=8.0.0",
-				"eslint-config-prettier": ">= 7.0.0 <10.0.0 || >=10.1.0",
-				"prettier": ">=3.0.0"
-			},
-			"peerDependenciesMeta": {
-				"@types/eslint": {
-					"optional": true
-				},
-				"eslint-config-prettier": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/eslint-plugin-regexp": {
 			"version": "2.7.0",
 			"resolved": "https://registry.npmjs.org/eslint-plugin-regexp/-/eslint-plugin-regexp-2.7.0.tgz",
@@ -5274,13 +5229,6 @@
 			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/fast-diff": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.3.0.tgz",
-			"integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==",
-			"dev": true,
-			"license": "Apache-2.0"
 		},
 		"node_modules/fast-glob": {
 			"version": "3.3.3",
@@ -8945,19 +8893,6 @@
 				"url": "https://github.com/prettier/prettier?sponsor=1"
 			}
 		},
-		"node_modules/prettier-linter-helpers": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
-			"integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"fast-diff": "^1.1.2"
-			},
-			"engines": {
-				"node": ">=6.0.0"
-			}
-		},
 		"node_modules/prettier-plugin-brace-style": {
 			"version": "0.7.2",
 			"resolved": "https://registry.npmjs.org/prettier-plugin-brace-style/-/prettier-plugin-brace-style-0.7.2.tgz",
@@ -10383,23 +10318,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/synckit": {
-			"version": "0.11.4",
-			"resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.4.tgz",
-			"integrity": "sha512-Q/XQKRaJiLiFIBNN+mndW7S/RHxvwzuZS6ZwmRzUBqJBv/5QIKCEwkBC8GBf8EQJKYnaFs0wOZbKTXBPj8L9oQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@pkgr/core": "^0.2.3",
-				"tslib": "^2.8.1"
-			},
-			"engines": {
-				"node": "^14.18.0 || >=16.0.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/synckit"
-			}
-		},
 		"node_modules/terser": {
 			"version": "5.39.0",
 			"resolved": "https://registry.npmjs.org/terser/-/terser-5.39.0.tgz",
@@ -10583,7 +10501,9 @@
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
 			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
 			"dev": true,
-			"license": "0BSD"
+			"license": "0BSD",
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/tsx": {
 			"version": "4.19.3",

--- a/package.json
+++ b/package.json
@@ -86,7 +86,6 @@
 		"eslint-plugin-eslint-comments": "^3.2.0",
 		"eslint-plugin-import": "^2.31.0",
 		"eslint-plugin-jsdoc": "^50.6.9",
-		"eslint-plugin-prettier": "^5.2.6",
 		"eslint-plugin-regexp": "^2.7.0",
 		"globals": "^16.0.0",
 		"gzip-size": "^7.0.0",


### PR DESCRIPTION
- We don't need `eslint-plugin-prettier` since we now use Prettier as a formatter. Moreover, it conflicts with the specified rules because it doesn't consider our Prettier configuration.
- Use `eslint-config-prettier` to turn off all unnecessary rules that might conflict with Prettier.