### PR TITLE
Fix regex pattern for string matching in R grammar

### DIFF
--- a/src/languages/r.js
+++ b/src/languages/r.js
@@ -4,7 +4,7 @@ export default {
 	grammar: {
 		'comment': /#.*/,
 		'string': {
-			pattern: /(['"])(?:\\.|(?!\1)[^\\\r\n])*\1/,
+            pattern: /(['"])(?:\\.|(?!\1)[^\\])*\1/,
 			greedy: true,
 		},
 		'percent-operator': {


### PR DESCRIPTION
## Summary
Fixes incorrect syntax highlighting of multiline strings in the R language
grammar by allowing newline characters inside quoted strings.

## Details
- Updated R string regex to support multiline strings
- Aligns behavior with Prism fixes in other languages

Fixes #4040
