### PR TITLE
ESM bundle build optimization

### DIFF
--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -386,7 +386,6 @@ async function buildJS () {
 
 	const defaultOutputOptions: OutputOptions = {
 		dir: './dist',
-		chunkFileNames: '_chunks/[name]-[hash].js',
 		validate: true,
 		sourcemap: 'hidden',
 	};
@@ -400,7 +399,13 @@ async function buildJS () {
 		}
 	> = {
 		esm: {
-			rollupOptions: defaultRollupOptions,
+			rollupOptions: {
+				...defaultRollupOptions,
+				input: {
+					...input,
+					'prism': path.join(SRC_DIR, 'auto-start.ts'),
+				},
+			},
 			outputOptions: defaultOutputOptions,
 		},
 		cjs: {
@@ -411,21 +416,7 @@ async function buildJS () {
 			outputOptions: {
 				...defaultOutputOptions,
 				dir: './dist/cjs',
-			},
-		},
-		global: {
-			rollupOptions: {
-				...defaultRollupOptions,
-				input: {
-					'prism': path.join(SRC_DIR, 'auto-start.ts'),
-				},
-			},
-			outputOptions: {
-				...defaultOutputOptions,
-				format: 'iife',
-				name: 'Prism',
-				exports: 'default',
-				extend: true,
+				chunkFileNames: '_chunks/[name]-[hash].js',
 			},
 		},
 	};

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -416,7 +416,6 @@ async function buildJS () {
 			outputOptions: {
 				...defaultOutputOptions,
 				dir: './dist/cjs',
-				chunkFileNames: '_chunks/[name]-[hash].js',
 			},
 		},
 	};

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -399,13 +399,7 @@ async function buildJS () {
 		}
 	> = {
 		esm: {
-			rollupOptions: {
-				...defaultRollupOptions,
-				input: {
-					...input,
-					'prism': path.join(SRC_DIR, 'auto-start.ts'),
-				},
-			},
+			rollupOptions: defaultRollupOptions,
 			outputOptions: defaultOutputOptions,
 		},
 		cjs: {
@@ -425,6 +419,15 @@ async function buildJS () {
 			bundle.build = await rollup(bundle.rollupOptions);
 			await bundle.build.write(bundle.outputOptions);
 		}
+
+		// Global “bundle”
+		await writeFile(
+			path.join(DIST_DIR, 'prism.js'),
+			`if (globalThis.document?.currentScript) {
+	// In browser and imported via non-ESM
+	import('./index.js').then(({ default: prism }) => (globalThis.Prism = prism));
+}`
+		);
 	}
 	finally {
 		for (const bundle of Object.values(bundles)) {

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -364,6 +364,7 @@ async function buildTypes () {
 async function buildJS () {
 	const input: Record<string, string> = {
 		'index': path.join(SRC_DIR, 'index.ts'),
+		'prism': path.join(SRC_DIR, 'prism.ts'), // global “bundle”
 		'shared': path.join(SRC_DIR, 'shared.ts'),
 	};
 	for (const id of languageIds) {
@@ -419,15 +420,6 @@ async function buildJS () {
 			bundle.build = await rollup(bundle.rollupOptions);
 			await bundle.build.write(bundle.outputOptions);
 		}
-
-		// Global “bundle”
-		await writeFile(
-			path.join(DIST_DIR, 'prism.js'),
-			`if (globalThis.document?.currentScript) {
-	// In browser and imported via non-ESM
-	import('./index.js').then(({ default: prism }) => (globalThis.Prism = prism));
-}`
-		);
 	}
 	finally {
 		for (const bundle of Object.values(bundles)) {

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -364,7 +364,7 @@ async function buildTypes () {
 async function buildJS () {
 	const input: Record<string, string> = {
 		'index': path.join(SRC_DIR, 'index.ts'),
-		'prism': path.join(SRC_DIR, 'prism.ts'), // global “bundle”
+		'prism': path.join(SRC_DIR, 'prism.global.ts'),
 		'shared': path.join(SRC_DIR, 'shared.ts'),
 	};
 	for (const id of languageIds) {

--- a/src/prism.global.ts
+++ b/src/prism.global.ts
@@ -1,0 +1,2 @@
+// In browser and imported via non-ESM
+import('./index.js').then(({ default: prism }) => ((globalThis as any).Prism = prism));

--- a/src/prism.ts
+++ b/src/prism.ts
@@ -1,0 +1,4 @@
+if (globalThis.document?.currentScript) {
+	// In browser and imported via non-ESM
+	import('./index.js').then(({ default: prism }) => ((globalThis as any).Prism = prism));
+}

--- a/src/prism.ts
+++ b/src/prism.ts
@@ -1,4 +1,0 @@
-if (globalThis.document?.currentScript) {
-	// In browser and imported via non-ESM
-	import('./index.js').then(({ default: prism }) => ((globalThis as any).Prism = prism));
-}


### PR DESCRIPTION
Rel to #3984.

- Ditch the `global` bundle (see below) in favor of a JS file
- Remove chunks (use native ESM features)
- Additionally, output `auto-load.ts` to `prism.js` (when we did that in a separate bundle, another instance of Prism was created automatically when attaching plugins to the global instance of Prism, which is wrong). As a result, `v2` can be used the same way (including automatically attaching plugins) as `v1` ~but should be included as a module~, i.e., `<script src="prism.js"></script>`

~I wonder if we still need to expose a Prism instance via `globalThis`? It seems like no `v2` functionality depends on it. By merging this PR, we won't do that (for now, since we have a separate `glo~al` bundle, we expose `Prism`).~