### PR TITLE
Improve the postinstall hook

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,2 @@
-postinstall.js # in the script, we use syntax that this version of ESLint can't parse
+# In the script, we use syntax that this version of ESLint can't parse
+postinstall.js

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+postinstall.js # in the script, we use syntax that this version of ESLint can't parse

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
 		"test:runner": "mocha tests/testrunner-tests.js",
 		"test": "npm-run-all test:*",
 		"release": "release-it",
-		"postinstall": "npm run build"
+		"postinstall": "node postinstall.js"
 	},
 	"repository": {
 		"type": "git",

--- a/postinstall.js
+++ b/postinstall.js
@@ -1,0 +1,27 @@
+// The script is compatible with Node.js 10+
+
+const { execSync } = require('child_process');
+const { resolve } = require('path');
+
+function gulpInstalled () {
+	try {
+		require.resolve('gulp');
+		return true;
+	}
+	catch {
+		return false;
+	}
+}
+
+const root = resolve(__dirname, '.');
+
+if (!gulpInstalled()) {
+	console.log('[postinstall] Dependencies missing — installing...');
+	execSync('npm install', { cwd: root, stdio: 'inherit' });
+}
+else {
+	console.log('[postinstall] Dependencies already installed.');
+}
+
+console.log('[postinstall] Running build...');
+execSync('npm run build', { cwd: root, stdio: 'inherit' });


### PR DESCRIPTION
- Works whether the package is installed via npm, from GitHub, or a local folder. For now, running `npm install` from the root project fails if we use this repo as a dev dependency.

- Ensures dependencies are installed before `gulp` is called.