### PR TITLE
feat(languages): add ssh-config language definition

### DIFF
--- a/src/components.json
+++ b/src/components.json
@@ -1133,6 +1133,10 @@
 			"title": "SQL",
 			"owner": "multipetros"
 		},
+		"ssh-config": {
+			"title": "SSH config",
+			"owner": "Errr0rr404"
+		},
 		"squirrel": {
 			"title": "Squirrel",
 			"owner": "RunDevelopment"

--- a/src/languages/ssh-config.js
+++ b/src/languages/ssh-config.js
@@ -1,0 +1,41 @@
+/** @type {import('../types.d.ts').LanguageProto<'ssh-config'>} */
+export default {
+	id: 'ssh-config',
+	alias: ['sshconfig', 'ssh_config', 'sshd_config'],
+	grammar: {
+		'comment': {
+			pattern: /(^[ \t]*)#.*/m,
+			lookbehind: true,
+			greedy: true,
+		},
+		// Host / Match blocks start a new section (word-boundary so HostName is not a Host)
+		'section': {
+			pattern: /(^[ \t]*)(?:Host|Match)\b(?:[ \t]+[^\n\r#]+)?/m,
+			lookbehind: true,
+			inside: {
+				'keyword': /^(?:Host|Match)\b/,
+				'operator': /[*?!]/,
+				'string': /\S+/,
+			},
+		},
+		// Common OpenSSH client/server keywords (ssh_config / sshd_config)
+		'keyword': {
+			pattern:
+				/(^[ \t]*)(?:AcceptEnv|AddressFamily|AllowAgentForwarding|AllowGroups|AllowTcpForwarding|AllowUsers|AuthenticationMethods|AuthorizedKeysFile|Banner|BatchMode|BindAddress|CertificateFile|CheckHostIP|Ciphers|ClearAllForwardings|ClientAliveCountMax|ClientAliveInterval|Compression|ConnectTimeout|ControlMaster|ControlPath|ControlPersist|DynamicForward|EscapeChar|ExitOnForwardFailure|ForwardAgent|ForwardX11|GatewayPorts|GlobalKnownHostsFile|HashKnownHosts|HostName|IdentitiesOnly|IdentityAgent|IdentityFile|Include|IPQoS|KbdInteractiveAuthentication|KexAlgorithms|LocalCommand|LocalForward|LogLevel|MACs|PasswordAuthentication|PermitRootLogin|Port|PreferredAuthentications|ProxyCommand|ProxyJump|PubkeyAuthentication|RemoteCommand|RemoteForward|RequestTTY|SendEnv|ServerAliveCountMax|ServerAliveInterval|SetEnv|StrictHostKeyChecking|TCPKeepAlive|Tunnel|UpdateHostKeys|UseDNS|User|UserKnownHostsFile|VerifyHostKeyDNS|VisualHostKey|X11Forwarding)\b/im,
+			lookbehind: true,
+		},
+		'boolean': {
+			pattern: /\b(?:no|off|on|yes)\b/i,
+			alias: 'constant',
+		},
+		'number': {
+			pattern: /\b\d+\b/,
+		},
+		'variable': {
+			pattern: /%[%CDdHhIiKkLlnpru]/i,
+			alias: 'symbol',
+		},
+		'operator': /=/,
+		'punctuation': /[,:]/,
+	},
+};

--- a/tests/languages/ssh-config/comment_feature.test
+++ b/tests/languages/ssh-config/comment_feature.test
@@ -1,0 +1,22 @@
+# Global defaults
+	# indented comment
+
+Host example.com
+	# per-host comment
+
+----------------------------------------------------
+
+[
+	["comment", "# Global defaults"],
+	["comment", "# indented comment"],
+
+	["section", [
+		["keyword", "Host"],
+		["string", "example.com"]
+	]],
+	["comment", "# per-host comment"]
+]
+
+----------------------------------------------------
+
+Comments start with #.

--- a/tests/languages/ssh-config/keyword_feature.test
+++ b/tests/languages/ssh-config/keyword_feature.test
@@ -1,0 +1,44 @@
+Host github.com
+	HostName github.com
+	User git
+	Port 22
+	IdentityFile ~/.ssh/id_ed25519
+	ForwardAgent yes
+	Compression no
+
+Match host *.internal
+	ProxyJump bastion
+
+----------------------------------------------------
+
+[
+	["section", [
+		["keyword", "Host"],
+		["string", "github.com"]
+	]],
+	["keyword", "HostName"],
+	" github.com\r\n\t",
+	["keyword", "User"],
+	" git\r\n\t",
+	["keyword", "Port"],
+	["number", "22"],
+	["keyword", "IdentityFile"],
+	" ~/.ssh/id_ed25519\r\n\t",
+	["keyword", "ForwardAgent"],
+	["boolean", "yes"],
+	["keyword", "Compression"],
+	["boolean", "no"],
+
+	["section", [
+		["keyword", "Match"],
+		["string", "host"],
+		["operator", "*"],
+		["string", ".internal"]
+	]],
+	["keyword", "ProxyJump"],
+	" bastion"
+]
+
+----------------------------------------------------
+
+Common ssh_config keywords, booleans, and Host/Match sections.


### PR DESCRIPTION
## Summary
- Add an `ssh-config` language for OpenSSH client/server config files.
- Highlights `Host`/`Match` sections, common keywords, booleans, numbers, and `%` tokens.
- Aliases: `sshconfig`, `ssh_config`, `sshd_config`.
- Includes language tests.

Closes #3444

## Test plan
- [x] `npx mocha tests/run.js --language ssh-config` (2 passing)