### PR TITLE
Generate `file-sizes.json` during the build

### DIFF
--- a/scripts/components.ts
+++ b/scripts/components.ts
@@ -7,4 +7,4 @@ const __dirname = path.dirname(__filename);
 
 export const components = JSON.parse(
 	fs.readFileSync(path.join(__dirname, '../src/components.json'), 'utf-8')
-) as Record<string, Record<string, { title: string; aliasTitles?: Record<string, string> }>>;
+) as Record<string, Record<string, { title: string; aliasTitles?: Record<string, string>; noCSS?: boolean }>>;

--- a/src/components.json
+++ b/src/components.json
@@ -1,7 +1,7 @@
 {
 	"core": {
 		"meta": {
-			"path": "components/prism-core.js",
+			"path": "index.js",
 			"option": "mandatory"
 		},
 		"core": "Core"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -100,5 +100,6 @@
 		// "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
 		"skipLibCheck": true /* Skip type checking all .d.ts files. */
 	},
-	"include": ["./src/**/*"]
+	"include": ["./src/**/*"],
+	"exclude": ["./src/plugins/**/demo.js"]
 }


### PR DESCRIPTION
This file is used on the Download page of the Prism website.

Some other changes:

- Make sure the Rollup plugins are applied in the correct order
- Exclude plugins' `demo.js` files from type checking
- Prettier