### PR TITLE
[redirects] Simplify resource URLs

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -1,0 +1,5 @@
+# Don't redirect direct URLs
+/dist/* /dist/:splat 200
+
+# Otherwise, if one requests something from this server, that means they need something from the dist folder
+/* /dist/:splat 200


### PR DESCRIPTION
Instead of `https://dev.prismjs.com/dist/prism.js` and `https://dev.prismjs.com/dist/languages/c.js`, etc., one can write `https://dev.prismjs.com/prism.js` and `https://dev.prismjs.com/languages/c.js` respectively.