### PR TITLE
fix(toolbar): increase z-index to prevent overlay slider issue

### DIFF
--- a/src/plugins/toolbar/toolbar.css
+++ b/src/plugins/toolbar/toolbar.css
@@ -1,57 +1,57 @@
 div.code-toolbar {
-	position: relative;
+    position: relative;
 }
 
 div.code-toolbar > .toolbar {
-	position: absolute;
-	z-index: 10;
-	top: 0.3em;
-	right: 0.2em;
-	transition: opacity 0.3s ease-in-out;
-	opacity: 0;
+    position: absolute;
+    z-index: 9999; /* increased z-index to prevent overlay slider issue */
+    top: 0.3em;
+    right: 0.2em;
+    transition: opacity 0.3s ease-in-out;
+    opacity: 0;
 }
 
 div.code-toolbar:hover > .toolbar {
-	opacity: 1;
+    opacity: 1;
 }
 
 /* Separate line b/c rules are thrown out if selector is invalid.
    IE11 and old Edge versions don't support :focus-within. */
 div.code-toolbar:focus-within > .toolbar {
-	opacity: 1;
+    opacity: 1;
 }
 
 div.code-toolbar > .toolbar > .toolbar-item {
-	display: inline-block;
+    display: inline-block;
 }
 
 div.code-toolbar > .toolbar > .toolbar-item > a {
-	cursor: pointer;
+    cursor: pointer;
 }
 
 div.code-toolbar > .toolbar > .toolbar-item > button {
-	background: none;
-	border: 0;
-	color: inherit;
-	font: inherit;
-	line-height: normal;
-	overflow: visible;
-	padding: 0;
-	-webkit-user-select: none; /* for button */
-	-moz-user-select: none;
-	-ms-user-select: none;
+    background: none;
+    border: 0;
+    color: inherit;
+    font: inherit;
+    line-height: normal;
+    overflow: visible;
+    padding: 0;
+    -webkit-user-select: none; /* for button */
+    -moz-user-select: none;
+    -ms-user-select: none;
 }
 
 div.code-toolbar > .toolbar > .toolbar-item > a,
 div.code-toolbar > .toolbar > .toolbar-item > button,
 div.code-toolbar > .toolbar > .toolbar-item > span {
-	color: #bbb;
-	font-size: 0.8em;
-	padding: 0 0.5em;
-	background: #f5f2f0;
-	background: rgba(224, 224, 224, 0.2);
-	box-shadow: 0 2px 0 0 rgba(0, 0, 0, 0.2);
-	border-radius: 0.5em;
+    color: #bbb;
+    font-size: 0.8em;
+    padding: 0 0.5em;
+    background: #f5f2f0;
+    background: rgba(224, 224, 224, 0.2);
+    box-shadow: 0 2px 0 0 rgba(0, 0, 0, 0.2);
+    border-radius: 0.5em;
 }
 
 div.code-toolbar > .toolbar > .toolbar-item > a:hover,
@@ -60,6 +60,7 @@ div.code-toolbar > .toolbar > .toolbar-item > button:hover,
 div.code-toolbar > .toolbar > .toolbar-item > button:focus,
 div.code-toolbar > .toolbar > .toolbar-item > span:hover,
 div.code-toolbar > .toolbar > .toolbar-item > span:focus {
-	color: inherit;
-	text-decoration: none;
+    color: inherit;
+    text-decoration: none;
 }
+


### PR DESCRIPTION
### Description
This PR fixes the toolbar overlay slider issue where the toolbar was hidden behind other elements due to a low z-index.

### Changes
- Increased the `z-index` of the toolbar from 10 to 9999 in `src/plugins/toolbar/toolbar.css`.

### Related Issue
Fixes #1380
