### PR TITLE
docs(unescaped-markup): remove duplicated doc sections

### DIFF
--- a/src/plugins/unescaped-markup/README.md
+++ b/src/plugins/unescaped-markup/README.md
@@ -34,113 +34,14 @@ This will only work if the `code` element contains exactly one comment and nothi
 
 # Examples
 
-View source to see that the following didn’t need escaping (except for <code>&lt;/script></code>, that does):
+With `<script type="text/plain">` (view source; only `</script>` needs escaping):
 
-<script type="text/plain"><!DOCTYPE html>
-<html lang="en">
-<head>
+<script type="text/plain"><p>Example with <strong>unescaped</strong> markup</p>
+</script>
 
-	<meta charset="utf-8" />
-	<link rel="icon" href="https://prismjs.com/assets/favicon.png" />
-	<title>Keep markup ▲ Prism plugins</title>
-	<base href=".." />
-	<link rel="stylesheet" href="https://prismjs.com/assets/style.css" />
-	<link rel="stylesheet" href="https://dev.prismjs.com/themes/prism.css" />
+With the HTML-comment method:
 
-</head>
-<body class="language-markup">
-
-<header>
-	<h2>Unescaped markup</h2>
-	<p>Write markup without having to escape anything.</p>
-</header>
-
-<section>
-	<h1>How to use</h1>
-	<p>Instead of using <code>&lt;pre>&lt;code></code> elements, use <code>&lt;script type="text/plain"></code>:</p>
-</section>
-
-<section>
-	<h1>FAQ</h1>
-
-	<p>Why not use the HTML <code>&lt;template></code> tag?</p>
-
-	<p>Because it is a PITA to get its <code>textContent</code> and needs to be pointlessly cloned.
-		Feel free to implement it yourself and send a pull request though, if you are so inclined.</p>
-
-	<p>Can I use this inline?</p>
-
-	<p>Not out of the box, because I figured it’s more of a hassle to type <code>&lt;script type="text/plain"></code> than escape the 1-2 <code>&lt;</code> characters you need to escape in inline code.
-	Also inline code is not as frequently copy-pasted, which was the major source of annoyance that got me to write this plugin.</p>
-</section>
-
-<section>
-	<h1>Examples</h1>
-
-	<p>With <code>&lt;script type="text/plain"></code>:</p>
-
-	<script type="text/plain"><div><span>Foo</span></div>&lt;/script>
-</section>
-
-<script src="https://dev.prismjs.com/prism.js">&lt;/script>
-<script src="unescaped-markup/unescaped-markup.js">&lt;/script>
-
-</body>
-</html></script>
-
-<p>The next example uses the HTML-comment method:</p>
-
-<pre><code><!--<!DOCTYPE html>
-<html lang="en">
-<head>
-
-	<meta charset="utf-8" />
-	<link rel="icon" href="https://prismjs.com/assets/favicon.png" />
-	<title>Keep markup ▲ Prism plugins</title>
-	<base href=".." />
-	<link rel="stylesheet" href="https://prismjs.com/assets/style.css" />
-	<link rel="stylesheet" href="https://dev.prismjs.com/themes/prism.css" />
-
-</head>
-<body class="language-markup">
-
-<header>
-	<h2>Unescaped markup</h2>
-	<p>Write markup without having to escape anything.</p>
-</header>
-
-<section>
-	<h1>How to use</h1>
-	<p>Instead of using <code>&lt;pre>&lt;code></code> elements, use <code>&lt;script type="text/plain"></code>:</p>
-</section>
-
-<section>
-	<h1>FAQ</h1>
-
-	<p>Why not use the HTML <code>&lt;template></code> tag?</p>
-
-	<p>Because it is a PITA to get its <code>textContent</code> and needs to be pointlessly cloned.
-		Feel free to implement it yourself and send a pull request though, if you are so inclined.</p>
-
-	<p>Can I use this inline?</p>
-
-	<p>Not out of the box, because I figured it’s more of a hassle to type <code>&lt;script type="text/plain"></code> than escape the 1-2 <code>&lt;</code> characters you need to escape in inline code.
-	Also inline code is not as frequently copy-pasted, which was the major source of annoyance that got me to write this plugin.</p>
-</section>
-
-<section>
-	<h1>Examples</h1>
-
-	<p>With <code>&lt;script type="text/plain"></code>:</p>
-
-	<script type="text/plain"><div><span>Foo</span></div></script>
-</section>
-
-<script src="https://dev.prismjs.com/prism.js"></script>
-<script src="unescaped-markup/unescaped-markup.js"></script>
-
-</body>
-</html>--></code></pre>
+<pre><code><!--<p>Example with <strong>unescaped</strong> markup</p>--></code></pre>
 
 </section>
 


### PR DESCRIPTION
## Summary
- Fixes #4038
- The Unescaped Markup examples embedded a full demo page whose headings (How to use, Examples, FAQ) showed up again on the docs page
- Replaced those demos with short samples so each section appears once

## Test plan
- [ ] Open the Unescaped Markup plugin docs and confirm How to use, Examples, and FAQ each appear once in the TOC and page body
- [ ] Confirm both example methods still demonstrate unescaped markup