### PR TITLE
Adjust Okaidia Prism theme color for WCAG contrast compliance

### DIFF
--- a/src/themes/okaidia.css
+++ b/src/themes/okaidia.css
@@ -71,7 +71,7 @@ pre[class*="language-"] {
 .token.constant,
 .token.symbol,
 .token.deleted {
-	color: #f92672;
+	color: #ff4f8f;
 }
 
 .token.boolean,


### PR DESCRIPTION
## Summary

The Okaida theme consists of a font color that fails WCAG AA and AAA for normal text. This PR adjusts the font color to meet WCAG AA.

> [!NOTE]
> I would recommend striving for AAA, but that would cause the theme to change more drastically. I can update this PR if that is not a problem.

### Before

Fails WCAG AA and AAA:

* Background: `#272822`
* Foreground: `#F92672`

<img width="720" height="114" alt="Screenshot 2026-04-01 at 7 22 27 PM" src="https://github.com/user-attachments/assets/3be8ec93-60e7-4fb3-92eb-15fe3eed97c7" />

https://webaim.org/resources/contrastchecker/?fcolor=F92672&bcolor=272822

### After

Passes WCAG AA:

* Background: `#272822`
* Foreground: `#FF4F8F`

<img width="720" height="114" alt="Screenshot 2026-04-01 at 7 22 40 PM" src="https://github.com/user-attachments/assets/9199768f-bcbf-44d7-91c7-32c996b66572" />

https://webaim.org/resources/contrastchecker/?fcolor=FF4F8F&bcolor=272822