### PR TITLE
Fix: TOML table to avoid splitting brackets from key

### DIFF
--- a/src/languages/toml.js
+++ b/src/languages/toml.js
@@ -4,6 +4,7 @@ export default {
 	grammar () {
 		const key = /(?:[\w-]+|'[^'\n\r]*'|"(?:\\.|[^\\"\r\n])*")/.source;
 		const dottedKey = key + '(?:\\s*\\.\\s*' + key + ')*';
+		const trailingComment = '(?=\\s*(?:#.*)?$)';
 
 		return {
 			'comment': {
@@ -12,15 +13,18 @@ export default {
 			},
 			'table': {
 				// keep entire table header (including brackets) under one parent token
-				pattern: RegExp('(^[\\t ]*)\\[\\[?\\s*' + dottedKey + '\\s*\\]\\]?', 'm'),
+				pattern: RegExp(
+					'(^[\\t ]*)(?:\\[(?!\\[)\\s*' + dottedKey + '\\s*\\]' + trailingComment +
+						'|\\[\\[\\s*' + dottedKey + '\\s*\\]\\]' + trailingComment + ')',
+					'm'
+				),
 				lookbehind: true,
 				greedy: true,
-				alias: 'class-name',
 				inside: {
 					'table-name': {
 						pattern: RegExp('(^\\[\\[?\\s*)' + dottedKey),
 						lookbehind: true,
-						alias: 'class-name',
+						alias: 'variable',
 					},
 					'punctuation': /\[|\]/,
 				},

--- a/src/languages/toml.js
+++ b/src/languages/toml.js
@@ -3,15 +3,7 @@ export default {
 	id: 'toml',
 	grammar () {
 		const key = /(?:[\w-]+|'[^'\n\r]*'|"(?:\\.|[^\\"\r\n])*")/.source;
-
-		/**
-		 *
-		 * @param {string} pattern
-		 * @returns {string}
-		 */
-		function insertKey (pattern) {
-			return pattern.replace(/__/g, () => key);
-		}
+		const dottedKey = key + '(?:\\s*\\.\\s*' + key + ')*';
 
 		return {
 			'comment': {
@@ -19,19 +11,22 @@ export default {
 				greedy: true,
 			},
 			'table': {
-				pattern: RegExp(
-					insertKey(/(^[\t ]*\[\s*(?:\[\s*)?)__(?:\s*\.\s*__)*(?=\s*\])/.source),
-					'm'
-				),
+				// keep entire table header (including brackets) under one parent token
+				pattern: RegExp('(^[\\t ]*)\\[\\[?\\s*' + dottedKey + '\\s*\\]\\]?', 'm'),
 				lookbehind: true,
 				greedy: true,
 				alias: 'class-name',
+				inside: {
+					'table-name': {
+						pattern: RegExp('(^\\[\\[?\\s*)' + dottedKey),
+						lookbehind: true,
+						alias: 'class-name',
+					},
+					'punctuation': /\[|\]/,
+				},
 			},
 			'key': {
-				pattern: RegExp(
-					insertKey(/(^[\t ]*|[{,]\s*)__(?:\s*\.\s*__)*(?=\s*=)/.source),
-					'm'
-				),
+				pattern: RegExp('(^[\\t ]*|[{,]\\s*)' + dottedKey + '(?=\\s*=)', 'm'),
 				lookbehind: true,
 				greedy: true,
 				alias: 'property',

--- a/src/languages/toml.js
+++ b/src/languages/toml.js
@@ -14,8 +14,11 @@ export default {
 			'table': {
 				// keep entire table header (including brackets) under one parent token
 				pattern: RegExp(
-					'(^[\\t ]*)(?:\\[(?!\\[)\\s*' + dottedKey + '\\s*\\]' + trailingComment +
-						'|\\[\\[\\s*' + dottedKey + '\\s*\\]\\]' + trailingComment + ')',
+					'(^[\\t ]*)(?:\\[\\[\\s*' +
+						dottedKey +
+						'\\s*\\]\\]|\\[\\s*' +
+						dottedKey +
+						'\\s*\\])(?!\\])',
 					'm'
 				),
 				lookbehind: true,

--- a/src/languages/toml.js
+++ b/src/languages/toml.js
@@ -4,7 +4,6 @@ export default {
 	grammar () {
 		const key = /(?:[\w-]+|'[^'\n\r]*'|"(?:\\.|[^\\"\r\n])*")/.source;
 		const dottedKey = key + '(?:\\s*\\.\\s*' + key + ')*';
-		const trailingComment = '(?=\\s*(?:#.*)?$)';
 
 		return {
 			'comment': {

--- a/tests/languages/toml/table_feature.test
+++ b/tests/languages/toml/table_feature.test
@@ -7,15 +7,18 @@ foo = [ "bar" ]
 ----------------------------------------------------
 
 [
-	["punctuation", "["],
-	["table", "table"],
-	["punctuation", "]"],
-
-	["punctuation", "["],
-	["punctuation", "["],
-	["table", "array"],
-	["punctuation", "]"],
-	["punctuation", "]"],
+	["table", [
+		["punctuation", "["],
+		["table-name", "table"],
+		["punctuation", "]"]
+	]],
+	["table", [
+		["punctuation", "["],
+		["punctuation", "["],
+		["table-name", "array"],
+		["punctuation", "]"],
+		["punctuation", "]"]
+	]],
 
 	["comment", "# not a table"],
 

--- a/tests/languages/toml/table_feature.test
+++ b/tests/languages/toml/table_feature.test
@@ -1,5 +1,12 @@
 [table]
 [[array]]
+[a.b]
+[[a.b]]
+[name] # trailing comment
+[name]]
+[[name]
+[name
+name]
 
 # not a table
 foo = [ "bar" ]
@@ -19,6 +26,35 @@ foo = [ "bar" ]
 		["punctuation", "]"],
 		["punctuation", "]"]
 	]],
+	["table", [
+		["punctuation", "["],
+		["table-name", "a.b"],
+		["punctuation", "]"]
+	]],
+	["table", [
+		["punctuation", "["],
+		["punctuation", "["],
+		["table-name", "a.b"],
+		["punctuation", "]"],
+		["punctuation", "]"]
+	]],
+	["table", [
+		["punctuation", "["],
+		["table-name", "name"],
+		["punctuation", "]"]
+	]],
+	["comment", "# trailing comment"],
+	["punctuation", "["],
+	"name",
+	["punctuation", "]"],
+	["punctuation", "]"],
+	["punctuation", "["],
+	["punctuation", "["],
+	"name",
+	["punctuation", "]"],
+	["punctuation", "["],
+	"name\r\nname",
+	["punctuation", "]"],
 
 	["comment", "# not a table"],
 


### PR DESCRIPTION
I had discovered an issue where TOML table header parsing had undesired behaviour where table declarations like [table] and [[array]] were being split across multiple tokens, creating split spans when parsed. The bug was actually, for me, found in refractor but it uses prismjs language files upstream which cause the issue.

I would propose is to be consistent and copy the approach used in parsing .ini files, where the whole thing becomes a nested structure

using this:

```js
inside: {
	table-name': {
			pattern: RegExp('(^\\[\\[?\\s*)' + dottedKey),
			lookbehind: true,
			alias: 'class-name',
		},
		'punctuation': /\[|\]/,
	},
```

to produce this output:

```text
	["table", [
		["punctuation", "["],
		["table-name", "table"],
		["punctuation", "]"]
	]],
	["table", [
		["punctuation", "["],
		["punctuation", "["],
		["table-name", "array"],
		["punctuation", "]"],
		["punctuation", "]"]
	]],
```

This PR swaps to that approach and I personally think this is a superior approach.