### PR TITLE
Highlight `using` / `await using` declarations in JavaScript & TypeScript

### DIFF
--- a/src/languages/javascript.js
+++ b/src/languages/javascript.js
@@ -31,6 +31,11 @@ export default {
 			'keyword': [
 				{
 					pattern:
+						/(^|[^.]|\.\.\.\s*)\busing(?=\s+(?!\s)[_$a-zA-Z\xA0-\uFFFF](?:(?!\s)[$\w\xA0-\uFFFF])*\s*(?:=(?!=)|\bof\b))/,
+					lookbehind: true,
+				},
+				{
+					pattern:
 						/(^|[^.]|\.\.\.\s*)\b(?:as|assert(?=\s*\{)|export|from(?=\s*(?:['"]|$))|import)\b/,
 					lookbehind: true,
 					alias: 'module',

--- a/tests/languages/javascript/keyword_feature.test
+++ b/tests/languages/javascript/keyword_feature.test
@@ -53,6 +53,11 @@ async (a,b,c) => {}
 import {} from "foo"
 import {} from 'foo'
 class { get foo(){} set baz(){} get [value](){} }
+using file = openFile();
+await using conn = getConn();
+using x = a, y = b;
+for (using x of arr) {}
+for (await using y of arr) {}
 
 // import assertion
 import json from "./foo.json" assert { type: "json" };
@@ -60,6 +65,11 @@ import json from "./foo.json" assert { type: "json" };
 // variables, not keywords
 
 const { async, from, to } = bar;
+const using = 1;
+obj.using;
+using();
+using {x} = obj;
+import using from "foo";
 promise.catch(foo).finally(bar);
 assert.equal(foo, bar);
 
@@ -199,6 +209,54 @@ assert.equal(foo, bar);
 	["punctuation", "}"],
 	["punctuation", "}"],
 
+	["keyword", "using"],
+	" file ",
+	["operator", "="],
+	["function", "openFile"],
+	["punctuation", "("],
+	["punctuation", ")"],
+	["punctuation", ";"],
+
+	["keyword", "await"],
+	["keyword", "using"],
+	" conn ",
+	["operator", "="],
+	["function", "getConn"],
+	["punctuation", "("],
+	["punctuation", ")"],
+	["punctuation", ";"],
+
+	["keyword", "using"],
+	" x ",
+	["operator", "="],
+	" a",
+	["punctuation", ","],
+	" y ",
+	["operator", "="],
+	" b",
+	["punctuation", ";"],
+
+	["keyword", "for"],
+	["punctuation", "("],
+	["keyword", "using"],
+	" x ",
+	["keyword", "of"],
+	" arr",
+	["punctuation", ")"],
+	["punctuation", "{"],
+	["punctuation", "}"],
+
+	["keyword", "for"],
+	["punctuation", "("],
+	["keyword", "await"],
+	["keyword", "using"],
+	" y ",
+	["keyword", "of"],
+	" arr",
+	["punctuation", ")"],
+	["punctuation", "{"],
+	["punctuation", "}"],
+
 	["comment", "// import assertion"],
 
 	["keyword", "import"],
@@ -225,6 +283,36 @@ assert.equal(foo, bar);
 	["punctuation", "}"],
 	["operator", "="],
 	" bar",
+	["punctuation", ";"],
+
+	["keyword", "const"],
+	" using ",
+	["operator", "="],
+	["number", "1"],
+	["punctuation", ";"],
+
+	"\r\nobj",
+	["punctuation", "."],
+	"using",
+	["punctuation", ";"],
+
+	["function", "using"],
+	["punctuation", "("],
+	["punctuation", ")"],
+	["punctuation", ";"],
+
+	"\r\nusing ",
+	["punctuation", "{"],
+	"x",
+	["punctuation", "}"],
+	["operator", "="],
+	" obj",
+	["punctuation", ";"],
+
+	["keyword", "import"],
+	" using ",
+	["keyword", "from"],
+	["string", "\"foo\""],
 	["punctuation", ";"],
 
 	"\r\npromise",

--- a/tests/languages/typescript/keyword_feature.test
+++ b/tests/languages/typescript/keyword_feature.test
@@ -55,10 +55,20 @@ async (a,b,c) => {}
 import {} from "foo"
 import {} from 'foo'
 class { get foo(){} set baz(){} get [value](){} }
+using file = openFile();
+await using conn = getConn();
+using x = a, y = b;
+for (using x of arr) {}
+for (await using y of arr) {}
 
 // variables, not keywords
 
 const { async, from, to } = bar;
+const using = 1;
+obj.using;
+using();
+using {x} = obj;
+import using from "foo";
 promise.catch(foo).finally(bar);
 
 // TypeScript keywords
@@ -220,6 +230,54 @@ import type *, {}
 	["punctuation", "}"],
 	["punctuation", "}"],
 
+	["keyword", "using"],
+	" file ",
+	["operator", "="],
+	["function", "openFile"],
+	["punctuation", "("],
+	["punctuation", ")"],
+	["punctuation", ";"],
+
+	["keyword", "await"],
+	["keyword", "using"],
+	" conn ",
+	["operator", "="],
+	["function", "getConn"],
+	["punctuation", "("],
+	["punctuation", ")"],
+	["punctuation", ";"],
+
+	["keyword", "using"],
+	" x ",
+	["operator", "="],
+	" a",
+	["punctuation", ","],
+	" y ",
+	["operator", "="],
+	" b",
+	["punctuation", ";"],
+
+	["keyword", "for"],
+	["punctuation", "("],
+	["keyword", "using"],
+	" x ",
+	["keyword", "of"],
+	" arr",
+	["punctuation", ")"],
+	["punctuation", "{"],
+	["punctuation", "}"],
+
+	["keyword", "for"],
+	["punctuation", "("],
+	["keyword", "await"],
+	["keyword", "using"],
+	" y ",
+	["keyword", "of"],
+	" arr",
+	["punctuation", ")"],
+	["punctuation", "{"],
+	["punctuation", "}"],
+
 	["comment", "// variables, not keywords"],
 
 	["keyword", "const"],
@@ -232,6 +290,36 @@ import type *, {}
 	["punctuation", "}"],
 	["operator", "="],
 	" bar",
+	["punctuation", ";"],
+
+	["keyword", "const"],
+	" using ",
+	["operator", "="],
+	["number", "1"],
+	["punctuation", ";"],
+
+	"\r\nobj",
+	["punctuation", "."],
+	"using",
+	["punctuation", ";"],
+
+	["function", "using"],
+	["punctuation", "("],
+	["punctuation", ")"],
+	["punctuation", ";"],
+
+	"\r\nusing ",
+	["punctuation", "{"],
+	"x",
+	["punctuation", "}"],
+	["operator", "="],
+	" obj",
+	["punctuation", ";"],
+
+	["keyword", "import"],
+	" using ",
+	["keyword", "from"],
+	["string", "\"foo\""],
 	["punctuation", ";"],
 
 	"\r\npromise",


### PR DESCRIPTION
Adds support for the ES2026 [Explicit Resource Management](https://github.com/tc39/proposal-explicit-resource-management) `using` and `await using` declarations.

```js
using file = openFile();
await using conn = getConn();
for (using x of arr) {}
```

Previously, `using` was treated as a plain identifier in all positions; these snippets now highlight `using` as a keyword.