### PR TITLE
Add Gleam language support

### DIFF
--- a/src/components.json
+++ b/src/components.json
@@ -502,6 +502,10 @@
 			"title": "GNU Linker Script",
 			"owner": "RunDevelopment"
 		},
+		"gleam": {
+    		"title": "Gleam",
+		"owner": "nikhilkalburgi45"
+		},
 		"go": {
 			"title": "Go",
 			"owner": "arnehormann"

--- a/src/languages/gleam.js
+++ b/src/languages/gleam.js
@@ -1,0 +1,36 @@
+Prism.languages.gleam = {
+	// doc comments first so /// isn't matched as //
+	'comment': [
+		/\/\/{3,4}.*/,
+		/\/\/.*/
+	],
+
+	'string': {
+		pattern: /"(?:\\.|[^"\\])*"/,
+		greedy: true
+	},
+
+	'attribute': {
+		pattern: /@\w+/,
+		alias: 'annotation'
+	},
+
+	'keyword': /\b(?:as|assert|case|const|echo|else|fn|if|import|let|opaque|panic|pub|todo|type|use)\b/,
+
+	'boolean': /\b(?:True|False)\b/,
+
+	// keep before class-name so builtins are highlighted correctly
+	'builtin': /\b(?:Int|Float|String|Bool|List|Result|Option|Nil)\b/,
+
+	// heuristic: matches types and constructors (no AST available)
+	'class-name': /\b[A-Z]\w*\b/,
+
+	'number': /\b(?:0b[01][01_]*|0o[0-7][0-7_]*|0x[\da-fA-F][\da-fA-F_]*|\d[\d_]*(?:\.[\d_]+)?(?:[eE][+-]?\d[\d_]*)?)\b/,
+
+	// best-effort: identifier followed by (
+	'function': /\b[a-z_]\w*(?=\s*\()/,
+
+	'operator': /\|>|<>|->|<-|\.\.|\+\.|-\.|\*\.|\/\.|==|!=|<=|>=|&&|\|\||[+\-*\/%<>=!]/,
+
+	'punctuation': /[{}[\](),.:;#]/
+};

--- a/tests/languages/gleam/attributes.test
+++ b/tests/languages/gleam/attributes.test
@@ -1,0 +1,9 @@
+======
+Attributes
+======
+@external(erlang, "calendar", "local_time")
+pub fn now() { Nil }
+======
+<span class="token attribute">@external</span><span class="token punctuation">(</span>erlang<span class="token punctuation">,</span> <span class="token string">"calendar"</span><span class="token punctuation">,</span> <span class="token string">"local_time"</span><span class="token punctuation">)</span>
+<span class="token keyword">pub</span> <span class="token keyword">fn</span> <span class="token function">now</span><span class="token punctuation">(</span><span class="token punctuation">)</span> <span class="token punctuation">{</span> <span class="token builtin">Nil</span> <span class="token punctuation">}</span>
+======

--- a/tests/languages/gleam/basic.test
+++ b/tests/languages/gleam/basic.test
@@ -1,0 +1,11 @@
+======
+Basic function
+======
+pub fn main() {
+  echo "hello"
+}
+======
+<span class="token keyword">pub</span> <span class="token keyword">fn</span> <span class="token function">main</span><span class="token punctuation">(</span><span class="token punctuation">)</span> <span class="token punctuation">{</span>
+  <span class="token keyword">echo</span> <span class="token string">"hello"</span>
+<span class="token punctuation">}</span>
+======

--- a/tests/languages/gleam/numbers.test
+++ b/tests/languages/gleam/numbers.test
@@ -1,0 +1,11 @@
+======
+Numbers
+======
+let x = 42
+let y = 3.14
+let z = 0xFF
+======
+<span class="token keyword">let</span> x <span class="token operator">=</span> <span class="token number">42</span>
+<span class="token keyword">let</span> y <span class="token operator">=</span> <span class="token number">3.14</span>
+<span class="token keyword">let</span> z <span class="token operator">=</span> <span class="token number">0xFF</span>
+======

--- a/tests/languages/gleam/operators.test
+++ b/tests/languages/gleam/operators.test
@@ -1,0 +1,7 @@
+======
+Operators
+======
+[1, 2] |> list.map(fn(x) { x + 1 })
+======
+<span class="token punctuation">[</span><span class="token number">1</span><span class="token punctuation">,</span> <span class="token number">2</span><span class="token punctuation">]</span> <span class="token operator">|&gt;</span> <span class="token function">list</span><span class="token punctuation">.</span><span class="token function">map</span><span class="token punctuation">(</span><span class="token keyword">fn</span><span class="token punctuation">(</span>x<span class="token punctuation">)</span> <span class="token punctuation">{</span> x <span class="token operator">+</span> <span class="token number">1</span> <span class="token punctuation">}</span><span class="token punctuation">)</span>
+======

--- a/tests/languages/gleam/types.test
+++ b/tests/languages/gleam/types.test
@@ -1,0 +1,9 @@
+======
+Types and constructors
+======
+type Result(a, b) { Ok(a) Error(b) }
+Ok(42)
+======
+<span class="token keyword">type</span> <span class="token class-name">Result</span><span class="token punctuation">(</span>a<span class="token punctuation">,</span> b<span class="token punctuation">)</span> <span class="token punctuation">{</span> <span class="token class-name">Ok</span><span class="token punctuation">(</span>a<span class="token punctuation">)</span> <span class="token class-name">Error</span><span class="token punctuation">(</span>b<span class="token punctuation">)</span> <span class="token punctuation">}</span>
+<span class="token class-name">Ok</span><span class="token punctuation">(</span><span class="token number">42</span><span class="token punctuation">)</span>
+======


### PR DESCRIPTION
This PR adds basic syntax highlighting for Gleam.

Gleam isn’t currently supported in Prism, and the Rust grammar people often fall back on doesn’t map well especially around pipes, pattern matching, and type usage. This adds a dedicated language definition.

## What’s covered

- Comments: line (`//`), doc (`///`), and module doc (`////`)
- Strings with standard escape sequences
- Attributes (`@external`, `@internal`, etc.)
- Keywords: `fn`, `let`, `use`, `case`, `type`, `import`, `pub`, `opaque`, `const`, `as`, `panic`, `todo`, `if`, `else`
- Numbers: decimal (with `_`), hex (`0x`), binary (`0b`), scientific notation
- Built-in types: `Int`, `Float`, `String`, `Bool`, `List`, `Result`, `Option`, `Nil`
- Boolean literals: `True`, `False`
- Operators: `|>`, `<>`, `->`, `..`, plus standard arithmetic and comparison operators
- Function calls (best-effort detection)

Test cases are included under `tests/languages/gleam/`, covering typical usage (functions, pipelines, numbers, etc.).

## Limitations

- Type names fall back to an uppercase heuristic when not explicitly listed.
- Function detection is best-effort and may match some non-function identifiers.
- `case` pattern matching isn’t deeply tokenized to avoid overly complex regex.

## Files

- `src/languages/gleam.js`
- `src/components.json`
- `tests/languages/gleam/`

## Note

I ran into an ESM path issue on Windows (`ERR_UNSUPPORTED_ESM_URL_SCHEME`) when running the full test suite. This appears to be environment-related rather than specific to the Gleam implementation. Happy to run tests via WSL if needed.