### PR TITLE
Move the `Token` class under the `classes` folder

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -1,2 +1,2 @@
 export { Prism } from './core/prism';
-export { Token } from './core/token';
+export { Token } from './core/classes/token';

--- a/src/core/classes/token.ts
+++ b/src/core/classes/token.ts
@@ -1,5 +1,37 @@
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-import type { Grammar, GrammarToken, TokenName } from '../types';
+type StandardTokenName =
+	| 'atrule'
+	| 'attr-name'
+	| 'attr-value'
+	| 'bold'
+	| 'boolean'
+	| 'builtin'
+	| 'cdata'
+	| 'char'
+	| 'class-name'
+	| 'comment'
+	| 'constant'
+	| 'deleted'
+	| 'doctype'
+	| 'entity'
+	| 'function'
+	| 'important'
+	| 'inserted'
+	| 'italic'
+	| 'keyword'
+	| 'namespace'
+	| 'number'
+	| 'operator'
+	| 'prolog'
+	| 'property'
+	| 'punctuation'
+	| 'regex'
+	| 'selector'
+	| 'string'
+	| 'symbol'
+	| 'tag'
+	| 'url';
+
+export type TokenName = (string & {}) | StandardTokenName;
 
 export class Token {
 	/**
@@ -68,6 +100,8 @@ export class Token {
 	}
 }
 
+export default Token;
+
 /**
  * A token stream is an array of strings and {@link Token Token} objects.
  *
@@ -77,7 +111,7 @@ export class Token {
  * 1. No adjacent strings.
  * 2. No empty strings.
  *
- *    The only exception here is the token stream that only contains the empty string and nothing else.
+ * The only exception here is the token stream that only contains the empty string and nothing else.
  */
 export type TokenStream = (string | Token)[];
 

--- a/src/core/hooks.ts
+++ b/src/core/hooks.ts
@@ -1,6 +1,6 @@
 import type { Grammar, TokenName } from '../types';
 import type { HookState } from './hook-state';
-import type { TokenStream } from './token';
+import type { TokenStream } from './classes/token';
 
 export class Hooks {
 	// eslint-disable-next-line func-call-spacing

--- a/src/core/prism.ts
+++ b/src/core/prism.ts
@@ -5,12 +5,12 @@ import { HookState } from './hook-state';
 import { Hooks } from './hooks';
 import { LinkedList } from './linked-list';
 import { Registry } from './registry';
-import { Token } from './token';
+import { Token } from './classes/token';
 import type { KnownPlugins } from '../known-plugins';
 import type { Grammar, GrammarToken, GrammarTokens, RegExpLike } from '../types';
 import type { HookEnvMap } from './hooks';
 import type { LinkedListHeadNode, LinkedListMiddleNode, LinkedListTailNode } from './linked-list';
-import type { TokenStream } from './token';
+import type { TokenStream } from './classes/token';
 
 /**
  * Prism: Lightweight, robust, elegant syntax highlighting

--- a/src/languages/jsx.ts
+++ b/src/languages/jsx.ts
@@ -1,9 +1,9 @@
-import { Token, getTextContent } from '../core/token';
+import { getTextContent, Token } from '../core/classes/token';
 import { insertBefore, withoutTokenize } from '../shared/language-util';
 import { rest, tokenize } from '../shared/symbols';
 import javascript from './javascript';
 import markup from './markup';
-import type { TokenStream } from '../core/token';
+import type { TokenStream } from '../core/classes/token';
 import type { Grammar, GrammarToken, LanguageProto } from '../types';
 
 function stringifyToken (token: string | Token | TokenStream | undefined): string {

--- a/src/languages/markdown.ts
+++ b/src/languages/markdown.ts
@@ -1,4 +1,4 @@
-import { getTextContent } from '../core/token';
+import { getTextContent } from '../core/classes/token';
 import { insertBefore, withoutTokenize } from '../shared/language-util';
 import { tokenize } from '../shared/symbols';
 import markup from './markup';

--- a/src/languages/naniscript.ts
+++ b/src/languages/naniscript.ts
@@ -1,4 +1,4 @@
-import { getTextContent } from '../core/token';
+import { getTextContent } from '../core/classes/token';
 import { withoutTokenize } from '../shared/language-util';
 import { tokenize } from '../shared/symbols';
 import type { LanguageProto } from '../types';

--- a/src/languages/treeview.ts
+++ b/src/languages/treeview.ts
@@ -1,4 +1,4 @@
-import { getTextContent } from '../core/token';
+import { getTextContent } from '../core/classes/token';
 import { withoutTokenize } from '../shared/language-util';
 import { tokenize } from '../shared/symbols';
 import type { LanguageProto } from '../types';

--- a/src/languages/xquery.ts
+++ b/src/languages/xquery.ts
@@ -1,8 +1,8 @@
-import { Token, getTextContent } from '../core/token';
+import { getTextContent, Token } from '../core/classes/token';
 import { withoutTokenize } from '../shared/language-util';
 import { tokenize } from '../shared/symbols';
 import markup from './markup';
-import type { TokenStream } from '../core/token';
+import type { TokenStream } from '../core/classes/token';
 import type { Grammar, GrammarToken, LanguageProto } from '../types';
 
 function walkTokens (tokens: TokenStream) {

--- a/src/plugins/diff-highlight/prism-diff-highlight.ts
+++ b/src/plugins/diff-highlight/prism-diff-highlight.ts
@@ -1,8 +1,8 @@
-import { Token, getTextContent } from '../../core/token';
+import { Token, getTextContent } from '../../core/classes/token';
 import diff, { PREFIXES } from '../../languages/diff';
 import { addHooks } from '../../shared/hooks-util';
 import type { BeforeSanityCheckEnv, BeforeTokenizeEnv } from '../../core/hooks';
-import type { TokenStream } from '../../core/token';
+import type { TokenStream } from '../../core/classes/token';
 import type { PluginProto } from '../../types';
 
 export default {

--- a/src/shared/languages/templating.ts
+++ b/src/shared/languages/templating.ts
@@ -1,8 +1,8 @@
-import { getTextContent } from '../../core/token';
+import { getTextContent } from '../../core/classes/token';
 import { withoutTokenize } from '../language-util';
 import type { Prism } from '../../core';
+import type { Token, TokenStream } from '../../core/classes/token';
 import type { Registry } from '../../core/registry';
-import type { Token, TokenStream } from '../../core/token';
 import type { Grammar } from '../../types';
 import type { tokenize } from '../symbols';
 

--- a/src/shared/tokenize-strings.ts
+++ b/src/shared/tokenize-strings.ts
@@ -1,4 +1,4 @@
-import type { TokenStream } from '../core/token';
+import type { TokenStream } from '../core/classes/token';
 
 /**
  * Given a token stream and a tokenization function, this will tokenize all

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,5 +1,5 @@
 import type { Prism } from './core/prism';
-import type { TokenStream } from './core/token';
+import type { TokenStream } from './core/classes/token';
 import type { KnownPlugins } from './known-plugins';
 import type { rest, tokenize } from './shared/symbols';
 

--- a/tests/helper/test-case.ts
+++ b/tests/helper/test-case.ts
@@ -4,7 +4,7 @@ import { createInstance } from './prism-loader';
 import * as TokenStreamTransformer from './token-stream-transformer';
 import { formatHtml, getLeadingSpaces } from './util';
 import type { Prism } from '../../src/core';
-import type { TokenStream } from '../../src/core/token';
+import type { TokenStream } from '../../src/core/classes/token';
 
 const defaultCreateInstance = createInstance;
 

--- a/tests/identifier-test.ts
+++ b/tests/identifier-test.ts
@@ -3,7 +3,7 @@ import { toArray } from '../src/shared/util';
 import { createInstance, getComponent, getLanguageIds } from './helper/prism-loader';
 import { prettyprint } from './helper/token-stream-transformer';
 import type { Prism, Token } from '../src/core';
-import type { TokenStream } from '../src/core/token';
+import type { TokenStream } from '../src/core/classes/token';
 
 // This is where you can exclude a language from the identifier test.
 //


### PR DESCRIPTION
Let's consider this the first step in splitting the `simplify` branch into a bunch of more manageable PRs we can easily integrate.