### PR TITLE
[tests] Allow typecheck tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,9 @@
 		"test:plugins": "mocha tests/plugins/**/*.js",
 		"test:runner": "mocha tests/testrunner-tests.js",
 		"test": "npm-run-all test:*",
-		"typecheck": "tsc"
+		"typecheck:core": "tsc",
+		"typecheck:tests": "tsc -p tests/tsconfig.json",
+		"typecheck": "npm-run-all typecheck:*"
 	},
 	"repository": {
 		"type": "git",

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -42,7 +42,7 @@ export const noop = () => {
 
 /**
  * @param {any} value
- * @returns {boolean}
+ * @returns {value is T & {}}
  */
 export function isNonNull (value) {
 	return value != null;

--- a/tests/components-test.js
+++ b/tests/components-test.js
@@ -14,9 +14,9 @@ describe('Components', () => {
 
 		for (const id of getComponentIds()) {
 			const proto = await getComponent(id).catch(noop);
-			const require = new Set(toArray(proto?.require).map(p => p.id));
+			const require = new Set(toArray(/** @type any */ (proto)?.require).map(p => p.id));
 
-			forEach(proto?.optional, opt => {
+			forEach(/** @type any */ (proto?.optional), opt => {
 				if (require.has(opt)) {
 					assert.fail(
 						`The optional dependency ${opt} is redundant because ${id} already requires it. Remove the optional dependency.`
@@ -47,7 +47,8 @@ describe('Components', () => {
 		for (const id of getComponentIds()) {
 			const proto = await getComponent(id).catch(noop);
 			add(id, 'a component id');
-			forEach(proto?.alias, a => add(a, `an alias of ${id}`));
+			forEach(/** @type {string | string[] | null | undefined} */ (proto?.alias), a =>
+				add(a, `an alias of ${id}`));
 		}
 	});
 });
@@ -74,15 +75,22 @@ describe('components.json', () => {
 		}
 
 		for (const id in entries) {
-			consumeFn(entries[id], id, entries);
+			consumeFn(entries[id], id, /** @type {Record<string, ComponentEntry>} */ (entries));
 		}
 	}
 
 	describe('- should have valid alias titles', () => {
 		for (const lang of getLanguageIds()) {
 			it(`- ${lang} should have all alias titles registered as alias`, async () => {
-				const aliases = new Set(toArray((await getComponent(lang)).alias));
-				const aliasTitles = components.languages[lang]?.aliasTitles ?? {};
+				const aliases = new Set(
+					toArray(
+						/** @type {string | string[] | null | undefined} */ (
+							(await getComponent(lang)).alias
+						)
+					)
+				);
+				const aliasTitles =
+					/** @type {ComponentEntry} */ (components.languages[lang])?.aliasTitles ?? {};
 
 				Object.keys(aliasTitles).forEach(id => {
 					if (!aliases.has(id)) {
@@ -103,7 +111,7 @@ describe('components.json', () => {
 			.map(key => {
 				return {
 					id: key,
-					title: components.languages[key].title,
+					title: /** @type {ComponentEntry} */ (components.languages[key]).title,
 				};
 			});
 
@@ -119,12 +127,16 @@ describe('components.json', () => {
 		}
 
 		const sorted = [...languages].sort((a, b) => {
-			const comp = transformTitle(a.title).localeCompare(transformTitle(b.title));
+			const comp = transformTitle(/** @type {string} */ (a.title)).localeCompare(
+				transformTitle(/** @type {string} */ (b.title))
+			);
 			if (comp !== 0) {
 				return comp;
 			}
 			// a and b have the same intermediate form (e.g. "C" => "C", "C++" => "C", "C#" => "C").
-			return a.title.toLowerCase().localeCompare(b.title.toLowerCase());
+			return /** @type {string} */ (a.title)
+				.toLowerCase()
+				.localeCompare(/** @type {string} */ (b.title).toLowerCase());
 		});
 
 		assert.sameOrderedMembers(languages, sorted);

--- a/tests/helper/args.js
+++ b/tests/helper/args.js
@@ -1,10 +1,7 @@
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
 
-/**
- * @type {Args}
- */
-const args = yargs(hideBin(process.argv)).argv;
+const args = /** @type {Args} */ (yargs(hideBin(process.argv)).argv);
 
 export const language = args.language;
 export const update = !!args.update;

--- a/tests/helper/prism-dom-util.js
+++ b/tests/helper/prism-dom-util.js
@@ -81,7 +81,7 @@ export function createTestSuite (options) {
 						await dom.loadLanguages(options.languages);
 					}
 					if (options.plugins) {
-						await dom.loadPlugins(options.plugins);
+						await dom.loadPlugins(/** @type {string | string[]} */ (options.plugins));
 					}
 
 					dom.withGlobals(() => {
@@ -101,7 +101,7 @@ export function createTestSuite (options) {
  */
 
 /**
- * @template T
+ * @template {string} T
  * @typedef {import('../types.d.ts').TestSuiteDom<T>} TestSuiteDom
  */
 

--- a/tests/helper/prism-loader.js
+++ b/tests/helper/prism-loader.js
@@ -143,7 +143,7 @@ export function createPrismDOM () {
 		finally {
 			undo?.();
 			// Clean up navigator property
-			delete g.navigator;
+			delete (/** @type {Partial<typeof global>} */ (g).navigator);
 		}
 	};
 

--- a/tests/helper/token-stream-transformer.js
+++ b/tests/helper/token-stream-transformer.js
@@ -498,7 +498,7 @@ function prettyGlueTogetherAll (prettyStream, slice) {
 /**
  *
  * @param {PrettyTokenStreamItem} item
- * @returns {boolean}
+ * @returns {item is SimplifiedToken}
  */
 function isToken (item) {
 	return typeof item === 'string' || Array.isArray(item);
@@ -506,7 +506,7 @@ function isToken (item) {
 /**
  *
  * @param {PrettyTokenStreamItem} item
- * @returns {boolean}
+ * @returns {item is [string, SimplifiedToken[]]}
  */
 function isNested (item) {
 	return Array.isArray(item) && Array.isArray(item[1]);
@@ -515,7 +515,7 @@ function isNested (item) {
 /**
  *
  * @param {PrettyTokenStreamItem} item
- * @returns {boolean}
+ * @returns {item is [string, [string]]}
  */
 function isTriviallyNested (item) {
 	return isNested(item) && item[1].length === 1 && typeof item[1][0] === 'string';

--- a/tests/identifier-test.js
+++ b/tests/identifier-test.js
@@ -78,7 +78,9 @@ for (const lang of getLanguageIds()) {
 	describe(`Patterns of '${lang}' with optional dependencies`, () => {
 		const getPrism = async () => {
 			const component = await getComponent(lang);
-			const optional = toArray(component.optional);
+			const optional = toArray(
+				/** @type {string | string[] | null | undefined} */ (component.optional)
+			);
 			const Prism = await createInstance([lang, ...optional]);
 			return Prism;
 		};

--- a/tests/pattern-tests.js
+++ b/tests/pattern-tests.js
@@ -54,7 +54,9 @@ for (const lang of getLanguageIds()) {
 	describe(`Patterns of '${lang}' with optional dependencies`, () => {
 		const create = lazy(async () => {
 			const component = await getComponent(lang);
-			const optional = toArray(component.optional);
+			const optional = toArray(
+				/** @type {string | string[] | null | undefined} */ (component.optional)
+			);
 			if (optional.length === 0) {
 				return undefined;
 			}
@@ -517,7 +519,7 @@ function getResultCache (cacheName) {
 }
 
 /**
- * @template T
+ * @template {Node} T
  * @param {string} cacheName
  * @param {T} cacheKey
  * @param {(node: T) => void} compute
@@ -752,7 +754,10 @@ function checkPolynomialBacktracking (path, pattern, ast) {
 		ast = parseRegex(pattern);
 	}
 
-	const result = scslre.analyse(ast, { maxReports: 1, reportTypes: { 'Move': false } });
+	const result = scslre.analyse(/** @type {scslre.ParsedLiteral} */ (ast), {
+		maxReports: 1,
+		reportTypes: { 'Move': false },
+	});
 	if (result.reports.length > 0) {
 		const report = result.reports[0];
 
@@ -926,4 +931,17 @@ async function replaceRegExpProto (execSupplier, fn) {
  * @typedef {object} ForEachCapturingGroupCallbackValue
  * @property {CapturingGroup} group
  * @property {number} number - Note: Starts at 1.
+ */
+
+/**
+ * @typedef {object} ForEachPatternCallbackValue
+ * @property {RegExp} pattern
+ * @property {LiteralAST} ast
+ * @property {string} tokenPath
+ * @property {string} name
+ * @property {any} parent
+ * @property {boolean} lookbehind
+ * @property {CapturingGroup | undefined} lookbehindGroup
+ * @property {PathItem[]} path
+ * @property {(message: string) => void} reportError
  */

--- a/tests/plugins/copy-to-clipboard/basic-functionality.js
+++ b/tests/plugins/copy-to-clipboard/basic-functionality.js
@@ -20,7 +20,7 @@ class DummyClipboard {
 	 * @param {Navigator} navigator
 	 */
 	assign (navigator) {
-		navigator.clipboard = this;
+		/** @type {any} */ (navigator).clipboard = this;
 	}
 }
 

--- a/tests/plugins/show-language/basic-functionality.js
+++ b/tests/plugins/show-language/basic-functionality.js
@@ -15,7 +15,7 @@ describe('Show language', () => {
 
 	/**
 	 *
-	 * @param {import('../../helper/prism-loader').PrismDOM} dom
+	 * @param {import('../../types.d.ts').PrismDOM<{}>} dom
 	 * @param {string} expectedLanguage
 	 * @param {string} code
 	 */

--- a/tests/tsconfig.json
+++ b/tests/tsconfig.json
@@ -1,0 +1,82 @@
+{
+	"extends": "../tsconfig.json",
+	"compilerOptions": {
+		/* Visit https://aka.ms/tsconfig to read more about this file */
+
+		/* Projects */
+		// "incremental": true,                              /* Save .tsbuildinfo files to allow for incremental compilation of projects. */
+		// "composite": true,                                /* Enable constraints that allow a TypeScript project to be used with project references. */
+		// "tsBuildInfoFile": "./.tsbuildinfo",              /* Specify the path to .tsbuildinfo incremental compilation file. */
+		// "disableSourceOfProjectReferenceRedirect": true,  /* Disable preferring source files instead of declaration files when referencing composite projects. */
+		// "disableSolutionSearching": true,                 /* Opt a project out of multi-project reference checking when editing. */
+		// "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
+
+		/* Language and Environment */
+		"target": "ES2020" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
+		// "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
+		// "jsx": "preserve",                                /* Specify what JSX code is generated. */
+		// "experimentalDecorators": true,                   /* Enable experimental support for TC39 stage 2 draft decorators. */
+		// "emitDecoratorMetadata": true,                    /* Emit design-type metadata for decorated declarations in source files. */
+		// "jsxFactory": "",                                 /* Specify the JSX factory function used when targeting React JSX emit, e.g. 'React.createElement' or 'h'. */
+		// "jsxFragmentFactory": "",                         /* Specify the JSX Fragment reference used for fragments when targeting React JSX emit e.g. 'React.Fragment' or 'Fragment'. */
+		// "jsxImportSource": "",                            /* Specify module specifier used to import the JSX factory functions when using 'jsx: react-jsx*'. */
+		// "reactNamespace": "",                             /* Specify the object invoked for 'createElement'. This only applies when targeting 'react' JSX emit. */
+		// "noLib": true,                                    /* Disable including any library files, including the default lib.d.ts. */
+		// "useDefineForClassFields": true,                  /* Emit ECMAScript-standard-compliant class fields. */
+		// "moduleDetection": "auto",                        /* Control what method is used to detect module-format JS files. */
+
+		/* Modules */
+		"module": "ES2022" /* Specify what module code is generated. */,
+		// "rootDir": "./",                                  /* Specify the root folder within your source files. */
+		// "moduleResolution": "node",                       /* Specify how TypeScript looks up a file from a given module specifier. */
+		// "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
+		// "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
+		// "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
+		// "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */
+		// "types": [],                                      /* Specify type package names to be included without being referenced in a source file. */
+		// "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
+		// "moduleSuffixes": [],                             /* List of file name suffixes to search when resolving a module. */
+		// "resolveJsonModule": true,                        /* Enable importing .json files. */
+		// "noResolve": true,                                /* Disallow 'import's, 'require's or '<reference>'s from expanding the number of files TypeScript should add to a project. */
+
+		/* JavaScript Support */
+		"allowJs": true /* Allow JavaScript files to be a part of your program. Use the 'checkJS' option to get errors from these files. */,
+		"checkJs": true /* Enable error reporting in type-checked JavaScript files. */,
+		// "maxNodeModuleJsDepth": 1,                        /* Specify the maximum folder depth used for checking JavaScript files from 'node_modules'. Only applicable with 'allowJs'. */
+
+		/* Emit */
+		// "declaration": true,                              /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
+		// "declarationMap": true,                           /* Create sourcemaps for d.ts files. */
+		// "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
+		// "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
+		// "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
+		// "outDir": "./",                                   /* Specify an output folder for all emitted files. */
+		// "removeComments": true,                           /* Disable emitting comments. */
+		"noEmit": true /* Disable emitting files from a compilation. */,
+		// "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */
+		// "importsNotUsedAsValues": "remove",               /* Specify emit/checking behavior for imports that are only used for types. */
+		// "downlevelIteration": true,                       /* Emit more compliant, but verbose and less performant JavaScript for iteration. */
+		// "sourceRoot": "",                                 /* Specify the root path for debuggers to find the reference source code. */
+		// "mapRoot": "",                                    /* Specify the location where debugger should locate map files instead of generated locations. */
+		// "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
+		// "inlineSources": true,                            /* Include source code in the sourcemaps inside the emitted JavaScript. */
+		// "emitBOM": true,                                  /* Emit a UTF-8 Byte Order Mark (BOM) in the beginning of output files. */
+		// "newLine": "crlf",                                /* Set the newline character for emitting files. */
+		// "stripInternal": true,                            /* Disable emitting declarations that have '@internal' in their JSDoc comments. */
+		// "noEmitHelpers": true,                            /* Disable generating custom helper functions like '__extends' in compiled output. */
+		// "noEmitOnError": true,                            /* Disable emitting files if any type checking errors are reported. */
+		// "preserveConstEnums": true,                       /* Disable erasing 'const enum' declarations in generated code. */
+		// "declarationDir": "./",                           /* Specify the output directory for generated declaration files. */
+		// "preserveValueImports": true,                     /* Preserve unused imported values in the JavaScript output that would otherwise be removed. */
+
+		/* Interop Constraints */
+		// "isolatedModules": true,                          /* Ensure that each file can be safely transpiled without relying on other imports. */
+		// "allowSyntheticDefaultImports": true,             /* Allow 'import x from y' when a module doesn't have a default export. */
+		"esModuleInterop": true /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */,
+
+		/* Type Checking */
+		"strict": true /* Enable all strict type-checking options. */,
+		"noImplicitAny": false /* Enable error reporting for expressions and declarations with an implied 'any' type. */
+	},
+	"include": ["./**/*"]
+}

--- a/tests/types.d.ts
+++ b/tests/types.d.ts
@@ -1,6 +1,8 @@
-import { KebabToCamelCase } from '../src/types.d.ts';
 import { createUtil } from './helper/prism-dom-util.js';
 import { useSnapshot } from './helper/snapshot.js';
+import type { KebabToCamelCase } from '../src/types.d.ts';
+import type { PrismDOM, PrismWindow } from './prism-loader.js';
+import type { DOMWindow, JSDOM } from 'jsdom';
 
 export type PrismWindow<T> = DOMWindow & { Prism: Prism & T };
 


### PR DESCRIPTION
### Summary

- Restore `tsconfig.json` for tests
- Adjust types and fix TS errors
- Add corresponding NPM scripts

Still, the only check that fails now is the Lint check.

No type errors:
<img width="428" height="221" alt="image" src="https://github.com/user-attachments/assets/3ef4808b-c69e-4dc9-a657-d825f4b31923" />
