### PR TITLE
Update the `Language` class

### DIFF
--- a/src/core/classes/language.ts
+++ b/src/core/classes/language.ts
@@ -89,7 +89,16 @@ export default class Language extends EventTarget {
 			return null;
 		}
 
-		return this.registry.getLanguage(this.def.base.id) ?? null;
+		let base = this.def.base;
+		let language = this.registry.peek(base);
+		if (language) {
+			// Already resolved
+			return language;
+		}
+		else {
+			this.registry.add(base as LanguageProto);
+			return this.registry.getLanguage(base.id);
+		}
 	}
 
 	get extends () {
@@ -114,7 +123,7 @@ export default class Language extends EventTarget {
 				languages: this.languages,
 				getLanguage: (id: string) => {
 					let language = this.languages[id] ?? this.registry.getLanguage(id);
-					return language?.resolvedGrammar as Grammar;
+					return language?.resolvedGrammar as Grammar ?? language;
 				},
 				whenDefined: (id: string) => {
 					return this.registry.whenDefined(id) as unknown as Promise<Language>;


### PR DESCRIPTION
### Summary

- If a grammar has a base language, it should always be resolved
- Fix `getLanguage()`: `language` can already be a resolved grammar if it is taken from `this.languages`

With the change, code blocks in HTML, CSS, and JS can be highlighted correctly without needing to specify the base languages (`clike` and `xml`):

```html
<script type="module" src="./dist/index.js" data-prism-languages="javascript, css, markup"></script>
```

Without the change, we need to explicitly specify them:

```html
<script type="module" src="./dist/index.js" data-prism-languages="clike, javascript, css, xml, markup"></script>
```