### PR TITLE
Before highlighting code, resolve the language if its definition is already loaded, and it is not yet resolved

### DIFF
--- a/src/core/highlight.ts
+++ b/src/core/highlight.ts
@@ -54,6 +54,10 @@ export function highlight (
 		language,
 	};
 
+	if (env.languageDef && !env.language) {
+		env.language = prism.languageRegistry.getLanguage(env.languageDef);
+	}
+
 	prism.hooks.run('before-tokenize', env);
 
 	if (!env.language) {


### PR DESCRIPTION
For now, one can write a code that looks correct but will throw (necessary imports are omitted):

```js
prism.languageRegistry.add(javascript);
prism.highlight("let foo = 42;", javascript);
```
