### PR TITLE
feat: add `delphi` alias to `pascal` language

### DIFF
--- a/src/components.json
+++ b/src/components.json
@@ -871,7 +871,8 @@
 		"pascal": {
 			"title": "Pascal",
 			"aliasTitles": {
-				"objectpascal": "Object Pascal"
+				"objectpascal": "Object Pascal",
+				"delphi": "Delphi"
 			},
 			"owner": "Golmote"
 		},

--- a/src/languages/pascal.js
+++ b/src/languages/pascal.js
@@ -1,7 +1,7 @@
 /** @type {import('../types.d.ts').LanguageProto<'pascal'>} */
 export default {
 	id: 'pascal',
-	alias: 'objectpascal',
+	alias: ['objectpascal', 'delphi'],
 	grammar () {
 		// Based on Free Pascal
 


### PR DESCRIPTION
Delphi has been an official and widely-used programming language since 1995.