### PR TITLE
[CI] Pin Node 20 in Danger workflow

### DIFF
--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -11,6 +11,12 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+      # Pin Node 20 — Danger v13 uses node-fetch 2.x, which throws
+      # `ERR_STREAM_PREMATURE_CLOSE` on gzip responses under newer Node.js
+      # versions provided by the default `ubuntu-latest` runner image.
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 20.x
       # create a new branch called pr from the remote PR branch
       - run: git remote add pr_repo $PR_URL && git fetch pr_repo $PR_REF && git branch pr pr_repo/$PR_REF
         env:


### PR DESCRIPTION
## Summary

The `Danger` check has been failing on every new PR since 2026-06-26 with `ERR_STREAM_PREMATURE_CLOSE` while fetching the PR file list from the GitHub API. GitHub status is fully operational; the error is a node-fetch / Node.js incompatibility.

## Root cause

- `danger@13.0.7` depends on `node-fetch@2.7.0`
- `node-fetch` 2.x has a long-standing bug with gzip stream cleanup on newer Node.js versions ([node-fetch/node-fetch#1486](https://github.com/node-fetch/node-fetch/issues/1486) and related)
- `.github/workflows/danger.yml` didn't pin a Node version, so it ran on whatever the `ubuntu-latest` runner image shipped
- Between the last green Danger run (2026-06-23) and the first failure (2026-06-26), the runner image's default Node was bumped, and `npx danger ci` started crashing on every PR

## Fix

Add a `setup-node@v3` step pinning Node 20.x to `danger.yml`, matching the version range already used by the `tests` and `build` jobs in `test.yml`. One actions step + a brief inline comment explaining why.

## ⚠️ This PR can't validate its own fix

The Danger workflow uses `pull_request_target`, which always runs the workflow definition from the **base** branch (`v2`), not the PR head. That's intentional GitHub security behavior — it prevents PRs from modifying CI to exfiltrate secrets. As a result, the `run` job on this PR's checks will keep failing until the change is merged into `v2`; the fix can only be confirmed by a subsequent PR.

Verified by the run logs: no `setup-node` step appears, because the workflow that executes still comes from `v2`.

## How to verify post-merge

After merging this PR, rerun the failed `run` (Danger) check on PR #4090 (or open a tiny test PR). If it goes from `fail` → `pass`, the fix is good.

## Test plan

- [x] Merge to v2
- [x] Rerun Danger on PR #4090 — confirm it passes _(verified by close/reopen; PR #4090 is now fully green)_
- [x] (Optional) Confirm on another open PR _(skipped &mdash; #4090 was sufficient confirmation)_

## Note on the `lint` failure on this PR

The `lint` check fails because this branch doesn't include PR #4090's ESLint cleanup. The two PRs are independent and will both pass once both are merged.
