### PR TITLE
Fix issue with relative URL in dynamic import

### DIFF
--- a/src/prism.global.ts
+++ b/src/prism.global.ts
@@ -1,2 +1,4 @@
 // In browser and imported via non-ESM
-import('./index.js').then(({ default: prism }) => ((globalThis as any).Prism = prism));
+const url = new URL('./index.js', (globalThis.document.currentScript as HTMLScriptElement).src);
+
+void import(url.toString()).then(({ default: prism }) => ((globalThis as any).Prism = prism));

--- a/src/prism.global.ts
+++ b/src/prism.global.ts
@@ -1,4 +1,7 @@
-// In browser and imported via non-ESM
-const url = new URL('./index.js', (globalThis.document.currentScript as HTMLScriptElement).src);
+const currentScript = globalThis.document?.currentScript as HTMLScriptElement;
+if (currentScript) {
+	// In browser and imported via non-ESM
+	const url = new URL('./index.js', currentScript.src);
 
-void import(url.toString()).then(({ default: prism }) => ((globalThis as any).Prism = prism));
+	void import(url.toString()).then(({ default: prism }) => ((globalThis as any).Prism = prism));
+}


### PR DESCRIPTION
For now, when using the global bundle, we get the `Uncaught (in promise) TypeError: Failed to resolve module specifier './index.js'. The base URL is about:blank because import() is called from a CORS-cross-origin script.` error.