### PR TITLE
Fix CJS build to actually emit CommonJS

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -411,7 +411,10 @@ async function buildJS () {
 	const bundles = {
 		esm: {
 			rollupOptions: defaultRollupOptions,
-			outputOptions: defaultOutputOptions,
+			outputOptions: {
+				...defaultOutputOptions,
+				format: 'es',
+			},
 		},
 		cjs: {
 			rollupOptions: {
@@ -421,6 +424,7 @@ async function buildJS () {
 			outputOptions: {
 				...defaultOutputOptions,
 				dir: './dist/cjs',
+				format: 'cjs',
 			},
 		},
 	};
@@ -430,6 +434,14 @@ async function buildJS () {
 			bundle.build = await rollup(bundle.rollupOptions);
 			await bundle.build.write(bundle.outputOptions);
 		}
+		// The root package.json has "type": "module", so Node treats all .js files as ESM.
+		// This overrides that for the CJS directory, since Node uses the nearest parent
+		// package.json to determine the module system: https://nodejs.org/api/packages.html#type
+		await writeFile(
+			path.join(DIST_DIR, 'cjs', 'package.json'),
+			JSON.stringify({ type: 'commonjs' }),
+			'utf-8'
+		);
 	}
 	finally {
 		for (const bundle of Object.values(bundles)) {

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -305,6 +305,25 @@ const lazyGrammarPlugin = {
 };
 
 /**
+ * Makes `require("prismjs")` return the default export directly with named
+ * exports as properties, so CJS consumers don't need `.default`.
+ *
+ * @type {Plugin}
+ */
+const cjsExportPlugin = {
+	name: 'cjs-default-export',
+	renderChunk (code) {
+		if (!code.includes('exports.default=')) {
+			return null;
+		}
+
+		code += 'module.exports=Object.assign(exports.default,exports);';
+
+		return { code, map: null };
+	},
+};
+
+/**
  * @param {MagicString} s
  * @returns {{ code: string; map: SourceMapInput }}
  */
@@ -419,7 +438,7 @@ async function buildJS () {
 		cjs: {
 			rollupOptions: {
 				...defaultRollupOptions,
-				plugins: [...defaultRollupOptions.plugins, commonjs()],
+				plugins: [...defaultRollupOptions.plugins, commonjs(), cjsExportPlugin],
 			},
 			outputOptions: {
 				...defaultOutputOptions,


### PR DESCRIPTION
## Summary

- The CJS bundle (`dist/cjs/`) was byte-for-byte identical to the ESM bundle because the Rollup config never specified `format: 'cjs'` — both bundles used the default `'es'` format
- This caused `require("prismjs")` to throw `SyntaxError` on Node 18–21 (can't `require` ESM), and return an unexpected ESM namespace object on Node 22+ (need `.default` to get the Prism instance)
- Add `format: 'cjs'` to the CJS output options so Rollup emits `require()`/`exports` syntax
- Add `format: 'es'` to the ESM output options for clarity
- Write `dist/cjs/package.json` with `{"type":"commonjs"}` after the build — needed because the root `"type": "module"` would otherwise make Node parse the CJS `.js` files as ESM. Node uses the [nearest parent `package.json`](https://nodejs.org/api/packages.html#type) to determine the module system
- Add `cjsExportPlugin` so `require("prismjs")` returns the Prism instance directly with named exports (`Prism`, `Token`, `loadLanguages`) as properties — no `.default` needed.

## Test plan

- [x] `npm run build` completes without errors
- [x] `npm test` passes (all 7 suites)
- [x] `npm pack` → install in a fresh project → `require("prismjs").highlight(...)` works (no `.default`)
- [x] Named exports accessible: `require("prismjs").Token`, `.Prism`, `.loadLanguages`
- [x] `dist/cjs/index.js` contains `require()`/`exports` (not `import`/`export`)
- [x] `dist/cjs/package.json` exists with `{"type":"commonjs"}`
- [x] ESM path (`import Prism from "prismjs"`) still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)