### PR TITLE
Fix the Markdown language

### DIFF
--- a/src/languages/markdown.ts
+++ b/src/languages/markdown.ts
@@ -95,9 +95,10 @@ export default {
 					// code block
 					// ```
 					pattern:
-						/^```(?<codeLanguage>[a-z-]+)(?:.+)?(?:\n|\r\n?)(?<codeBlock>[\s\S]*)?(?:\n|\r\n?)```$/i,
+						/^```(?<codeLanguage>[a-z-]+)(?:.+)?(?:\n|\r\n?)(?<codeBlock>[\s\S]*?)(?:\n|\r\n?)```$/im,
 					inside: {
-						'code-block': groups => groups.codeLanguage,
+						'code-language': groups => groups.codeLanguage,
+						'code-block': groups => groups.codeBlock,
 						'punctuation': /```/,
 					},
 				},

--- a/src/languages/markdown.ts
+++ b/src/languages/markdown.ts
@@ -95,7 +95,7 @@ export default {
 					// code block
 					// ```
 					pattern:
-						/^```(?<codeLanguage>[a-z-]+)(?:.+)?(?:\n|\r\n?)(?<codeBlock>[\s\S]*?)(?:\n|\r\n?)```$/im,
+						/^```(?:\s*)(?<codeLanguage>[a-z-]+)(?:.+)?(?:\n|\r\n?)(?<codeBlock>[\s\S]*?)(?:\n|\r\n?)```$/im,
 					inside: {
 						'code-language': groups => groups.codeLanguage,
 						'code-block': groups => groups.codeBlock,


### PR DESCRIPTION
- Add the missing inside token and fix the existing one
- Fix the regex that is too greedy now: if we have more than one code block next to each other, all of them starting from the second one will be interpreted as a code block of the first one
- Ignore spaces before the language code

However, to fully support it, we need to support functional tokens first. For now, we don't, and we work with it as it is a regex, or an object with the `pattern` property. In both cases, `matchPattern()` (in `tokenize/match.ts`) throws.