### PR TITLE
Some fixes to `tokenize`

### DIFF
--- a/src/core/tokenize/match.ts
+++ b/src/core/tokenize/match.ts
@@ -50,7 +50,7 @@ export function _matchGrammar (
 				// Without the global flag, lastIndex won't work
 				flagsToAdd += 'g';
 			}
-			if (pattern.source.includes('(?<') && pattern.hasIndices === false) {
+			if (pattern.source?.includes('(?<') && pattern.hasIndices === false) {
 				// Has named groups, we need to be able to capture their indices
 				flagsToAdd += 'd';
 			}

--- a/src/core/tokenize/util.ts
+++ b/src/core/tokenize/util.ts
@@ -10,7 +10,7 @@ export function resolve (
 	let ret = reference ?? undefined;
 
 	if (typeof ret === 'string') {
-		ret = prism.languageRegistry.getLanguage(ret)?.grammar;
+		ret = prism.languageRegistry.getLanguage(ret)?.resolvedGrammar;
 	}
 
 	if (typeof ret === 'function' && ret.length === 0) {

--- a/src/core/tokenize/util.ts
+++ b/src/core/tokenize/util.ts
@@ -20,6 +20,7 @@ export function resolve (
 
 	if (typeof ret === 'object' && ret.$rest) {
 		let restGrammar = resolve.call(prism, ret.$rest) ?? {};
+		delete ret.$rest;
 
 		if (typeof restGrammar === 'object') {
 			ret = { ...ret, ...restGrammar };


### PR DESCRIPTION
### Summary

- Don’t choke on patterns that are not instances of `RegExp`
- In `resolve()` return `resolvedGrammar` and delete `$rest` after it is properly resolved