### PR TITLE
Swift: highlight underscore-prefixed class names

### DIFF
--- a/src/languages/swift.js
+++ b/src/languages/swift.js
@@ -136,8 +136,9 @@ export default {
 		},
 		'number': /\b(?:[\d_]+(?:\.[\de_]+)?|0x[a-f0-9_]+(?:\.[a-f0-9p_]+)?|0b[01_]+|0o[0-7_]+)\b/i,
 
-		// A class name must start with an upper-case letter and be either 1 letter long or contain a lower-case letter.
-		'class-name': /\b[A-Z](?:[A-Z_\d]*[a-z]\w*)?\b/,
+		// A class name starts with an optional underscore prefix, then an upper-case letter.
+		// It must be either 1 letter long or contain a lower-case letter.
+		'class-name': /\b_*[A-Z](?:[A-Z_\d]*[a-z]\w*)?\b/,
 		'function': /\b[a-z_]\w*(?=\s*\()/i,
 		'constant': /\b(?:[A-Z_]{2,}|k[A-Z][A-Za-z_]+)\b/,
 

--- a/tests/languages/swift/class-name_feature.test
+++ b/tests/languages/swift/class-name_feature.test
@@ -5,6 +5,7 @@ class SomeClass: SomeSuperclass {
         return 107
     }
 }
+class _Foo: __Bar {}
 
 ----------------------------------------------------
 
@@ -37,5 +38,16 @@ class SomeClass: SomeSuperclass {
 
 	["punctuation", "}"],
 
+	["punctuation", "}"],
+
+	["keyword", "class"],
+	["class-name", "_Foo"],
+	["punctuation", ":"],
+	["class-name", "__Bar"],
+	["punctuation", "{"],
 	["punctuation", "}"]
 ]
+
+----------------------------------------------------
+
+Swift types may be prefixed with underscores.


### PR DESCRIPTION
## Summary
- Swift types such as `_Foo` and `__Bar` were not highlighted as class names because the pattern required an immediate uppercase letter.
- Allow an optional underscore prefix so those names match Swift's convention for client-visible private API.

Fixes #4100

## Test plan
- [x] `npx mocha tests/run.js --language=swift`
- [x] Pattern tests for the updated class-name regex
- [ ] CI on this PR