### PR TITLE
Make `nextTick()` work in environments other than browsers

### DIFF
--- a/src/util/async.ts
+++ b/src/util/async.ts
@@ -26,7 +26,17 @@ export function documentReady (document = globalThis.document) {
 }
 
 export function nextTick () {
-	return new Promise(resolve => requestAnimationFrame(resolve));
+	return new Promise(resolve => {
+		if (typeof requestAnimationFrame === 'function') {
+			requestAnimationFrame(resolve);
+		}
+		else if (typeof setImmediate === 'function') {
+			setImmediate(resolve);
+		}
+		else {
+			setTimeout(resolve, 0);
+		}
+	});
 }
 
 export async function allSettled<T> (promises: Promise<T>[]): Promise<(T | null)[]> {


### PR DESCRIPTION
For now, when we call `nextTick()`, the returned promise is always rejected.