### PR TITLE
Add proper typing for the `Grammar` type

### DIFF
--- a/src/grammar.d.ts
+++ b/src/grammar.d.ts
@@ -81,12 +81,8 @@ export interface GrammarToken {
 	inside?: string | Grammar | null;
 }
 
-export type GrammarTokens = Partial<
-	Record<
-		TokenName,
-		RegExpLike | GrammarToken | GrammarTokens | (RegExpLike | GrammarToken | GrammarTokens)[]
-	>
->;
+export type GrammarTokens = GrammarTokensRec<GrammarTokensDepth>;
+
 export interface GrammarSymbols {
 	/**
 	 * An optional grammar object that will be appended to this grammar.
@@ -102,3 +98,60 @@ export interface GrammarSpecial {
 }
 
 export type Grammar = GrammarTokens & GrammarSymbols & GrammarSpecial;
+
+/**
+ * Recursive type helpers for GrammarTokens
+ *
+ * Why do we need this?
+ * The structure of a Prism grammar is inherently recursive: a token can contain an “inside” grammar, which itself is a set of tokens, and so on.
+ * To accurately type this, we need a recursive type definition.
+ *
+ * Why not just use the old type?
+ * ```ts
+ * export type GrammarTokens = Partial<Record<TokenName, RegExpLike | GrammarToken | GrammarTokens | (RegExpLike | GrammarToken | GrammarTokens)[]>>;
+ * ```
+ * This type definition is infinitely recursive, which caused TypeScript to give up and treat it as “any”.
+ * By introducing a recursion depth limit (using a decrement tuple), we keep the type safe and precise, and prevent TypeScript from running into infinite recursion.
+ *
+ * The helpers below allow us to control the recursion depth in one place, making the type both maintainable and type-safe.
+ */
+
+// Centralize the depth
+type GrammarTokensDepth = 5;
+
+// Helper to build a tuple of length N
+type BuildTuple<L extends number, T extends unknown[] = []> = T['length'] extends L
+	? T
+	: BuildTuple<L, [unknown, ...T]>;
+
+/**
+ * Helper to generate a decrement tuple
+ *
+ * TypeScript can't subtract numbers at the type level, so we use a tuple (array) to "count down" the depth for recursion.
+ * This lets us limit how many times GrammarTokensRec can call itself, which prevents infinite recursion and keeps the type safe.
+ */
+type DecrementTuple<T extends unknown[], R extends number[] = []> = T extends [
+	unknown,
+	...infer Rest,
+]
+	? DecrementTuple<Rest, [...R, Rest['length']]>
+	: R;
+
+// The actual decrement tuple, derived from the depth
+type Decrement = DecrementTuple<BuildTuple<GrammarTokensDepth>>;
+
+/**
+ * GrammarTokensRec is a recursive type that builds a partial record of token names as keys, with values that can be a RegExp, GrammarToken, or an array of those types.
+ * It uses the decrement tuple to count down the depth of recursion, preventing infinite loops.
+ */
+type GrammarTokensRec<Depth extends number = GrammarTokensDepth> = Depth extends 0
+	? never
+	: Partial<
+			Record<
+				TokenName,
+				| RegExpLike
+				| GrammarToken
+				| GrammarTokensRec<Decrement[Depth]>
+				| (RegExpLike | GrammarToken | GrammarTokensRec<Decrement[Depth]>)[]
+			>
+		>;

--- a/src/grammar.d.ts
+++ b/src/grammar.d.ts
@@ -120,9 +120,9 @@ export type Grammar = GrammarTokens & GrammarSymbols & GrammarSpecial;
 type GrammarTokensDepth = 5;
 
 // Helper to build a tuple of length N
-type BuildTuple<L extends number, T extends unknown[] = []> = T['length'] extends L
+type BuildTuple<N extends number, T extends unknown[] = []> = T['length'] extends N
 	? T
-	: BuildTuple<L, [unknown, ...T]>;
+	: BuildTuple<N, [unknown, ...T]>;
 
 /**
  * Helper to generate a decrement tuple


### PR DESCRIPTION
TS still treats it as `any` because of infinite recursion.

For now,  we limit the recursion depth to 5 (`GrammarTokensDepth`). We can change it if needed.