### PR TITLE
Update themes' docs

### DIFF
--- a/src/themes/coy.css
+++ b/src/themes/coy.css
@@ -1,7 +1,10 @@
 /**
+ * Coy
+ *
  * prism.js Coy theme for JavaScript, CoffeeScript, CSS and HTML
  * Based on https://github.com/tshedor/workshop-wp-theme.
- * @author Tim Shedor
+ *
+ * @author Tim Shedor (tshedor)
  */
 
 code[class*="language-"],

--- a/src/themes/dark.css
+++ b/src/themes/dark.css
@@ -1,7 +1,10 @@
 /**
+ * Dark
+ *
  * prism.js Dark theme for JavaScript, CSS and HTML
  * Based on the slides of the talk [“/Reg(exp){2}lained/”](https://regexplained.com/slides.html).
- * @author Lea Verou
+ *
+ * @author Lea Verou (LeaVerou)
  */
 
 code[class*="language-"],

--- a/src/themes/funky.css
+++ b/src/themes/funky.css
@@ -1,7 +1,10 @@
 /**
+ * Funky
+ *
  * prism.js Funky theme
  * Based on [“Polyfilling the gaps”](https://talks.verou.me/polyfilling-the-gaps/) talk slides.
- * @author Lea Verou
+ *
+ * @author Lea Verou (LeaVerou)
  */
 
 code[class*="language-"],

--- a/src/themes/okaidia.css
+++ b/src/themes/okaidia.css
@@ -1,7 +1,10 @@
 /**
+ * Okaidia
+ *
  * prism.js Okaidia theme for JavaScript, CSS and HTML
  * Loosely based on Monokai textmate theme by https://monokai.com/.
- * @author Paul Livingstone
+ *
+ * @author Paul Livingstone (ocodia)
  */
 
 code[class*="language-"],

--- a/src/themes/prism.css
+++ b/src/themes/prism.css
@@ -1,7 +1,10 @@
 /**
+ * Default
+ *
  * prism.js default theme for JavaScript, CSS and HTML
  * Based on [dabblet](https://dabblet.com).
- * @author Lea Verou
+ *
+ * @author Lea Verou (LeaVerou)
  */
 
 code[class*="language-"],

--- a/src/themes/solarizedlight.css
+++ b/src/themes/solarizedlight.css
@@ -1,7 +1,10 @@
 /**
+ * Solarized Light
+ *
  * prism.js Solarized Light theme
  * Based on [Solarized Color Schemes](https://ethanschoonover.com/solarized) by Ethan Schoonover.
- * @author Hector Matos
+ *
+ * @author Hector Matos (hectormatos2011)
 */
 
 /*

--- a/src/themes/tomorrow.css
+++ b/src/themes/tomorrow.css
@@ -1,7 +1,10 @@
 /**
+ * Tomorrow Night
+ *
  * prism.js Tomorrow Night theme for JavaScript, CoffeeScript, CSS and HTML
  * Based on https://github.com/chriskempson/tomorrow-theme.
- * @author Rose Robertson
+ *
+ * @author Rose Robertson (Rosey)
  */
 
 code[class*="language-"],

--- a/src/themes/twilight.css
+++ b/src/themes/twilight.css
@@ -1,7 +1,10 @@
 /**
+ * Twilight
+ *
  * prism.js Twilight theme
  * Based (more or less) on the Twilight theme originally of Textmate fame.
- * @author Rémy Bach
+ *
+ * @author Rémy Bach (remybach)
  */
 
 code[class*="language-"],


### PR DESCRIPTION
So that they follow the structure (we can parse and use on the website):

```
/**
 * <title>
 *
 * <description>
 *
 * @author <name> (<GitHub_username>)
 */
```

Between the data chunks, there should be at least one empty line.