### PR TITLE
Correctly parse CLI arguments

### DIFF
--- a/benchmark/benchmark.ts
+++ b/benchmark/benchmark.ts
@@ -141,7 +141,7 @@ async function runBenchmark (config: Config) {
 function getConfig (): Config {
 	const base = baseConfig;
 
-	const args = yargs(hideBin(process.argv)) as unknown as Record<string, unknown>;
+	const args = yargs(hideBin(process.argv)).argv as Record<string, unknown>;
 
 	if (typeof args.testFunction === 'string') {
 		baseConfig.options.testFunction = args.testFunction as ConfigOptions['testFunction'];

--- a/tests/helper/args.ts
+++ b/tests/helper/args.ts
@@ -1,7 +1,7 @@
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
 
-const args = yargs(hideBin(process.argv)) as {
+const args = yargs(hideBin(process.argv)).argv as {
 	language?: string | string[];
 	update?: boolean;
 };


### PR DESCRIPTION
Was fixed in #3949 (in the `simplify` branch). Move it here to make testing easier.