### PR TITLE
Fix the gradle language

### DIFF
--- a/src/languages/gradle.ts
+++ b/src/languages/gradle.ts
@@ -3,7 +3,7 @@ import type { LanguageProto } from '../types';
 
 export default {
 	id: 'gradle',
-	require: clike,
+	base: clike,
 	grammar () {
 		const interpolation = {
 			pattern: /((?:^|[^\\$])(?:\\{2})*)\$(?:\w+|\{[^{}]*\})/,


### PR DESCRIPTION
Initially, we extended `clike`; it wasn’t just a required dependency.