### PR TITLE
Markup: match comments containing a nested "<!--"

### DIFF
--- a/src/languages/xml.js
+++ b/src/languages/xml.js
@@ -15,7 +15,7 @@ export default {
 
 		return {
 			'comment': {
-				pattern: /<!--(?:(?!<!--)[\s\S])*?-->/,
+				pattern: /<!--[\s\S]*?-->/,
 				greedy: true,
 			},
 			'prolog': {

--- a/tests/languages/markup/nested_marker_comment_feature.test
+++ b/tests/languages/markup/nested_marker_comment_feature.test
@@ -1,0 +1,13 @@
+<!-- foo <!-- bar -->
+
+----------------------------------------------------
+
+[
+	["comment", "<!-- foo <!-- bar -->"]
+]
+
+----------------------------------------------------
+
+Checks that a comment containing a literal "<!--" in its body is not split into
+multiple tokens. Per the HTML tokenizer, a comment only ends at the first literal
+"-->"; an embedded "<!--" has no special meaning and is just comment content.


### PR DESCRIPTION
Prism's `comment` rule for markup uses `/<!--(?:(?!<!--)[\s\S])*?-->/`, which refuses to match once it encounters a second `<!--` inside the comment body. Per the HTML tokenizer (WHATWG §13.2.5 comment states), a comment ends at the first `-->`; an embedded `<!--` has no special meaning and is just content.

So `<!-- foo <!-- bar -->` — commented-out markup that itself contains a comment marker — fails to tokenize as a comment and falls through to the `tag` rule, which mis-highlights the whole thing as a bogus HTML tag. Dropping the `(?!<!--)` guard matches the comment as a single token, in line with the spec. Added a test case.
