### PR TITLE
Correctly highlight the behind glyph

### DIFF
--- a/src/languages/apl.js
+++ b/src/languages/apl.js
@@ -21,7 +21,7 @@ export default {
 			alias: 'operator',
 		},
 		'dyadic-operator': {
-			pattern: /[.⍣⍠⍤∘⌸@⌺⍥]/,
+			pattern: /[.⍣⍠⍤⍛∘⌸@⌺⍥]/,
 			alias: 'operator',
 		},
 		'assignment': {

--- a/tests/languages/apl/dyadic-operator_feature.test
+++ b/tests/languages/apl/dyadic-operator_feature.test
@@ -1,13 +1,15 @@
 . ⍣ ⍠
 ⍤ ∘ ⌸
 @ ⌺ ⍥
+⍛
 
 ----------------------------------------------------
 
 [
 	["dyadic-operator", "."], ["dyadic-operator", "⍣"], ["dyadic-operator", "⍠"],
 	["dyadic-operator", "⍤"], ["dyadic-operator", "∘"], ["dyadic-operator", "⌸"],
-	["dyadic-operator", "@"], ["dyadic-operator", "⌺"], ["dyadic-operator", "⍥"]
+	["dyadic-operator", "@"], ["dyadic-operator", "⌺"], ["dyadic-operator", "⍥"],
+	["dyadic-operator", "⍛"]  
 ]
 
 ----------------------------------------------------


### PR DESCRIPTION
As #4043 states, correctly highlight the behind glyph.