### PR TITLE
SCSS: Support parameterized pseudo-classes in selectors

### DIFF
--- a/src/languages/scss.js
+++ b/src/languages/scss.js
@@ -29,7 +29,7 @@ export default {
 			'selector': {
 				// Initial look-ahead is used to prevent matching of blank selectors
 				pattern:
-					/(?=\S)[^@;{}()]?(?:[^@;{}()\s]|\s+(?!\s)|#\{\$[-\w]+\})+(?=\s*\{(?:\}|\s|[^}][^:{}]*[:{][^}]))/,
+					/(?=\S)[^@;{}()]?(?:[^@;{}()\s]|\s+(?!\s)|#\{\$[-\w]+\}|:{1,2}[-\w]+\((?:[^()]|\([^()]*\))*\))+(?=\s*\{(?:\}|\s|[^}][^:{}]*[:{][^}]))/,
 				inside: {
 					'parent': {
 						pattern: /&/,

--- a/tests/languages/scss/selector_feature.test
+++ b/tests/languages/scss/selector_feature.test
@@ -5,9 +5,8 @@ p, div {}
 &-sidebar {}
 #context a%extreme {}
 #{$selector}:before {}
-
+foo :foo() bar {}
 ----------------------------------------------------
-
 [
 	["selector", ["a "]], ["punctuation", "{"], ["punctuation", "}"],
 	["selector", ["p, div "]], ["punctuation", "{"], ["punctuation", "}"],
@@ -15,9 +14,8 @@ p, div {}
 	["selector", [["parent", "&"], ":hover "]], ["punctuation", "{"], ["punctuation", "}"],
 	["selector", [["parent", "&"], "-sidebar "]], ["punctuation", "{"], ["punctuation", "}"],
 	["selector", ["#context a", ["placeholder", "%extreme"]]], ["punctuation", "{"], ["punctuation", "}"],
-	["selector", [["variable", "#{$selector}"], ":before "]], ["punctuation", "{"], ["punctuation", "}"]
+	["selector", [["variable", "#{$selector}"], ":before "]], ["punctuation", "{"], ["punctuation", "}"],
+	["selector", ["foo :foo() bar "]], ["punctuation", "{"], ["punctuation", "}"]
 ]
-
 ----------------------------------------------------
-
 Checks for selectors.


### PR DESCRIPTION
Fixes #3740

## Problem

SCSS selectors containing a parameterized pseudo-class were not
highlighted as selectors:

    foo :foo() bar {

    }

`:foo()` broke the match entirely — only `bar` was left as an
unmatched token, while `foo :foo()` fell out of the `selector` token.
The equivalent selector without parens (`foo :foo bar {}`) worked fine.

## Root cause

`Prism.languages.scss.selector.pattern` explicitly excludes `(` and `)`
from the character class that makes up a selector:

    [^@;{}()\s]

This exclusion exists on purpose: the same pattern is reused (via
`atrule`'s `$rest: 'scss'`) to tokenize the *inside* of at-rules like
`@mixin` and `@include`, and parens there belong to the argument list,
not to a selector. A naive fix — just deleting `()` from the exclusion
class, as originally suggested in the issue — makes the selector
pattern swallow at-rule argument lists too, which breaks highlighting
of code like:

    @mixin prefix($property, $value, $prefixes) {
    }

(`prefix` should tokenize as a `function`; with the naive fix it gets
absorbed into a spurious `selector` token instead, as flagged by
@Golmote in the issue thread.)

## Fix

Instead of opening up `()` unconditionally, this adds one new,
narrowly-scoped alternative to the selector pattern: a balanced
parenthesized group, but *only* when it directly follows a
pseudo-class name (`:name(...)` or `::name(...)`):

    :{1,2}[-\w]+\((?:[^()]|\([^()]*\))*\)

This matches `:foo()`, `:nth-child(2n+1)`, `:not(.active)`, etc., while
leaving the existing exclusion of bare `(`/`)` intact everywhere else —
so `@mixin`/`@include` argument lists (which are never preceded by a
colon) are unaffected.

## Testing

Added a new case to `tests/languages/scss/selector_feature.test`:

    foo :foo() bar {}

Verified the fix two ways:

1. **Regression-proof**: temporarily reverted just the `scss.js`
   change (`git stash push -- src/languages/scss.js`) while keeping
   the new test case, and confirmed `selector_feature` fails against
   the old pattern — `foo :foo() bar {}` tokenizes as
   `property`/`punctuation`/`function`/`punctuation`/`punctuation`/
   `selector("bar ")` instead of one clean `selector` token. This
   reproduces the exact bug from the issue.
2. Restored the fix and confirmed all tests pass again
   (`npm run test:languages -- --language=scss`, 15 passing).
3. Manually re-checked Golmote's `@mixin prefix($property, $value,
   $prefixes) {}` counter-example against the new pattern to confirm
   `prefix` still tokenizes correctly as a `function` and is not
   swallowed into a `selector` — the specific regression that sank
   the original one-line workaround in the issue thread.

## Scope

One-line regex change in `src/languages/scss.js`, plus one new test
case appended to the existing `selector_feature.test` (no existing
cases modified).