### PR TITLE
feat(mcfunction): adiciona suporte à linguagem mcfunction

### DIFF
--- a/components/prism-mcfunction.js
+++ b/components/prism-mcfunction.js
@@ -1,0 +1,8 @@
+Prism.languages.mcfunction = {
+  'comment': /^#.*/m,
+  'keyword': /\b(?:say|give|execute|run|as|at|if|unless|summon)\b/,
+  'selector': /@\w+/,
+  'item': /minecraft:\w+/,
+  'number': /\b\d+\b/,
+  'punctuation': /[~^]/,
+};


### PR DESCRIPTION
Este Pull Request adiciona suporte inicial à linguagem `mcfunction`, usada para pacotes de dados no Minecraft.

A definição cobre:
- Comentários (`#`)
- Comandos principais (`say`, `give`, `execute`, etc.)
- Seletores como `@p`, `@a`
- Itens do tipo `minecraft:...`
- Números e símbolos `~`, `^`

Tudo foi feito com base no exemplo da issue #3995 e testado localmente.