### PR TITLE
HCL: include new ephemeral block

### DIFF
--- a/src/languages/hcl.js
+++ b/src/languages/hcl.js
@@ -10,10 +10,10 @@ export default {
 		},
 		'keyword': [
 			{
-				pattern: /(?:data|resource)\s+(?:"(?:\\[\s\S]|[^\\"])*")(?=\s+"[\w-]+"\s+\{)/i,
+				pattern: /(?:data|resource|ephemeral)\s+(?:"(?:\\[\s\S]|[^\\"])*")(?=\s+"[\w-]+"\s+\{)/i,
 				inside: {
 					'type': {
-						pattern: /(resource|data|\s+)(?:"(?:\\[\s\S]|[^\\"])*")/i,
+						pattern: /(resource|data|ephemeral|\s+)(?:"(?:\\[\s\S]|[^\\"])*")/i,
 						lookbehind: true,
 						alias: 'variable',
 					},

--- a/tests/languages/hcl/keyword_feature.test
+++ b/tests/languages/hcl/keyword_feature.test
@@ -1,5 +1,6 @@
 resource "aws_db_instance" "main" {
 data "terraform_remote_state" "main" {
+ephemeral "provider_type" "main" {
 output "dev_vpc_id" {
 config {
 terraform {
@@ -15,6 +16,11 @@ terraform {
 	["keyword",
 		["data ",
 		["type", "\"terraform_remote_state\""]]],
+    ["string", ["\"main\""]],
+    ["punctuation", "{"],
+	["keyword",
+		["ephemeral ",
+		["type", "\"provider_type\""]]],
     ["string", ["\"main\""]],
     ["punctuation", "{"],
 	["keyword",


### PR DESCRIPTION
OpenTofu and Terraform have added support for ephemeral blocks, similar to resources and datasources