### PR TITLE
Remove obsolete jspm config

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,17 +112,5 @@
 		"typescript": "^5.8.3",
 		"webfont": "^11.2.26",
 		"yargs": "^17.7.2"
-	},
-	"jspm": {
-		"main": "prism",
-		"registry": "jspm",
-		"jspmPackage": true,
-		"format": "global",
-		"files": [
-			"components/**/*.js",
-			"plugins/**/*",
-			"themes/*.css",
-			"prism.js"
-		]
 	}
 }


### PR DESCRIPTION
The `jspm` field in `package.json` was for JSPM 0.x/1.x. It references paths that no longer exist at the root (`prism.js`, `components/`, `plugins/`, `themes/`) and declares `"format": "global"`, which is wrong now that the package is `"type": "module"`.

Modern JSPM reads the standard `exports` field, which already maps all entry points correctly. The `jspm` config is dead weight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)