### PR TITLE
Build dist/prism.js as IIFE for synchronous globalThis.Prism

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -334,7 +334,8 @@ function toRenderedChunk (s) {
 	};
 }
 
-const terserPlugin = rollupTerser({
+/** @type {import('@rollup/plugin-terser').Options} */
+const terserOptions = {
 	ecma: 2020,
 	module: true,
 	compress: {
@@ -348,7 +349,8 @@ const terserPlugin = rollupTerser({
 		comments: false,
 	},
 	keep_classnames: true,
-});
+};
+const terserPlugin = rollupTerser(terserOptions);
 
 async function clean () {
 	const outputDir = path.join(__dirname, '../dist');
@@ -404,7 +406,6 @@ async function buildJS () {
 	const input = {
 		'index': path.join(SRC_DIR, 'index.js'),
 		'global': path.join(SRC_DIR, 'global.js'),
-		'prism': path.join(SRC_DIR, 'prism.global.js'),
 		'shared': path.join(SRC_DIR, 'shared.js'),
 	};
 	for (const id of languageIds) {
@@ -444,6 +445,24 @@ async function buildJS () {
 				...defaultOutputOptions,
 				dir: './dist/cjs',
 				format: 'cjs',
+			},
+		},
+		iife: {
+			rollupOptions: {
+				...defaultRollupOptions,
+				input: path.join(SRC_DIR, 'auto-start.js'),
+				plugins: [
+					...defaultRollupOptions.plugins.slice(0, -1), // remove default terser plugin
+					rollupTerser({ ...terserOptions, module: false }),
+				],
+			},
+			outputOptions: {
+				...defaultOutputOptions,
+				dir: undefined,
+				file: path.join(DIST_DIR, 'prism.js'),
+				format: 'iife',
+				name: 'Prism',
+				exports: 'default',
 			},
 		},
 	};

--- a/src/global.js
+++ b/src/global.js
@@ -5,5 +5,8 @@ import globalPrism from './core/prism.js';
  *
  * This instance of Prism is unique. Even if this module is imported from
  * different sources, the same Prism instance will be returned.
+ *
+ * When a global build (IIFE) has already set `globalThis.Prism`, this
+ * module reuses that instance so ESM plugins share the same singleton.
  */
-export default globalPrism;
+export default globalThis.Prism?.constructor?.name === 'Prism' ? globalThis.Prism : globalPrism;

--- a/src/prism.global.js
+++ b/src/prism.global.js
@@ -1,7 +1,0 @@
-const currentScript = /** @type {HTMLScriptElement | null} */ (globalThis.document?.currentScript);
-if (currentScript) {
-	// In browser and imported via non-ESM
-	const url = new URL('./index.js', currentScript.src);
-
-	import(url.toString()).then(({ default: prism }) => (globalThis.Prism = prism));
-}


### PR DESCRIPTION
## Summary

- `prism.global.js` used `import()` to dynamically load `index.js`, making `globalThis.Prism` available only **asynchronously** — breaking backward compatibility with v1 where `Prism` was available immediately after the `<script>` tag
- Replace it with an IIFE build target that bundles `auto-start.js` (core + autoloader) into a single self-contained file (~20KB)
- Rollup's `name: 'Prism'` assigns the default export to `var Prism`, making it synchronously available as a global
- Languages are still loaded dynamically by the autoloader via `import()`
- `global.js` now bridges the IIFE and ESM singletons: when `globalThis.Prism` is already a Prism instance (set by the IIFE), ESM plugins reuse it instead of creating a second one

Live demo: https://codepen.io/dmitrysharabin/pen/xbbdXZb

## Test plan

- [x] Load `dist/prism.js` via `<script>` and verify `globalThis.Prism` is defined synchronously in the next `<script>` block
- [x] Verify autoloaded language highlighting still works (e.g. `<code class="language-javascript">`)
- [x] Verify ESM (`import Prism from 'prismjs'`) and CJS (`require('prismjs')`) still work
- [x] Verify pre-load config (`window.Prism = { manual: true }`) is still read correctly
- [x] Verify ESM plugins (`line-numbers`, `inline-color`, `show-invisibles`) loaded via `<script type="module">` work alongside the IIFE build
- [x] Verify Node.js (no IIFE) — `globalThis.Prism` stays `undefined`, ESM/CJS return a fresh instance

🤖 Generated with [Claude Code](https://claude.com/claude-code)